### PR TITLE
Patch EADataStructures C++23 aligned storage deprecations

### DIFF
--- a/CMake/FindEADataStructures.cmake
+++ b/CMake/FindEADataStructures.cmake
@@ -1,6 +1,30 @@
 include(CPM)
 
+set(_eadatastructures_patch
+        "${CMAKE_CURRENT_LIST_DIR}/patches/eadatastructures-cxx23-aligned-storage.patch")
+
 CPMAddPackage(
         NAME EADataStructures
         GITHUB_REPOSITORY eyalamirmusic/cpp_data_structures
         GIT_TAG main)
+
+set(_eadatastructures_probe
+        "${EADataStructures_SOURCE_DIR}/ea_data_structures/Structures/FixedDynamicArray.h")
+
+if (EXISTS "${_eadatastructures_probe}")
+    file(READ "${_eadatastructures_probe}" _eadatastructures_probe_contents)
+    if (_eadatastructures_probe_contents MATCHES "aligned_storage_t")
+        find_program(_eadatastructures_patch_executable patch REQUIRED)
+        execute_process(
+                COMMAND "${_eadatastructures_patch_executable}" -p1 -i "${_eadatastructures_patch}"
+                WORKING_DIRECTORY "${EADataStructures_SOURCE_DIR}"
+                RESULT_VARIABLE _eadatastructures_patch_result
+                OUTPUT_VARIABLE _eadatastructures_patch_output
+                ERROR_VARIABLE _eadatastructures_patch_error)
+        if (NOT _eadatastructures_patch_result EQUAL 0)
+            message(FATAL_ERROR
+                    "Failed to patch EADataStructures for C++23 aligned storage deprecations:\n"
+                    "${_eadatastructures_patch_output}\n${_eadatastructures_patch_error}")
+        endif ()
+    endif ()
+endif ()

--- a/CMake/patches/eadatastructures-cxx23-aligned-storage.patch
+++ b/CMake/patches/eadatastructures-cxx23-aligned-storage.patch
@@ -1,0 +1,63 @@
+diff --git a/ea_data_structures/Allocators/SmallVectorAllocator.h b/ea_data_structures/Allocators/SmallVectorAllocator.h
+index 9d93a1f..795c179 100644
+--- a/ea_data_structures/Allocators/SmallVectorAllocator.h
++++ b/ea_data_structures/Allocators/SmallVectorAllocator.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstddef>
+ #include "DefaultAllocators.h"
+ 
+ namespace EA::Allocators::SmallVector
+@@ -65,7 +66,7 @@ struct Allocator : Base
+         return isSmallBuffer == !other.isSmallBuffer;
+     }
+ 
+-    std::aligned_storage_t<sizeof(T), alignof(T)> buffer[MaxSize];
++    alignas(T) std::byte buffer[sizeof(T) * MaxSize];
+ };
+ 
+ } // namespace EA::Allocators::SmallVector
+diff --git a/ea_data_structures/Allocators/StaticVectorAllocator.h b/ea_data_structures/Allocators/StaticVectorAllocator.h
+index 5168dfc..8a56534 100644
+--- a/ea_data_structures/Allocators/StaticVectorAllocator.h
++++ b/ea_data_structures/Allocators/StaticVectorAllocator.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstddef>
+ #include <cassert>
+ 
+ namespace EA::Allocators::StaticVector
+@@ -40,7 +41,7 @@ struct Allocator
+ 
+     bool operator==(const Allocator&) const { return false; }
+ 
+-    std::aligned_storage_t<sizeof(T), alignof(T)> buffer[MaxSize];
++    alignas(T) std::byte buffer[sizeof(T) * MaxSize];
+ };
+ 
+ } // namespace EA::Allocators::StaticVector
+diff --git a/ea_data_structures/Structures/FixedDynamicArray.h b/ea_data_structures/Structures/FixedDynamicArray.h
+index 5e878b3..44b8c50 100644
+--- a/ea_data_structures/Structures/FixedDynamicArray.h
++++ b/ea_data_structures/Structures/FixedDynamicArray.h
+@@ -1,5 +1,6 @@
+ #pragma once
+ 
++#include <cstddef>
+ #include <type_traits>
+ 
+ namespace EA
+@@ -11,7 +12,10 @@ template <typename T>
+ class FixedDynamicArray
+ {
+ public:
+-    using Aligned = std::aligned_storage_t<sizeof(T), alignof(T)>;
++    struct alignas(T) Aligned
++    {
++        std::byte bytes[sizeof(T)];
++    };
+ 
+     template <typename... ARGS>
+     explicit FixedDynamicArray(int sizeToUse, ARGS&&... args)


### PR DESCRIPTION
## Summary
- patch EADataStructures during eacp dependency setup to replace deprecated std::aligned_storage_t usage
- use alignas(T) std::byte storage in the affected allocator/fixed-array headers
- keep the patch application idempotent for already-populated CPM checkouts

## Verification
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DGIT_EXECUTABLE=/etc/profiles/per-user/jamiepond/bin/git
- cmake --build build
- rg -n "aligned_storage_t" build/_deps/eadatastructures-src/ea_data_structures/Allocators/SmallVectorAllocator.h build/_deps/eadatastructures-src/ea_data_structures/Allocators/StaticVectorAllocator.h build/_deps/eadatastructures-src/ea_data_structures/Structures/FixedDynamicArray.h