### PR TITLE
EventLoop/macOS: route NSApplication terminate: through the clean quit path

### DIFF
--- a/Lib/eacp/Core/Threads/EventLoop-macOS.mm
+++ b/Lib/eacp/Core/Threads/EventLoop-macOS.mm
@@ -1,9 +1,23 @@
 #include "EventLoop.h"
+#include "../ObjC/ObjC.h"
 #import <Foundation/Foundation.h>
 #import <Cocoa/Cocoa.h>
 
 #include <cassert>
 #include <chrono>
+
+// terminate: (Cmd+Q, Dock quit, quit Apple Events) calls exit() without
+// unwinding run<T>(); cancel it and stop the loop so the normal teardown runs.
+@interface AppTerminationBridge : NSObject <NSApplicationDelegate>
+@end
+
+@implementation AppTerminationBridge
+- (NSApplicationTerminateReply)applicationShouldTerminate:(NSApplication*)sender
+{
+    eacp::Threads::getEventLoop().quit();
+    return NSTerminateCancel;
+}
+@end
 
 namespace eacp::Threads
 {
@@ -31,6 +45,11 @@ NSApplication* getApp()
     static NSApplication* app = [] {
         auto* application = [NSApplication sharedApplication];
         [application setActivationPolicy:activationPolicyFromBundle()];
+
+        static auto delegate =
+            ObjC::Ptr<AppTerminationBridge>([[AppTerminationBridge alloc] init]);
+        [application setDelegate:delegate.get()];
+
         return application;
     }();
     return app;

--- a/Tests/Core/AppTerminationHarness.mm
+++ b/Tests/Core/AppTerminationHarness.mm
@@ -1,0 +1,44 @@
+// Subprocess harness for AppTerminationTests: quits a running app via
+// terminate: and reports whether run<T>() unwound.
+#include <eacp/Core/App/App.h>
+
+#import <Cocoa/Cocoa.h>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <thread>
+
+namespace
+{
+struct TerminatingApp
+{
+    TerminatingApp()
+    {
+        eacp::Threads::callAsync([] { [NSApp terminate:nil]; });
+    }
+
+    ~TerminatingApp()
+    {
+        std::puts("app-destroyed");
+        std::fflush(stdout);
+    }
+};
+} // namespace
+
+int main()
+{
+    std::thread(
+        []
+        {
+            std::this_thread::sleep_for(std::chrono::seconds(15));
+            std::_Exit(3);
+        })
+        .detach();
+
+    eacp::Apps::run<TerminatingApp>();
+
+    std::puts("run-returned");
+    std::fflush(stdout);
+    return 0;
+}

--- a/Tests/Core/AppTerminationTests.cpp
+++ b/Tests/Core/AppTerminationTests.cpp
@@ -1,0 +1,18 @@
+#include <eacp/Core/Process/Process.h>
+#include <NanoTest/NanoTest.h>
+
+using namespace nano;
+namespace Proc = eacp::Processes;
+
+// A Cocoa terminate: must unwind run<T>() and destroy the app before main
+// returns, like Apps::quit() — not fall through to exit().
+auto tCocoaTerminateUnwindsRun =
+    test("App/cocoaTerminateUnwindsRunAndDestroysApp") = []
+{
+    auto result = Proc::run(EACP_TERMINATION_HARNESS, {});
+
+    check(result.launched);
+    check(result.exited);
+    check(result.exitCode == 0);
+    check(result.output == "app-destroyed\nrun-returned\n");
+};

--- a/Tests/Core/CMakeLists.txt
+++ b/Tests/Core/CMakeLists.txt
@@ -14,6 +14,18 @@ nano_add_executable(AppAffordanceTests
         SOURCES AppAffordanceTests.cpp
         TARGETS eacp-core)
 
+if (APPLE AND NOT IOS)
+    add_executable(AppTerminationHarness AppTerminationHarness.mm)
+    target_link_libraries(AppTerminationHarness PRIVATE eacp-core)
+
+    nano_add_executable(AppTerminationTests
+            SOURCES AppTerminationTests.cpp
+            TARGETS eacp-core)
+    target_compile_definitions(AppTerminationTests PRIVATE
+            EACP_TERMINATION_HARNESS="$<TARGET_FILE:AppTerminationHarness>")
+    add_dependencies(AppTerminationTests AppTerminationHarness)
+endif ()
+
 nano_add_executable(EventLoopTests
         SOURCES EventLoopTests.cpp
         TARGETS eacp-core)


### PR DESCRIPTION
Cmd+Q, Dock quit and quit Apple Events go through `-[NSApplication terminate:]`, which calls `exit()` directly — `[NSApp run]` never returns, so `run<T>()` never unwinds and `destroyApp()` never runs. The app gets destroyed during static teardown instead, while its background threads are still running. In Tamber this crashes on every quit (ggml-metal residency-set assert, use-after-free in the CLAP indexer).

Fix: install an app delegate that cancels `terminate:` and stops the run loop, so OS quits take the same path as `Apps::quit()`.

`AppTerminationTests` runs a subprocess that quits itself via `[NSApp terminate:nil]` and checks that the app destructor runs and `run<T>()` returns. Fails without the delegate.