### PR TITLE
Honor captureOutput=false on Windows

### DIFF
--- a/Lib/eacp/Core/Process/Process-Windows.cpp
+++ b/Lib/eacp/Core/Process/Process-Windows.cpp
@@ -247,6 +247,12 @@ private:
             return;
         }
 
+        if (!options.captureOutput)
+        {
+            launchInheritingStdio(options);
+            return;
+        }
+
         SECURITY_ATTRIBUTES inherit {};
         inherit.nLength = sizeof inherit;
         inherit.bInheritHandle = TRUE;
@@ -324,6 +330,68 @@ private:
 
         outReader = std::thread([this, outRead] { drain(outRead, outBuffer); });
         errReader = std::thread([this, errRead] { drain(errRead, errBuffer); });
+    }
+
+    // No pipes: the child writes straight to the launcher's stdio, so a
+    // long-running child's output streams instead of buffering unbounded.
+    // The launcher's std handles are duplicated inheritable first — the
+    // ones a harness hands us (pipes, files) often aren't.
+    void launchInheritingStdio(const ProcessOptions& options)
+    {
+        HANDLE handles[3] = {};
+        const DWORD channels[3] = {
+            STD_INPUT_HANDLE, STD_OUTPUT_HANDLE, STD_ERROR_HANDLE};
+
+        for (auto i = 0; i < 3; ++i)
+        {
+            auto original = GetStdHandle(channels[i]);
+
+            if (original != nullptr && original != INVALID_HANDLE_VALUE)
+                DuplicateHandle(GetCurrentProcess(),
+                                original,
+                                GetCurrentProcess(),
+                                &handles[i],
+                                0,
+                                TRUE,
+                                DUPLICATE_SAME_ACCESS);
+        }
+
+        STARTUPINFOW startup {};
+        startup.cb = sizeof startup;
+        startup.dwFlags = STARTF_USESTDHANDLES;
+        startup.hStdInput = handles[0];
+        startup.hStdOutput = handles[1];
+        startup.hStdError = handles[2];
+
+        auto commandLine = buildCommandLine(options.executable, options.arguments);
+        commandLine.push_back(L'\0');
+
+        auto workingDir = toWide(options.workingDirectory);
+        auto environment = buildEnvironmentBlock(options.environment);
+
+        PROCESS_INFORMATION info {};
+        auto created = CreateProcessW(
+            nullptr,
+            commandLine.data(),
+            nullptr,
+            nullptr,
+            TRUE,
+            environment.empty() ? 0 : CREATE_UNICODE_ENVIRONMENT,
+            environment.empty() ? nullptr : (LPVOID) environment.data(),
+            workingDir.empty() ? nullptr : workingDir.c_str(),
+            &startup,
+            &info);
+
+        for (auto handle: handles)
+            if (handle != nullptr)
+                CloseHandle(handle);
+
+        if (!created)
+            return;
+
+        processHandle = info.hProcess;
+        threadHandle = info.hThread;
+        processId = info.dwProcessId;
     }
 
     void launchDetached(const ProcessOptions& options)

--- a/Lib/eacp/Core/Process/Process.h
+++ b/Lib/eacp/Core/Process/Process.h
@@ -20,7 +20,7 @@ struct ProcessOptions
 
     // When false the child inherits the launcher's stdio rather than having it
     // captured into output()/errorOutput(). Suits long-running children whose
-    // output would otherwise buffer unbounded. POSIX only for now.
+    // output would otherwise buffer unbounded.
     bool captureOutput = true;
 
     // When true the child is launched detached: destroying the Process never

--- a/Tests/Core/CMakeLists.txt
+++ b/Tests/Core/CMakeLists.txt
@@ -75,6 +75,19 @@ if (NOT WIN32)
             TARGETS eacp-core)
 endif ()
 
