### PR TITLE
TCP: detect refused connects promptly on Windows

### DIFF
--- a/Apps/Network/CMakeLists.txt
+++ b/Apps/Network/CMakeLists.txt
@@ -4,6 +4,7 @@ add_subdirectory(HTTP)
 add_subdirectory(BasicHTTP)
 add_subdirectory(HttpServer)
 add_subdirectory(TcpClient)
+add_subdirectory(TcpProbe)
 add_subdirectory(TcpServer)
 
 if (NOT IOS)

--- a/Apps/Network/TcpClient/Main.cpp
+++ b/Apps/Network/TcpClient/Main.cpp
@@ -3,6 +3,9 @@
 // point it at the local TcpServer with:
 //
 //   TcpClient --host 127.0.0.1 --port 5050
+//
+// If the connect fails, TcpProbe tells you whether the port is refusing or
+// just unresponsive - and how quickly the library found out.
 
 #include <eacp/Network/TCP/Connection.h>
 

--- a/Apps/Network/TcpProbe/CMakeLists.txt
+++ b/Apps/Network/TcpProbe/CMakeLists.txt
@@ -1,0 +1,10 @@
+add_executable(TcpProbe Main.cpp)
+target_link_libraries(TcpProbe PRIVATE eacp-network)
+
+set(BUNDLE_ID "com.eacp.tcpprobe")
+
+set_target_properties(TcpProbe PROPERTIES
+        MACOSX_BUNDLE TRUE
+        MACOSX_BUNDLE_BUNDLE_NAME "TCP Probe App"
+        MACOSX_BUNDLE_GUI_IDENTIFIER ${BUNDLE_ID}
+        XCODE_ATTRIBUTE_PRODUCT_BUNDLE_IDENTIFIER ${BUNDLE_ID})

