### PR TITLE
Implement Windows chooseFile/chooseDirectory with IFileOpenDialog

### DIFF
--- a/Lib/eacp/Core/App/App-Windows-FilePicker.h
+++ b/Lib/eacp/Core/App/App-Windows-FilePicker.h
@@ -1,0 +1,42 @@
+#pragma once
+
+// Windows-only seam behind chooseFile() / chooseDirectory().
+//
+// The native picker is an interactive modal (IFileOpenDialog::Show), so it
+// cannot be driven from a headless unit test. Everything around the modal —
+// turning the picked wide path into the UTF-8 result, telling cancel from a
+// selection, and building the file-type filter — is pulled out here as pure
+// functions the tests exercise directly. App-Windows.cpp wires these to the
+// real dialog; the tests wire chooseWithDialog() to a fake one.
+
+#include "App.h"
+
+#include <functional>
+#include <optional>
+#include <string>
+
+namespace eacp::Apps::detail
+{
+// {"wav", "mp3"} -> L"*.wav;*.mp3". Empty in -> empty out (caller applies no
+// filter, i.e. every file is shown).
+std::wstring buildFilterPattern(const Vector<std::string>& extensions);
+
+// The wide path the shell dialog handed back -> the UTF-8 string the public
+// API returns. nullptr or empty (the user cancelled) -> nullopt.
+std::optional<std::string> shellResultToPath(const wchar_t* pickedWidePath);
+
+// Shows a native "open" dialog and yields the selected path, or nullopt on
+// cancel; `pickFolders` chooses folder vs. file selection. This is the one
+// piece that blocks on a human, so it is the injection point — the real
+// implementation lives in App-Windows.cpp; tests pass a fake.
+using ShellOpenDialog = std::function<std::optional<std::wstring>(
+    bool pickFolders, const FilePickerOptions& options)>;
+
+// Shared core behind chooseFile() / chooseDirectory(): run `dialog`, then
+// convert its result to the public UTF-8 form. Split out so a fake `dialog`
+// can prove the picked path is honoured without showing a modal — the bug was
+// that the Windows stubs returned nullopt regardless of what the user chose.
+std::optional<std::string> chooseWithDialog(bool pickFolders,
+                                            const FilePickerOptions& options,
+                                            const ShellOpenDialog& dialog);
+} // namespace eacp::Apps::detail

--- a/Lib/eacp/Core/App/App-Windows-FilePicker.h
+++ b/Lib/eacp/Core/App/App-Windows-FilePicker.h
@@ -1,13 +1,7 @@
 #pragma once
 
-// Windows-only seam behind chooseFile() / chooseDirectory().
-//
-// The native picker is an interactive modal (IFileOpenDialog::Show), so it
-// cannot be driven from a headless unit test. Everything around the modal —
-// turning the picked wide path into the UTF-8 result, telling cancel from a
-// selection, and building the file-type filter — is pulled out here as pure
-// functions the tests exercise directly. App-Windows.cpp wires these to the
-// real dialog; the tests wire chooseWithDialog() to a fake one.
+// The native picker (IFileOpenDialog::Show) is an untestable modal; these pure
+// helpers factor out its surrounding logic so tests can drive it with a fake.
 
 #include "App.h"
 