+# Cross-platform proof for captureOutput=false: redirect the test's own
+# stdout to a file and assert a non-capturing child writes through to it,
+# live, while a capturing child still doesn't.
+if (WIN32)
+    set(stdioCaptureSource StdioCapture-Windows.cpp)
+else ()
+    set(stdioCaptureSource StdioCapture-Posix.cpp)
+endif ()
+
+nano_add_executable(ProcessInheritStdioTests
+        SOURCES ProcessInheritStdioTests.cpp ${stdioCaptureSource}
+        TARGETS eacp-core)
+
 # The file/folder picker seam is Windows-only (App-Windows-FilePicker.h).
 if (WIN32)
     nano_add_executable(FilePickerWindowsTests

--- a/Tests/Core/ProcessInheritStdioTests.cpp
+++ b/Tests/Core/ProcessInheritStdioTests.cpp
@@ -1,0 +1,98 @@
+#include "Common.h"
+#include "StdioCapture.h"
+
+#include <chrono>
+#include <filesystem>
+#include <fstream>
+#include <sstream>
+
+using namespace nano;
+namespace Proc = eacp::Processes;
+
+namespace
+{
+std::string tempPath(const std::string& name)
+{
+    return (std::filesystem::temp_directory_path() / name).string();
+}
+
+std::string contentsOf(const std::string& file)
+{
+    auto stream = std::ifstream {file, std::ios::binary};
+    auto buffer = std::ostringstream {};
+    buffer << stream.rdbuf();
+    return buffer.str();
+}
+
+bool contains(const std::string& text, const std::string& needle)
+{
+    return text.find(needle) != std::string::npos;
+}
+} // namespace
+
+// With captureOutput off, the child's stdout must land in whatever the
+// parent's stdout points at — here, a file the test redirected it to. The
+// pre-fix Windows implementation piped it into capture buffers nothing read,
+// leaving the file empty.
+auto tChildWritesThrough = test("Process/inheritStdio/childWritesThrough") = []
+{
+    const auto file = tempPath("eacp-inherit-through.txt");
+    auto result = Proc::ProcessResult {};
+    {
+        auto redirect = StdioCapture::StdoutToFile {file};
+        auto options = StdioCapture::echoCommand("inherit-proof");
+        options.captureOutput = false;
+        result = Proc::run(std::move(options));
+    }
+
+    check(result.launched);
+    check(result.exited);
+    check(result.exitCode == 0);
+    check(result.output.empty());
+    check(contains(contentsOf(file), "inherit-proof"));
+    std::filesystem::remove(file);
+};
+
+auto tCaptureStaysCaptured = test("Process/inheritStdio/captureStaysCaptured") = []
+{
+    const auto file = tempPath("eacp-inherit-captured.txt");
+    auto result = Proc::ProcessResult {};
+    {
+        auto redirect = StdioCapture::StdoutToFile {file};
+        result = Proc::run(StdioCapture::echoCommand("captured-text"));
+    }
+
+    check(result.exitCode == 0);
+    check(contains(result.output, "captured-text"));
+    check(contentsOf(file).empty());
+    std::filesystem::remove(file);
+};
+
+// Streaming, not buffering: the marker must be visible while the child is
+// still alive — it lingers ~5s after echoing, and the test kills it as soon
+// as the marker shows up.
+auto tStreamsWhileRunning = test("Process/inheritStdio/streamsWhileRunning") = []
+{
+    const auto file = tempPath("eacp-inherit-live.txt");
+    auto sawItLive = false;
+    {
+        auto redirect = StdioCapture::StdoutToFile {file};
+        auto options = StdioCapture::echoThenLinger("live-proof");
+        options.captureOutput = false;
+        auto process = Proc::Process {std::move(options)};
+
+        for (auto i = 0; i < 300 && process.isRunning(); ++i)
+        {
+            if (contains(contentsOf(file), "live-proof"))
+            {
+                sawItLive = process.isRunning();
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds {10});
+        }
+        process.kill();
+    }
+
+    check(sawItLive);
+    std::filesystem::remove(file);
+};

--- a/Tests/Core/ProcessInheritStdioTests.cpp
+++ b/Tests/Core/ProcessInheritStdioTests.cpp
@@ -90,7 +90,11 @@ auto tStreamsWhileRunning = test("Process/inheritStdio/streamsWhileRunning") = [
             }
             std::this_thread::sleep_for(std::chrono::milliseconds {10});
         }
+
+        // Kill is asynchronous on Windows; reap before the file cleanup
+        // below, or the child's inherited handle still blocks the delete.
         process.kill();
+        process.wait();
     }
 
     check(sawItLive);

--- a/Tests/Core/StdioCapture-Posix.cpp
+++ b/Tests/Core/StdioCapture-Posix.cpp
@@ -1,0 +1,35 @@
+#include "StdioCapture.h"
+
+#include <cstdio>
+#include <fcntl.h>
+#include <unistd.h>
+
+namespace StdioCapture
+{
+StdoutToFile::StdoutToFile(const std::string& file)
+{
+    std::fflush(stdout);
+    savedFd = dup(STDOUT_FILENO);
+
+    const auto fd = open(file.c_str(), O_CREAT | O_WRONLY | O_TRUNC, 0644);
+    dup2(fd, STDOUT_FILENO);
+    close(fd);
+}
+
+StdoutToFile::~StdoutToFile()
+{
+    std::fflush(stdout);
+    dup2(savedFd, STDOUT_FILENO);
+    close(savedFd);
+}
+
+eacp::Processes::ProcessOptions echoCommand(const std::string& text)
+{
+    return {"/bin/echo", {text}};
+}
+
+eacp::Processes::ProcessOptions echoThenLinger(const std::string& text)
+{
+    return {"/bin/sh", {"-c", "echo " + text + "; sleep 5"}};
+}
+} // namespace StdioCapture

