### PR TITLE
Window: add transparentTitlebar option (macOS)

### DIFF
--- a/Lib/eacp/Graphics/Window/Window-macOS.mm
+++ b/Lib/eacp/Graphics/Window/Window-macOS.mm
@@ -116,6 +116,7 @@ struct Window::Native
         [getWindow() setTitle:@(options.title.c_str())];
         [getWindow() setTitleVisibility:options.showTitle ? NSWindowTitleVisible
                                                           : NSWindowTitleHidden];
+        [getWindow() setTitlebarAppearsTransparent:options.transparentTitlebar];
         [getWindow() center];
         [getWindow() makeKeyAndOrderFront:nil];
         [getWindow() setDelegate:delegate.get()];

--- a/Lib/eacp/Graphics/Window/Window.h
+++ b/Lib/eacp/Graphics/Window/Window.h
@@ -61,6 +61,11 @@ struct WindowOptions
     // When false, the title bar still shows but the title text is hidden.
     bool showTitle = true;
 
+    // macOS only: makes the title bar background transparent so the
+    // content view's color shows through. Pair with FullSizeContentView
+    // for an edge-to-edge look. No-op on Windows.
+    bool transparentTitlebar = false;
+
     EA::Vector<WindowFlags> flags;
 
     Callback effectiveOnQuit() const


### PR DESCRIPTION
Adds `WindowOptions::transparentTitlebar` (default `false`). When `true`, sets `NSWindow.titlebarAppearsTransparent` so the title bar background blends into the content view — useful with `FullSizeContentView` for edge-to-edge layouts. No-op on Windows.