@@ -17,25 +11,17 @@
 
 namespace eacp::Apps::detail
 {
-// {"wav", "mp3"} -> L"*.wav;*.mp3". Empty in -> empty out (caller applies no
-// filter, i.e. every file is shown).
+// {"wav", "mp3"} -> L"*.wav;*.mp3".
 std::wstring buildFilterPattern(const Vector<std::string>& extensions);
 
-// The wide path the shell dialog handed back -> the UTF-8 string the public
-// API returns. nullptr or empty (the user cancelled) -> nullopt.
+// null/empty (cancelled) -> nullopt; else the wide path as UTF-8.
 std::optional<std::string> shellResultToPath(const wchar_t* pickedWidePath);
 
-// Shows a native "open" dialog and yields the selected path, or nullopt on
-// cancel; `pickFolders` chooses folder vs. file selection. This is the one
-// piece that blocks on a human, so it is the injection point — the real
-// implementation lives in App-Windows.cpp; tests pass a fake.
+// The modal itself — the injection seam; tests pass a fake.
 using ShellOpenDialog = std::function<std::optional<std::wstring>(
     bool pickFolders, const FilePickerOptions& options)>;
 
-// Shared core behind chooseFile() / chooseDirectory(): run `dialog`, then
-// convert its result to the public UTF-8 form. Split out so a fake `dialog`
-// can prove the picked path is honoured without showing a modal — the bug was
-// that the Windows stubs returned nullopt regardless of what the user chose.
+// Shared core of chooseFile()/chooseDirectory(): run dialog, convert result.
 std::optional<std::string> chooseWithDialog(bool pickFolders,
                                             const FilePickerOptions& options,
                                             const ShellOpenDialog& dialog);

--- a/Lib/eacp/Core/App/App-Windows.cpp
+++ b/Lib/eacp/Core/App/App-Windows.cpp
@@ -1,10 +1,15 @@
 #include "../Utils/WinInclude.h"
 
 #include "App.h"
+#include "App-Windows-FilePicker.h"
 
 #include <shellapi.h>
+#include <shobjidl.h>
 #include <wincrypt.h>
 #include <winrt/base.h>
+
+#include <optional>
+#include <string>
 
 namespace eacp::Apps
 {
@@ -48,15 +53,127 @@ void openExternalURL(const std::string& url)
     ShellExecuteW(nullptr, L"open", wide.c_str(), nullptr, nullptr, SW_SHOWNORMAL);
 }
 
-// TODO: implement with IFileOpenDialog.
-std::optional<std::string> chooseFile(const FilePickerOptions&)
+namespace detail
 {
-    return std::nullopt;
+std::wstring buildFilterPattern(const Vector<std::string>& extensions)
+{
+    auto pattern = std::wstring {};
+    for (const auto& extension: extensions)
+    {
+        if (!pattern.empty())
+            pattern += L';';
+
+        pattern += L"*.";
+        // Extensions are ASCII (wav, mp3, ...), so a per-char widen is exact.
+        for (char c: extension)
+            pattern += static_cast<wchar_t>(static_cast<unsigned char>(c));
+    }
+    return pattern;
 }
 
-// TODO: implement with IFileOpenDialog (FOS_PICKFOLDERS).
+std::optional<std::string> shellResultToPath(const wchar_t* pickedWidePath)
+{
+    if (pickedWidePath == nullptr || pickedWidePath[0] == L'\0')
+        return std::nullopt;
+
+    const auto size = WideCharToMultiByte(
+        CP_UTF8, 0, pickedWidePath, -1, nullptr, 0, nullptr, nullptr);
+    if (size <= 1)
+        return std::nullopt;
+
+    auto out = std::string(static_cast<size_t>(size - 1), '\0');
+    WideCharToMultiByte(
+        CP_UTF8, 0, pickedWidePath, -1, out.data(), size, nullptr, nullptr);
+    return out;
+}
+
+std::optional<std::string> chooseWithDialog(bool pickFolders,
+                                            const FilePickerOptions& options,
+                                            const ShellOpenDialog& dialog)
+{
+    const auto picked = dialog(pickFolders, options);
+    if (!picked)
+        return std::nullopt;
+
+    return shellResultToPath(picked->c_str());
+}
+} // namespace detail
+
+namespace
+{
+// The real, interactive dialog behind chooseFile()/chooseDirectory(). Split
+// from the pure logic in detail:: so the latter stays unit-testable — see
+// App-Windows-FilePicker.h. Returns the picked path, or nullopt on cancel.
+std::optional<std::wstring> showShellOpenDialog(bool pickFolders,
+                                                const FilePickerOptions& options)
+{
+    const auto coInit =
+        CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
+    const bool shouldUninitialize = SUCCEEDED(coInit);
+
+    // COM objects must release before CoUninitialize, so the whole dialog lives
+    // in this lambda; its com_ptrs unwind at return, ahead of the uninit below.
+    const auto result = [&]() -> std::optional<std::wstring>
+    {
+        auto dialog = winrt::com_ptr<IFileOpenDialog> {};
+        if (FAILED(CoCreateInstance(CLSID_FileOpenDialog,
+                                    nullptr,
+                                    CLSCTX_INPROC_SERVER,
+                                    IID_PPV_ARGS(dialog.put()))))
+            return std::nullopt;
+
+        auto flags = FILEOPENDIALOGOPTIONS {};
+        if (SUCCEEDED(dialog->GetOptions(&flags)))
+        {
+            flags = static_cast<FILEOPENDIALOGOPTIONS>(
+                flags | FOS_FORCEFILESYSTEM | FOS_FILEMUSTEXIST | FOS_PATHMUSTEXIST
+                | (pickFolders ? FOS_PICKFOLDERS : 0));
+            dialog->SetOptions(flags);
+        }
+
+        if (!pickFolders && !options.allowedExtensions.empty())
+        {
+            const auto pattern =
+                detail::buildFilterPattern(options.allowedExtensions);
+            const COMDLG_FILTERSPEC specs[] = {
+                {L"Supported files", pattern.c_str()},
+                {L"All files", L"*.*"},
+            };
+            dialog->SetFileTypes(2, specs);
+            dialog->SetFileTypeIndex(1);
+        }
+
+        if (FAILED(dialog->Show(nullptr)))
+            return std::nullopt;
+
+        auto item = winrt::com_ptr<IShellItem> {};
+        if (FAILED(dialog->GetResult(item.put())) || !item)
+            return std::nullopt;
+
+        PWSTR rawPath = nullptr;
+        if (FAILED(item->GetDisplayName(SIGDN_FILESYSPATH, &rawPath))
+            || rawPath == nullptr)
+            return std::nullopt;
+
+        auto path = std::wstring {rawPath};
+        CoTaskMemFree(rawPath);
+        return path;
+    }();
+
+    if (shouldUninitialize)
+        CoUninitialize();
+
+    return result;
+}
+} // namespace
+
+std::optional<std::string> chooseFile(const FilePickerOptions& options)
+{
+    return detail::chooseWithDialog(false, options, showShellOpenDialog);
+}
+
 std::optional<std::string> chooseDirectory()
 {
-    return std::nullopt;
+    return detail::chooseWithDialog(true, {}, showShellOpenDialog);
 }
 } // namespace eacp::Apps

