### PR TITLE
WebView: add backgroundThrottling option (Apple)

### DIFF
--- a/Lib/eacp/WebView/WebView/WebView.h
+++ b/Lib/eacp/WebView/WebView/WebView.h
@@ -126,6 +126,17 @@ public:
         std::unordered_map<std::string, StreamingProvider> streamingSchemes;
         Embedded embedded;
         bool debugConsole = true;
+
+        // Apple: when false, opts the page out of WebKit's hidden-page power
+        // saving — process suppression (App Nap) and the ~1s DOM timer clamp
+        // that kick in when WebKit decides the page isn't visible. Occlusion
+        // tracking is unreliable for borderless/floating windows shown via
+        // orderFront without key status, so a perfectly visible page can sit
+        // suppressed (queued evaluateJavaScript, dead timers) until it gains
+        // focus. Mirrors Electron's backgroundThrottling. Uses private
+        // WKPreferences setters, guarded — a WebKit that drops them just
+        // keeps the default behaviour. No-op on Windows.
+        bool backgroundThrottling = true;
     };
 
     WebView();

--- a/Lib/eacp/WebView/WebView/WebView.mm
+++ b/Lib/eacp/WebView/WebView/WebView.mm
@@ -37,6 +37,16 @@ typedef NS_OPTIONS(NSUInteger, _WKCaptureDevices) {
 };
 #endif
 
+// Private WKPreferences SPI (WKPreferencesPrivate.h, stable since
+// macOS 10.12 / iOS 10): the two switches behind hidden-page power saving.
+// Declared as a category and called behind respondsToSelector: so a WebKit
+// that removes them degrades to the default (throttled) behaviour instead
+// of crashing. See WebView::Options::backgroundThrottling.
+@interface WKPreferences (EacpBackgroundThrottlingSPI)
+- (void)_setPageVisibilityBasedProcessSuppressionEnabled:(BOOL)enabled;
+- (void)_setHiddenPageDOMTimerThrottlingEnabled:(BOOL)enabled;
+@end
+
 namespace eacp::Graphics
 {
 class WebView;
@@ -107,6 +117,19 @@ struct WebView::Native
         {
             [config.get().preferences setValue:@YES
                                         forKey:@"developerExtrasEnabled"];
+        }
+
+        if (!options.backgroundThrottling)
+        {
+            WKPreferences* prefs = config.get().preferences;
+
+            if ([prefs respondsToSelector:@selector
+                       (_setPageVisibilityBasedProcessSuppressionEnabled:)])
+                [prefs _setPageVisibilityBasedProcessSuppressionEnabled:NO];
+
+            if ([prefs respondsToSelector:@selector
+                       (_setHiddenPageDOMTimerThrottlingEnabled:)])
+                [prefs _setHiddenPageDOMTimerThrottlingEnabled:NO];
         }
 
         for (auto& [scheme, provider]: options.schemes)


### PR DESCRIPTION
## What

Adds `WebView::Options::backgroundThrottling` (default `true`, i.e. current behaviour). Setting it to `false` opts the page out of WebKit's hidden-page power saving on Apple platforms:

- **process suppression** (App Nap for the WebContent process), via `_setPageVisibilityBasedProcessSuppressionEnabled:NO`
- **the ~1s DOM timer clamp** for hidden pages, via `_setHiddenPageDOMTimerThrottlingEnabled:NO`

Both are `WKPreferences` SPI from `WKPreferencesPrivate.h`, stable since macOS 10.12 / iOS 10. They're declared in a category and called behind `respondsToSelector:`, so a future WebKit that drops them just falls back to the default throttled behaviour — no crash. No-op on Windows.

## Why

WebKit decides page visibility from window occlusion, and macOS occlusion tracking is unreliable for borderless/floating windows shown via `orderFront:` that never become key. A perfectly visible floating panel can sit suppressed — `evaluateJavaScript` deliveries queued, timers dead — until the user clicks it. We hit this with a two-WebView app (a main window plus a floating companion window): state pushed from one window's bridge visibly arrived in the other only when it gained focus.

This mirrors Electron's `webPreferences.backgroundThrottling: false`, which does the Chromium equivalent: its `disable_hidden.patch` stops the renderer from ever being told it's hidden/occluded, plus `SetSchedulerThrottling(false)` ([electron_api_web_contents.cc](https://github.com/electron/electron/blob/main/shell/browser/api/electron_api_web_contents.cc), [disable_hidden.patch](https://github.com/electron/electron/blob/main/patches/chromium/disable_hidden.patch)).

## Testing

- Compiled into the Tamber native app (macOS, both its WebViews) via its workspace build — builds and links clean.
- Default (`true`) leaves behaviour byte-for-byte unchanged: the new branch is the only addition and is skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)