### PR TITLE
Stamp GUI apps with the project version the OS can show

### DIFF
--- a/Apps/Graphics/Todo/CMakeLists.txt
+++ b/Apps/Graphics/Todo/CMakeLists.txt
@@ -1,3 +1,8 @@
+# An app whose version differs from the enclosing tree declares its own
+# project(): PROJECT_VERSION is scoped to the nearest project() call, so the
+# version stamp (eacp_set_gui_subsystem) picks this one up.
+project(Todo VERSION 2.5.0)
+
 add_executable(Todo Main.cpp)
 target_link_libraries(Todo PRIVATE eacp-graphics)
 

--- a/CMake/TargetSetup.cmake
+++ b/CMake/TargetSetup.cmake
@@ -60,10 +60,115 @@ function(eacp_force_optimization target)
     endif ()
 endfunction()
 
+# Stamps the version identity a platform shows without running the binary,
+# taken from the version CMake already knows — the enclosing project(...
+# VERSION x.y.z): a VERSIONINFO resource on Windows (Explorer's Details tab,
+# installers, crash tooling), the bundle Info.plist version keys on macOS
+# (Get Info, crash reports). Runs from eacp_set_gui_subsystem so every eacp
+# GUI app is stamped with no extra calls; a project without a VERSION is
+# left unstamped. An app that versions independently of the tree declares
+# its own project() — PROJECT_VERSION is the nearest enclosing one.
+#
+# EACP_COMPANY_NAME (a variable set by the consuming tree) populates
+# CompanyName + LegalCopyright; both are omitted when unset. The product
+# name is the target's MACOSX_BUNDLE_BUNDLE_NAME when set (as
+# eacp_add_webview_app does), else the target name.
+function(_eacp_stamp_version_info target)
+    set(version "${PROJECT_VERSION}")
+    if (NOT version)
+        return()
+    endif ()
+
+    get_target_property(product_name ${target} MACOSX_BUNDLE_BUNDLE_NAME)
+    if (NOT product_name)
+        set(product_name "${target}")
+    endif ()
+
+    # Numeric version fields want exactly four integer parts; pad project()'s
+    # 1-4 dotted components with zeros ("1.2" -> 1.2.0.0).
+    string(REPLACE "." ";" version_parts "${version}")
+    list(LENGTH version_parts part_count)
+    while (part_count LESS 4)
+        list(APPEND version_parts 0)
+        list(LENGTH version_parts part_count)
+    endwhile ()
+    list(SUBLIST version_parts 0 4 version_parts)
+    list(SUBLIST version_parts 0 3 short_version_parts)
+    list(JOIN version_parts "," rc_version)
+    list(JOIN short_version_parts "." short_version)
+
+    if (APPLE)
+        # Consumed by the Info.plist template when the target is a bundle
+        # (CFBundleShortVersionString / CFBundleVersion /
+        # NSHumanReadableCopyright). Harmless on non-bundle targets.
+        set_target_properties(${target} PROPERTIES
+                MACOSX_BUNDLE_SHORT_VERSION_STRING "${short_version}"
+                MACOSX_BUNDLE_BUNDLE_VERSION "${version}"
+                MACOSX_BUNDLE_LONG_VERSION_STRING "${version}")
+        if (EACP_COMPANY_NAME)
+            set_target_properties(${target} PROPERTIES
+                    MACOSX_BUNDLE_COPYRIGHT
+                    "Copyright (C) ${EACP_COMPANY_NAME}")
+        endif ()
+        return()
+    endif ()
+
+    if (NOT WIN32)
+        return()
+    endif ()
+
+    # rc string literals escape embedded quotes by doubling them.
+    string(REPLACE "\"" "\"\"" product_name "${product_name}")
+
+    set(string_values "")
+    if (EACP_COMPANY_NAME)
+        string(REPLACE "\"" "\"\"" company "${EACP_COMPANY_NAME}")
+        string(APPEND string_values
+                "            VALUE \"CompanyName\", \"${company}\"\n"
+                "            VALUE \"LegalCopyright\", \"Copyright (C) ${company}\"\n")
+    endif ()
+    string(APPEND string_values
+            "            VALUE \"FileDescription\", \"${product_name}\"\n"
+            "            VALUE \"FileVersion\", \"${version}\"\n"
+            "            VALUE \"InternalName\", \"${target}\"\n"
+            "            VALUE \"OriginalFilename\", \"${target}.exe\"\n"
+            "            VALUE \"ProductName\", \"${product_name}\"\n"
+            "            VALUE \"ProductVersion\", \"${version}\"")
+
+    # Raw resource id and numeric flags so the .rc compiles without winres.h:
+    # 1 = VS_VERSION_INFO, 0x3f = VS_FFI_FILEFLAGSMASK, 0x40004 =
+    # VOS_NT_WINDOWS32, 0x1 = VFT_APP; "040904B0" / 0x409,1200 = en-US, Unicode.
+    set(rc_file "${CMAKE_CURRENT_BINARY_DIR}/${target}-version.rc")
+    file(CONFIGURE OUTPUT "${rc_file}" @ONLY CONTENT [[1 VERSIONINFO
+FILEVERSION @rc_version@
+PRODUCTVERSION @rc_version@
+FILEFLAGSMASK 0x3fL
+FILEFLAGS 0x0L
+FILEOS 0x40004L
+FILETYPE 0x1L
+FILESUBTYPE 0x0L
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0"
+        BEGIN
+@string_values@
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x409, 1200
+    END
+END
+]])
+    target_sources(${target} PRIVATE "${rc_file}")
+endfunction()
+
 # Mark an executable as a windowed GUI app so launching it never pops a console
 # window on Windows — the cross-platform analogue of MACOSX_BUNDLE on Apple. A
 # no-op everywhere but Windows. Call this on any eacp app that owns a window