--- a/Lib/eacp/Core/App/App-Windows.cpp
+++ b/Lib/eacp/Core/App/App-Windows.cpp
@@ -64,7 +64,7 @@ std::wstring buildFilterPattern(const Vector<std::string>& extensions)
             pattern += L';';
 
         pattern += L"*.";
-        // Extensions are ASCII (wav, mp3, ...), so a per-char widen is exact.
+        // Extensions are ASCII, so a per-char widen is exact.
         for (char c: extension)
             pattern += static_cast<wchar_t>(static_cast<unsigned char>(c));
     }
@@ -101,9 +101,7 @@ std::optional<std::string> chooseWithDialog(bool pickFolders,
 
 namespace
 {
-// The real, interactive dialog behind chooseFile()/chooseDirectory(). Split
-// from the pure logic in detail:: so the latter stays unit-testable — see
-// App-Windows-FilePicker.h. Returns the picked path, or nullopt on cancel.
+// Real IFileOpenDialog behind the detail:: seam; tests substitute a fake.
 std::optional<std::wstring> showShellOpenDialog(bool pickFolders,
                                                 const FilePickerOptions& options)
 {
@@ -111,8 +109,8 @@ std::optional<std::wstring> showShellOpenDialog(bool pickFolders,
         CoInitializeEx(nullptr, COINIT_APARTMENTTHREADED | COINIT_DISABLE_OLE1DDE);
     const bool shouldUninitialize = SUCCEEDED(coInit);
 
-    // COM objects must release before CoUninitialize, so the whole dialog lives
-    // in this lambda; its com_ptrs unwind at return, ahead of the uninit below.
+    // COM objects must release before CoUninitialize, so the dialog lives in
+    // this lambda — its com_ptrs unwind before the uninit below.
     const auto result = [&]() -> std::optional<std::wstring>
     {
         auto dialog = winrt::com_ptr<IFileOpenDialog> {};

--- a/Lib/eacp/Core/App/App.h
+++ b/Lib/eacp/Core/App/App.h
@@ -67,14 +67,14 @@ struct FilePickerOptions
 
 // Shows the OS's native file chooser, blocking until the user picks a file
 // or cancels. Returns the chosen absolute path, or std::nullopt on cancel.
-// Must be called on the UI thread. Implemented on macOS; other backends
-// return std::nullopt for now.
+// Must be called on the UI thread. Implemented on macOS and Windows; Linux
+// returns std::nullopt for now.
 std::optional<std::string> chooseFile(const FilePickerOptions& options = {});
 
 // Shows the OS's native folder chooser, blocking until the user picks a
 // directory or cancels. Returns the chosen absolute path, or std::nullopt
-// on cancel. Must be called on the UI thread. Implemented on macOS; other
-// backends return std::nullopt for now.
+// on cancel. Must be called on the UI thread. Implemented on macOS and
+// Windows; Linux returns std::nullopt for now.
 std::optional<std::string> chooseDirectory();
 
 template <typename T>

--- a/Tests/Core/CMakeLists.txt
+++ b/Tests/Core/CMakeLists.txt
@@ -45,3 +45,10 @@ if (NOT WIN32)
             SOURCES ProcessTests.cpp
             TARGETS eacp-core)
 endif ()
+
+# The file/folder picker seam is Windows-only (App-Windows-FilePicker.h).
+if (WIN32)
+    nano_add_executable(FilePickerWindowsTests
+            SOURCES FilePickerWindowsTests.cpp
+            TARGETS eacp-core)
+endif ()

--- a/Tests/Core/FilePickerWindowsTests.cpp
+++ b/Tests/Core/FilePickerWindowsTests.cpp
@@ -1,0 +1,98 @@
+#include <eacp/Core/App/App-Windows-FilePicker.h>
+#include <eacp/Core/App/App.h>
+
+#include <NanoTest/NanoTest.h>
+
+#include <optional>
+#include <string>
+
+using namespace nano;
+using eacp::Apps::FilePickerOptions;
+using eacp::Apps::detail::buildFilterPattern;
+using eacp::Apps::detail::chooseWithDialog;
+using eacp::Apps::detail::shellResultToPath;
+
+// --- buildFilterPattern ---------------------------------------------------
+
+auto tFilterEmpty = test("FilePicker/Windows/emptyExtensionsGiveEmptyPattern") = []
+{ check(buildFilterPattern({}).empty()); };
+
+auto tFilterSingle = test("FilePicker/Windows/singleExtension") = []
+{ check(buildFilterPattern({"wav"}) == std::wstring(L"*.wav")); };
+
+auto tFilterMany = test("FilePicker/Windows/joinsExtensionsWithSemicolons") = []
+{
+    check(buildFilterPattern({"wav", "mp3", "flac"})
+          == std::wstring(L"*.wav;*.mp3;*.flac"));
+};
+
+// --- shellResultToPath ----------------------------------------------------
+
+auto tCancelNull = test("FilePicker/Windows/nullSelectionIsCancel") = []
+{ check(!shellResultToPath(nullptr).has_value()); };
+
+auto tCancelEmpty = test("FilePicker/Windows/emptySelectionIsCancel") = []
+{ check(!shellResultToPath(L"").has_value()); };
+
+auto tAsciiPath = test("FilePicker/Windows/asciiPathRoundTrips") = []
+{
+    const auto path = shellResultToPath(L"C:\\Users\\me\\Music");
+    check(path.has_value());
+    check(*path == std::string("C:\\Users\\me\\Music"));
+};
+
+auto tUnicodePath = test("FilePicker/Windows/unicodePathEncodesToUtf8") = []
+{
+    // Escapes, not raw glyphs, so both sides are independent of source
+    // encoding: the wide U+00FC maps to the two UTF-8 bytes 0xC3 0xBC.
+    const auto path = shellResultToPath(L"C:\\M\u00fcsic");
+    check(path.has_value());
+    check(*path
+          == std::string("C:\\M\xC3\xBC"
+                         "sic"));
+};
+
+// --- chooseWithDialog: proves the reported bug ----------------------------
+// Before the fix the Windows chooseDirectory()/chooseFile() returned nullopt
+// no matter what the user picked - "selecting a dir does nothing". Driving the
+// shared core with a fake dialog makes that contract checkable headlessly.
+
+auto tHonoursSelection = test("FilePicker/Windows/returnsThePickedDirectory") = []
+{
+    const auto picked = chooseWithDialog(
+        true,
+        {},
+        [](bool, const FilePickerOptions&) -> std::optional<std::wstring>
+        { return L"C:\\Users\\me\\Samples"; });
+
+    check(picked.has_value());
+    check(*picked == std::string("C:\\Users\\me\\Samples"));
+};
+
+auto tCancelYieldsNullopt = test("FilePicker/Windows/cancelReturnsNullopt") = []
+{
+    const auto picked = chooseWithDialog(
+        true,
+        {},
+        [](bool, const FilePickerOptions&) -> std::optional<std::wstring>
+        { return std::nullopt; });
+
+    check(!picked.has_value());
+};
+
+auto tForwardsPickFoldersFlag =
+    test("FilePicker/Windows/forwardsFolderModeToDialog") = []
+{
+    auto sawPickFolders = std::optional<bool> {};
+    chooseWithDialog(true,
+                     {},
+                     [&](bool pickFolders,
+                         const FilePickerOptions&) -> std::optional<std::wstring>
+                     {
+                         sawPickFolders = pickFolders;
+                         return std::nullopt;
+                     });
+
+    check(sawPickFolders.has_value());
+    check(*sawPickFolders == true);
+};

--- a/Tests/Core/FilePickerWindowsTests.cpp
+++ b/Tests/Core/FilePickerWindowsTests.cpp
@@ -12,8 +12,6 @@ using eacp::Apps::detail::buildFilterPattern;
 using eacp::Apps::detail::chooseWithDialog;
 using eacp::Apps::detail::shellResultToPath;
 
-// --- buildFilterPattern ---------------------------------------------------
-
 auto tFilterEmpty = test("FilePicker/Windows/emptyExtensionsGiveEmptyPattern") = []
 { check(buildFilterPattern({}).empty()); };
 
@@ -25,8 +23,6 @@ auto tFilterMany = test("FilePicker/Windows/joinsExtensionsWithSemicolons") = []
     check(buildFilterPattern({"wav", "mp3", "flac"})
           == std::wstring(L"*.wav;*.mp3;*.flac"));
 };
-
-// --- shellResultToPath ----------------------------------------------------
 
 auto tCancelNull = test("FilePicker/Windows/nullSelectionIsCancel") = []
 { check(!shellResultToPath(nullptr).has_value()); };
@@ -43,19 +39,14 @@ auto tAsciiPath = test("FilePicker/Windows/asciiPathRoundTrips") = []
 
 auto tUnicodePath = test("FilePicker/Windows/unicodePathEncodesToUtf8") = []
 {
-    // Escapes, not raw glyphs, so both sides are independent of source
-    // encoding: the wide U+00FC maps to the two UTF-8 bytes 0xC3 0xBC.
+    // Escapes not glyphs, so the test is independent of source encoding:
+    // U+00FC -> UTF-8 0xC3 0xBC.
     const auto path = shellResultToPath(L"C:\\M\u00fcsic");
     check(path.has_value());
     check(*path
           == std::string("C:\\M\xC3\xBC"
                          "sic"));
 };
-
-// --- chooseWithDialog: proves the reported bug ----------------------------
-// Before the fix the Windows chooseDirectory()/chooseFile() returned nullopt
-// no matter what the user picked - "selecting a dir does nothing". Driving the
-// shared core with a fake dialog makes that contract checkable headlessly.
 
 auto tHonoursSelection = test("FilePicker/Windows/returnsThePickedDirectory") = []
 {


### PR DESCRIPTION
## What

`chooseFile()` and `chooseDirectory()` were unimplemented stubs on Windows — they returned `std::nullopt` regardless of what the user picked. Any caller (e.g. a folder picker in a webview app) therefore saw "nothing selected" and did nothing.

This implements both with `IFileOpenDialog` (`FOS_PICKFOLDERS` for directories).

## How it's testable

The interactive modal (`IFileOpenDialog::Show`) can't be exercised headlessly, so the logic around it is factored into pure functions in a Windows-only `detail::` seam (`App-Windows-FilePicker.h`) that the real dialog is injected into:

- `buildFilterPattern(extensions)` — `{"wav","mp3"}` → `L"*.wav;*.mp3"`
- `shellResultToPath(widePath)` — picked wide path → UTF-8 result; `nullptr`/empty (cancel) → `nullopt`
- `chooseWithDialog(pickFolders, options, dialog)` — shared core; `chooseFile`/`chooseDirectory` wire the real dialog, tests wire a fake

`Tests/Core/FilePickerWindowsTests.cpp` (10 cases, WIN32-gated) drives that seam — including the previously-broken contract "a selection is returned, not dropped".

## Verification

- 10/10 unit tests pass.
- Integrated: driven end-to-end from a downstream app's folder picker — the dialog now opens and returns the chosen path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)