--- a/Tests/Core/StdioCapture-Windows.cpp
+++ b/Tests/Core/StdioCapture-Windows.cpp
@@ -1,0 +1,50 @@
+#include "StdioCapture.h"
+
+#include <cstdio>
+#include <fcntl.h>
+#include <io.h>
+#include <sys/stat.h>
+
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+
+namespace StdioCapture
+{
+// Both levels must move: the CRT fd so our own printf lands in the file, and
+// the Win32 std handle, which is what a spawned child actually inherits.
+StdoutToFile::StdoutToFile(const std::string& file)
+{
+    std::fflush(stdout);
+    savedHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+    savedFd = _dup(1);
+
+    auto fd = -1;
+    _sopen_s(&fd,
+             file.c_str(),
+             _O_CREAT | _O_WRONLY | _O_TRUNC,
+             _SH_DENYNO,
+             _S_IREAD | _S_IWRITE);
+    _dup2(fd, 1);
+    _close(fd);
+
+    SetStdHandle(STD_OUTPUT_HANDLE, (HANDLE) _get_osfhandle(1));
+}
+
+StdoutToFile::~StdoutToFile()
+{
+    std::fflush(stdout);
+    _dup2(savedFd, 1);
+    _close(savedFd);
+    SetStdHandle(STD_OUTPUT_HANDLE, (HANDLE) savedHandle);
+}
+
+eacp::Processes::ProcessOptions echoCommand(const std::string& text)
+{
+    return {"cmd.exe", {"/c", "echo " + text}};
+}
+
+eacp::Processes::ProcessOptions echoThenLinger(const std::string& text)
+{
+    return {"cmd.exe", {"/c", "echo " + text + " & ping -n 6 127.0.0.1 > nul"}};
+}
+} // namespace StdioCapture

--- a/Tests/Core/StdioCapture-Windows.cpp
+++ b/Tests/Core/StdioCapture-Windows.cpp
@@ -43,8 +43,14 @@ eacp::Processes::ProcessOptions echoCommand(const std::string& text)
     return {"cmd.exe", {"/c", "echo " + text}};
 }
 
+// A single process, deliberately: a cmd.exe one-liner would linger via a
+// grandchild, which kill() cannot reach — and an orphan holding the
+// inherited file handle keeps the test's cleanup from deleting it.
 eacp::Processes::ProcessOptions echoThenLinger(const std::string& text)
 {
-    return {"cmd.exe", {"/c", "echo " + text + " & ping -n 6 127.0.0.1 > nul"}};
+    return {"powershell.exe",
+            {"-NoProfile",
+             "-Command",
+             "Write-Output '" + text + "'; Start-Sleep -Seconds 5"}};
 }
 } // namespace StdioCapture

--- a/Tests/Core/StdioCapture.h
+++ b/Tests/Core/StdioCapture.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <eacp/Core/Core.h>
+#include <string>
+
+// The stdio seam the inherit-stdio tests poke through, implemented once per
+// platform (StdioCapture-Posix.cpp, StdioCapture-Windows.cpp): redirect this
+// process's stdout to a file at the level a spawned child inherits it, and
+// name shell one-liners for the child to run.
+namespace StdioCapture
+{
+struct StdoutToFile
+{
+    explicit StdoutToFile(const std::string& file);
+    ~StdoutToFile();
+
+    StdoutToFile(const StdoutToFile&) = delete;
+    StdoutToFile& operator=(const StdoutToFile&) = delete;
+
+    int savedFd = -1;
+    void* savedHandle = nullptr;
+};
+
+eacp::Processes::ProcessOptions echoCommand(const std::string& text);
+
+// Echo the text, then stay alive for ~5 seconds.
+eacp::Processes::ProcessOptions echoThenLinger(const std::string& text);
+} // namespace StdioCapture


### PR DESCRIPTION
## Summary

`ProcessOptions::captureOutput = false` was documented as POSIX-only: the Windows `launch()` never checked it, unconditionally piping the child's stdio into capture buffers. A long-running child (our use case: streaming a remote process's output line-by-line over ssh) produced no visible output at all.

- When `captureOutput` is false, skip the pipes entirely: duplicate the launcher's std handles inheritable (`DuplicateHandle(…, TRUE, …)`) and hand them to the child via `STARTF_USESTDHANDLES`, matching the POSIX branch's behavior.
- The duplication pre-flight matters: when the launcher itself runs under a harness, its std handles are usually pipes that aren't inheritable — a bare `GetStdHandle` pass-through would hand the child dead handles.
- Parent's duplicates are closed after `CreateProcessW`; no drain threads on this path.
- `Process.h`: dropped the "POSIX only for now" caveat.

## Tests

New cross-platform target `ProcessInheritStdioTests` (unlike `ProcessTests`, it builds on Windows too — the platform-specific redirect/shell seam is one small file per platform):

- **childWritesThrough** — the test redirects its own stdout to a file at the OS level (POSIX fd / Win32 std handle — the level a child inherits), spawns a non-capturing child, and asserts the child's bytes landed in the file and `result.output` stayed empty. **Red on pre-fix Windows** (the file stays empty), green with this change.
- **streamsWhileRunning** — the child echoes then lingers ~5s; the marker must appear while `isRunning()`, proving streaming rather than buffer-until-exit.
- **captureStaysCaptured** — the default capturing path still captures and leaks nothing to the parent's stdout, guarding the other direction.

## Verification

- macOS: all 3 tests pass (and the original end-to-end use case re-verified).
- Windows: end-to-end verified — a child `ssh <host> 'exec <tool> monitor'` streams line-by-line instead of printing nothing; test-suite red/green run (parent commit vs branch head) posted in comments.