-# (graphics/tray/webview apps) rather than a console.
+# (graphics/tray/webview apps) rather than a console. Also stamps the app with
+# the enclosing project()'s VERSION (see _eacp_stamp_version_info above).
 function(eacp_set_gui_subsystem target)
     set_target_properties(${target} PROPERTIES WIN32_EXECUTABLE TRUE)
     # WIN32_EXECUTABLE selects /SUBSYSTEM:WINDOWS, whose default MSVC entry point
@@ -73,6 +178,8 @@ function(eacp_set_gui_subsystem target)
     if (MSVC)
         target_link_options(${target} PRIVATE "/ENTRY:mainCRTStartup")
     endif ()
+
+    _eacp_stamp_version_info(${target})
 endfunction()
 
 # Gives an app its at-rest icon — the one Finder, Explorer and a

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.31)
-project(eacp LANGUAGES C CXX)
+project(eacp VERSION 0.1.0 LANGUAGES C CXX)
 
 if (CMAKE_SIZEOF_VOID_P EQUAL 4)
     message(FATAL_ERROR


### PR DESCRIPTION
## Reworked per review — project version only

No explicit function, no per-app calls, no version variables: `eacp_set_gui_subsystem` — which every eacp GUI app already goes through (`eacp_add_webview_app` included) — now also stamps the executable with the version CMake already knows from the enclosing `project(... VERSION x.y.z)`:

- **Windows**: a generated VERSIONINFO resource — Explorer's Details tab, installer UIs, crash tooling. (Previously the Details tab was completely empty.)
- **macOS**: the bundle Info.plist version keys (`CFBundleShortVersionString` / `CFBundleVersion`) via the standard `MACOSX_BUNDLE_*` properties the plist template consumes.
- A project without a `VERSION` is left unstamped; the product name is the target's `MACOSX_BUNDLE_BUNDLE_NAME` (which `eacp_add_webview_app` sets from `BUNDLE_NAME`), falling back to the target name.

**Per-app versions** work through normal CMake scoping — `PROJECT_VERSION` is the *nearest enclosing* `project()`, so an app that versions independently of the tree just declares its own (the Todo example demonstrates: `project(Todo VERSION 2.5.0)` → `Todo.exe` reports 2.5.0 while its siblings report the root's 0.1.0).

One optional variable: `EACP_COMPANY_NAME` populates CompanyName/LegalCopyright; both fields are simply absent when unset.

The diff is three files: `TargetSetup.cmake`, `project(eacp VERSION 0.1.0 ...)` at the root (number yours to choose), and the Todo example's per-app `project()`.

Verified on Windows ARM64:

```
GUI.exe         -> Product='GUI App'         Version='0.1.0'
SimpleView.exe  -> Product='Simple View App' Version='0.1.0'
WebViewTodo.exe -> Product='WebView Todo'    Version='0.1.0'
Todo.exe        -> Product='Todo App'        Version='2.5.0'   (own project())
Console.exe     -> unstamped (doesn't call eacp_set_gui_subsystem)
```

macOS side is standard CMake bundle plumbing — not exercised on this machine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)