--- a/Apps/Network/TcpProbe/Main.cpp
+++ b/Apps/Network/TcpProbe/Main.cpp
@@ -1,0 +1,58 @@
+// Probes whether a TCP endpoint accepts connections and reports how long the
+// verdict took. The timing is the point: a refused port answers in
+// milliseconds, while only a genuinely unresponsive host should spend the
+// connect timeout. Try it against a dead port, then against TcpServer:
+//
+//   TcpProbe --host 127.0.0.1 --port 5050 [--timeout-ms 5000]
+
+#include <eacp/Network/TCP/Connection.h>
+
+#include <chrono>
+#include <cstdint>
+#include <iostream>
+#include <string>
+
+int main(int argc, char** argv)
+{
+    using namespace std::chrono;
+
+    auto host = std::string {"127.0.0.1"};
+    auto port = std::uint16_t {5050};
+    auto timeout = milliseconds {5000};
+
+    for (auto i = 1; i < argc; ++i)
+    {
+        auto arg = std::string {argv[i]};
+        if (arg == "--host" && i + 1 < argc)
+            host = argv[++i];
+        else if (arg == "--port" && i + 1 < argc)
+            port = (std::uint16_t) std::stoi(argv[++i]);
+        else if (arg == "--timeout-ms" && i + 1 < argc)
+            timeout = milliseconds {std::stoi(argv[++i])};
+        else
+        {
+            std::cerr
+                << "usage: TcpProbe [--host HOST] [--port PORT] [--timeout-ms MS]\n";
+            return 2;
+        }
+    }
+
+    const auto start = steady_clock::now();
+    auto elapsedMs = [start]
+    { return duration_cast<milliseconds>(steady_clock::now() - start).count(); };
+
+    try
+    {
+        auto connection =
+            eacp::TCP::Connection::connect({host, port}, {timeout, timeout});
+        std::cout << host << ":" << port << " is open (verdict in " << elapsedMs()
+                  << " ms)\n";
+        return 0;
+    }
+    catch (const eacp::TCP::Error& e)
+    {
+        std::cout << host << ":" << port << " is not accepting connections "
+                  << "(verdict in " << elapsedMs() << " ms): " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/Apps/Network/TcpProbe/run.sh
+++ b/Apps/Network/TcpProbe/run.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Demos the probe both ways: first against a dead port - the refusal verdict
+# should arrive in milliseconds, not after the connect timeout - and then
+# against a live TcpServer.
+#
+#   Apps/Network/TcpProbe/run.sh [build-dir]   (default build dir: ./build)
+set -euo pipefail
+
+repo="$(cd "$(dirname "$0")/../../.." && pwd)"
+build="${1:-$repo/build}"
+
+cmake --build "$build" --target TcpServer TcpProbe >/dev/null
+
+# macOS produces a .app bundle; Linux a plain executable. Find whichever.
+bin() {
+    local app="$build/Apps/Network/$1/$1.app/Contents/MacOS/$1"
+    local plain="$build/Apps/Network/$1/$1"
+    [ -x "$app" ] && echo "$app" || echo "$plain"
+}
+
+echo "--- nothing listening on 5050: expect a refusal in milliseconds ---"
+"$(bin TcpProbe)" --port 5050 || true
+
+"$(bin TcpServer)" &
+server=$!
+trap 'kill "$server" 2>/dev/null' EXIT
+sleep 0.5
+
+echo "--- TcpServer now up on 5050: expect open ---"
+"$(bin TcpProbe)" --port 5050

--- a/Apps/Network/TcpServer/Main.cpp
+++ b/Apps/Network/TcpServer/Main.cpp
@@ -1,6 +1,7 @@
 // Simplest possible TCP server: listen on a port and echo every line back.
 // The mirror image of TcpClient - together they exercise both halves of the
-// library with no external server. Ctrl-C to stop.
+// library with no external server. TcpProbe checks whether it is up. Ctrl-C
+// to stop.
 
 #include <eacp/Network/TCP/Listener.h>
 

--- a/Lib/eacp/Network/TCP/Connection-Windows.cpp
+++ b/Lib/eacp/Network/TCP/Connection-Windows.cpp
@@ -38,12 +38,22 @@ bool waitWritable(SOCKET socket, std::chrono::milliseconds timeout)
     FD_ZERO(&writable);
     FD_SET(socket, &writable);
 
+    // WinSock reports a FAILED non-blocking connect on the except set, not
+    // the write set (unlike POSIX, where the socket becomes writable and
+    // SO_ERROR carries the failure). Without watching it, a refused
+    // connection blocks for the full timeout instead of failing promptly.
+    auto failed = fd_set {};
+    FD_ZERO(&failed);
+    FD_SET(socket, &failed);
+
     auto tv = timeval {};
     tv.tv_sec = (long) (timeout.count() / 1000);
     tv.tv_usec = (long) ((timeout.count() % 1000) * 1000);
 
     auto* deadline = timeout.count() > 0 ? &tv : nullptr; // null = block forever
-    return ::select(0, nullptr, &writable, nullptr, deadline) > 0;
+    // > 0 covers both sets: the caller checks SO_ERROR next, which reports
+    // the refusal for the except-set case.
+    return ::select(0, nullptr, &writable, &failed, deadline) > 0;
 }
 
 int pendingSocketError(SOCKET socket)

--- a/Tests/Network/TcpConnectionTests.cpp
+++ b/Tests/Network/TcpConnectionTests.cpp
@@ -205,6 +205,40 @@ auto tConnectRefusedThrows = test("Tcp/connectThrowsWhenNothingIsListening") = [
     check(threw);
 };
 
+auto tRefusedConnectFailsFast =
+    test("Tcp/refusedConnectFailsWellBeforeTheConnectTimeout") = []
+{
+    // Claim an ephemeral port, then free it so the connect is refused.
+    auto port = std::uint16_t {0};
+    {
+        auto listener = Listener::bind(0, testTimeouts());
+        port = listener.port();
+    }
+
+    // Regression: WinSock signals a refused non-blocking connect on the
+    // except set, which waitWritable didn't watch - so a refusal blocked
+    // for the full connect timeout instead of failing promptly. Give the
+    // connect a deliberately generous budget and require failure long
+    // before it. (The Windows kernel retries refused loopback connects
+    // internally, so "promptly" is ~2s there rather than instant.)
+    const auto start = std::chrono::steady_clock::now();
+
+    auto threw = false;
+    try
+    {
+        auto client = Connection::connect({"127.0.0.1", port}, {20000ms, 20000ms});
+    }
+    catch (const Error&)
+    {
+        threw = true;
+    }
+
+    const auto elapsed = std::chrono::steady_clock::now() - start;
+
+    check(threw);
+    check(elapsed < 10s);
+};
+
 auto tCloseEndsConnection = test("Tcp/closeMakesAConnectionNotOpen") = []
 {
     auto listener = Listener::bind(0, testTimeouts());

--- a/Tests/Network/TcpConnectionTests.cpp
+++ b/Tests/Network/TcpConnectionTests.cpp
@@ -224,19 +224,25 @@ auto tRefusedConnectFailsFast =
     const auto start = std::chrono::steady_clock::now();
 
     auto threw = false;
+    auto message = std::string {};
     try
     {
         auto client = Connection::connect({"127.0.0.1", port}, {20000ms, 20000ms});
     }
-    catch (const Error&)
+    catch (const Error& e)
     {
         threw = true;
+        message = e.what();
     }
 
     const auto elapsed = std::chrono::steady_clock::now() - start;
 
     check(threw);
     check(elapsed < 10s);
+
+    // A refusal must surface as a connect failure, never mislabelled as a
+    // timeout - which is exactly what the broken path produced.
+    check(message.find("connect timed out") == std::string::npos);
 };
 
 auto tCloseEndsConnection = test("Tcp/closeMakesAConnectionNotOpen") = []


### PR DESCRIPTION
## Bug

`waitWritable` in `Lib/eacp/Network/TCP/Connection-Windows.cpp` passes `select` a write set only. WinSock signals a **failed** non-blocking connect on the **except set**, not the write set (unlike POSIX, where the socket becomes writable and `SO_ERROR` carries the failure). So when nothing is listening on the target port, the refused connect never wakes the `select` and the call blocks for the **entire connect timeout** instead of failing promptly.

This is Windows-only behavior — the POSIX implementation is unaffected.

## Real-world impact

In Tamber, `AbletonApi` connects to the Ableton Live Remote Script port with the production 15s connect timeout, from a webview bridge handler on the UI thread. With Live not running, the UI polls connection status every 3s and each probe blocked the full 15s — the app window sat permanently in "Not Responding" on Windows. Captured live in a debugger; the hung UI thread:

```
ntdll!NtWaitForSingleObject
ws2_32!select
Tamber!eacp::TCP::detail::`anonymous namespace'::waitWritable
Tamber!eacp::TCP::detail::`anonymous namespace'::tryConnect
Tamber!eacp::TCP::detail::socketConnect
Tamber!eacp::TCP::Connection::connect
Tamber!tamber::`anonymous namespace'::AbletonConnection::open
...
```

## Fix

Watch the except set too. `tryConnect` already checks `pendingSocketError` (`SO_ERROR`) right after the wait, which correctly reports the refusal for the except-set case — so the only change needed is the extra fd_set.

Measured on Windows 11: refused loopback connect goes from blocking 15,000ms+ (full timeout) to ~2,000ms (the Windows kernel internally retries refused loopback connects, so that ~2s is the OS floor, not the library).

## Tests

`Tcp/refusedConnectFailsWellBeforeTheConnectTimeout`: gives a refused connect a 20s budget and requires failure well before it (<10s, leaving margin for the kernel's loopback retries). It also asserts the failure is not reported as `connect timed out` — exactly the mislabel the broken path produced. Verified red against the unfixed code (fails after eating the full 20s) and green with the fix (~2s). Full `TcpConnectionTests` suite: 30/30 passing on Windows 11 / MSVC 19.51.

## New example: `Apps/Network/TcpProbe`

A small CLI that dials a host:port and reports the verdict **with how long it took** — making the behavior this PR fixes directly observable:

```
$ TcpProbe --port 59999 --timeout-ms 20000
127.0.0.1:59999 is not accepting connections (verdict in 2030 ms): Couldn't connect to 127.0.0.1:59999: connect failed

$ TcpProbe --port 5050        # with TcpServer running
127.0.0.1:5050 is open (verdict in 11 ms)
```

Before the fix the first command sat for the full 20s on Windows. `run.sh` demos both paths against `TcpServer`, and the existing TcpClient/TcpServer examples cross-reference the probe. Both verified working against the local `TcpServer` on Windows 11.
