### PR TITLE
WebView: stream the cursor through a Windows file drag-out

### DIFF
--- a/Lib/eacp/WebView/WebView/FileDrag-Windows.h
+++ b/Lib/eacp/WebView/WebView/FileDrag-Windows.h
@@ -1,0 +1,180 @@
+#pragma once
+
+// Internal to the Windows WebView backend (WebView-Windows.cpp): the drop
+// source + target for a native file drag-out. A header rather than part of the
+// translation unit only so the logic is unit-testable without a live
+// SHDoDragDrop loop — see Tests/WebView/FileDragTests-Windows.cpp.
+
+#include "WebView.h"
+
+#include <eacp/Core/Utils/WinInclude.h>
+#include <ole2.h>
+
+#include <atomic>
+#include <functional>
+#include <utility>
+
+namespace eacp::Graphics
+{
+
+// A cursor position in the host window's client space, mapped into the page's
+// own client CSS pixels (top-left origin) — the same space the page reads as
+// clientX/clientY, so a drop can be hit-tested against the DOM. GetClientRect
+// is physical pixels and the WebView lays out at CSS pixels = physical / DPI,
+// so divide back down. `inside` is whether the cursor is over the window at
+// all — false once it leaves, which is the receiving app's half of the gesture.
+inline WebView::FileDragPoint toFileDragPoint(POINT cursorInClient,
+                                              const RECT& client,
+                                              float dpiScale)
+{
+    WebView::FileDragPoint point;
+    point.inside = PtInRect(&client, cursorInClient) != FALSE;
+
+    auto scale = dpiScale > 0.f ? dpiScale : 1.f;
+    point.x = cursorInClient.x / scale;
+    point.y = cursorInClient.y / scale;
+    return point;
+}
+
+// The live cursor in the drag's host window, in page CSS pixels (see above).
+inline WebView::FileDragPoint fileDragPointFromCursor(HWND hostHwnd,
+                                                      float dpiScale)
+{
+    POINT cursor {};
+    if (!GetCursorPos(&cursor))
+        return {};
+
+    RECT client {};
+    GetClientRect(hostHwnd, &client);
+    ScreenToClient(hostHwnd, &cursor);
+    return toFileDragPoint(cursor, client, dpiScale);
+}
+
+// A Windows file drag-out is a blocking modal loop (SHDoDragDrop). This drop
+// source is how the app hears about it while it runs: QueryContinueDrag fires on
+// every mouse move and button/key change inside the loop, so it streams the
+// cursor back and decides when the gesture ends. The default source SHDoDragDrop
+// uses with a null argument reports nothing — the host app could never follow
+// the drag without this. The cursor reader is injected so tests can drive the
+// verdict logic without a real cursor (the backend passes
+// fileDragPointFromCursor over its host window).
+class FileDragSource final: public IDropSource
+{
+public:
+    FileDragSource(std::function<WebView::FileDragPoint()> readPoint,
+                   std::function<void(WebView::FileDragPoint)> onMoved)
+        : readPoint(std::move(readPoint))
+        , onMoved(std::move(onMoved))
+    {
+    }
+
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** object) override
+    {
+        if (riid == IID_IUnknown || riid == IID_IDropSource)
+        {
+            *object = static_cast<IDropSource*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *object = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() override { return ++refCount; }
+
+    ULONG STDMETHODCALLTYPE Release() override
+    {
+        auto remaining = --refCount;
+        if (remaining == 0)
+            delete this;
+        return remaining;
+    }
+
+    HRESULT STDMETHODCALLTYPE QueryContinueDrag(BOOL escapePressed,
+                                                DWORD keyState) override
+    {
+        // Escape or the right button aborts; the left button coming up is the
+        // drop. Everything else is the drag in flight — report where it is.
+        if (escapePressed || (keyState & MK_RBUTTON) != 0)
+            return DRAGDROP_S_CANCEL;
+        if ((keyState & MK_LBUTTON) == 0)
+            return DRAGDROP_S_DROP;
+
+        onMoved(readPoint());
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE GiveFeedback(DWORD) override
+    {
+        // The drop target (see FileDragTarget) reports the effect, so the shell
+        // picks the right cursor from it. Over our own window that is a copy
+        // cursor; over Explorer / another app, whatever they return.
+        return DRAGDROP_S_USEDEFAULTCURSORS;
+    }
+
+private:
+    std::function<WebView::FileDragPoint()> readPoint;
+    std::function<void(WebView::FileDragPoint)> onMoved;
+    std::atomic<ULONG> refCount {1};
+};
+
+// A minimal drop target registered on our own window for the length of a
+// drag-out. Its only job is the cursor: without a target the shell paints the
+// ⊘ "no drop" badge over our window even where the page will accept the drop,
+// because the effect defaults to NONE. Reporting COPY gives the copy cursor
+// instead. The drop itself is deliberately a no-op — the app files the drop by
+// watching the cursor (onFileDragEnded, like the macOS path), not through OLE —
+// so Drop touches neither the data object nor the page; it only echoes the
+// effect to avoid a last-instant cursor flicker.
+class FileDragTarget final: public IDropTarget
+{
+public:
+    HRESULT STDMETHODCALLTYPE QueryInterface(REFIID riid, void** object) override
+    {
+        if (riid == IID_IUnknown || riid == IID_IDropTarget)
+        {
+            *object = static_cast<IDropTarget*>(this);
+            AddRef();
+            return S_OK;
+        }
+        *object = nullptr;
+        return E_NOINTERFACE;
+    }
+
+    ULONG STDMETHODCALLTYPE AddRef() override { return ++refCount; }
+
+    ULONG STDMETHODCALLTYPE Release() override
+    {
+        auto remaining = --refCount;
+        if (remaining == 0)
+            delete this;
+        return remaining;
+    }
+
+    HRESULT STDMETHODCALLTYPE DragEnter(
+        IDataObject*, DWORD, POINTL, DWORD* effect) override
+    {
+        *effect = DROPEFFECT_COPY;
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE DragOver(DWORD, POINTL, DWORD* effect) override
+    {
+        *effect = DROPEFFECT_COPY;
+        return S_OK;
+    }
+
+    HRESULT STDMETHODCALLTYPE DragLeave() override { return S_OK; }
+
+    HRESULT STDMETHODCALLTYPE Drop(
+        IDataObject*, DWORD, POINTL, DWORD* effect) override
+    {
+        *effect = DROPEFFECT_COPY;
+        return S_OK;
+    }
+
+private:
+    std::atomic<ULONG> refCount {1};
+};
+
+} // namespace eacp::Graphics

--- a/Lib/eacp/WebView/WebView/WebView-Windows.cpp
+++ b/Lib/eacp/WebView/WebView/WebView-Windows.cpp
@@ -4,10 +4,12 @@
 #include "WebView.h"
 #include "StreamingRange.h"
 #include "WebViewDetail.h"
+#include "FileDrag-Windows.h"
 #include <eacp/Graphics/DComp-Windows.h>
 #include <eacp/Graphics/Helpers/StringUtils-Windows.h>
 #include <eacp/Core/Threads/ThreadUtils.h>
 
+#include <atomic>
 #include <cstdlib>
 #include <queue>
 
@@ -1301,7 +1303,10 @@ struct WebView::Native
             return;
 
         auto ownerWindow = hostHwnd;
+        auto dpiScale = getDpiScale();
         auto onDragStarted = owner.onFileDragStarted;
+        auto onDragMoved = owner.onFileDragMoved;
+        auto onDragEnded = owner.onFileDragEnded;
         auto oleHr = OleInitialize(nullptr);
         if (FAILED(oleHr))
             return;
@@ -1311,6 +1316,11 @@ struct WebView::Native
         for (auto& path: paths)
         {
             auto widePath = toWideString(path);
+            // SHParseDisplayName only accepts the OS-native separator: a path
+            // with forward slashes (which is how cross-platform code, e.g.
+            // std::filesystem generic paths, hands them over) fails to parse and
+            // yields no PIDL, so the drag silently never starts. Normalize first.
+            std::replace(widePath.begin(), widePath.end(), L'/', L'\\');
             PIDLIST_ABSOLUTE pidl = nullptr;
             if (SUCCEEDED(
                     SHParseDisplayName(widePath.c_str(), nullptr, &pidl, 0, nullptr))
@@ -1337,12 +1347,41 @@ struct WebView::Native
 
                     if (IsWindow(ownerWindow))
                     {
+                        // Attach (not construct-from-raw) so the source keeps the
+                        // single ref it is born with; the ComPtr releases it — and
+                        // deletes the object — when the drag returns.
+                        ComPtr<IDropSource> dropSource;
+                        dropSource.Attach(new FileDragSource(
+                            [ownerWindow, dpiScale]
+                            {
+                                return fileDragPointFromCursor(ownerWindow,
+                                                               dpiScale);
+                            },
+                            onDragMoved));
+
+                        // Register our own window as a drop target for the length
+                        // of the drag purely for cursor feedback (see
+                        // FileDragTarget) — without it the shell shows ⊘ over our
+                        // own window. Fails harmlessly (leaving the old ⊘) if
+                        // something else already owns the window's drop slot.
+                        ComPtr<IDropTarget> dropTarget;
+                        dropTarget.Attach(new FileDragTarget());
+                        auto registered =
+                            SUCCEEDED(RegisterDragDrop(ownerWindow, dropTarget.Get()));
+
                         DWORD effect = DROPEFFECT_NONE;
                         SHDoDragDrop(ownerWindow,
                                      dataObject.Get(),
-                                     nullptr,
+                                     dropSource.Get(),
                                      DROPEFFECT_COPY,
                                      &effect);
+
+                        if (registered)
+                            RevokeDragDrop(ownerWindow);
+
+                        // The modal loop is over: report the release point so the
+                        // app can file the drop (or stand its filing UI down).
+                        onDragEnded(fileDragPointFromCursor(ownerWindow, dpiScale));
                     }
                 }
             }

--- a/Lib/eacp/WebView/WebView/WebView.h
+++ b/Lib/eacp/WebView/WebView/WebView.h
@@ -262,7 +262,24 @@ public:
     std::function<bool(OwningPointer<WebView> popup, const std::string& url)>
         onNewWindowRequested = [](auto&&, auto&&) { return false; };
 
+    // Cursor during a native file drag-out, in the page's own client CSS pixels
+    // (top-left origin — the same space as clientX/clientY). `inside` is false
+    // once the pointer leaves the window, so the drop belongs to whatever it
+    // lands on outside.
+    struct FileDragPoint
+    {
+        double x = 0;
+        double y = 0;
+        bool inside = false;
+    };
+
     std::function<void()> onFileDragStarted = [] {};
+    // Windows only: the OS file drag is a blocking modal loop (SHDoDragDrop), so
+    // eacp streams the cursor (onFileDragMoved) and reports the release
+    // (onFileDragEnded) from a custom drop source. On macOS the drag is async
+    // and the host polls the cursor itself, so these stay unused there.
+    std::function<void(FileDragPoint)> onFileDragMoved = [](auto&&) {};
+    std::function<void(FileDragPoint)> onFileDragEnded = [](auto&&) {};
     std::function<void()> onClose = [] {};
 
     // Fired (with Options::forwardUnhandledKeys) for every key event the page

--- a/Tests/WebView/CMakeLists.txt
+++ b/Tests/WebView/CMakeLists.txt
@@ -10,6 +10,16 @@ nano_add_executable(AsyncBridgeTests
         SOURCES AsyncBridgeTests.cpp
         TARGETS eacp-webview)
 
+# The drag-out drop source/target that stream onFileDragMoved / onFileDragEnded
+# through SHDoDragDrop's modal loop (FileDrag-Windows.h). The cursor reader is
+# injected, so the COM verdict logic and the physical->CSS pixel mapping test
+# without a live drag or window.
+if (WIN32)
+    nano_add_executable(FileDragTestsWindows
+            SOURCES FileDragTests-Windows.cpp
+            TARGETS eacp-webview)
+endif ()
+
 # Drives the live streaming pump on a real WebView, so it needs the
 # NSApplication / runloop bootstrap from eacp-webview-test-main rather than
 # nano_add_executable's bare main(). That target only exists on the platforms

--- a/Tests/WebView/FileDragTests-Windows.cpp
+++ b/Tests/WebView/FileDragTests-Windows.cpp
@@ -1,0 +1,152 @@
+// The Windows file drag-out runs inside SHDoDragDrop's blocking modal loop, so
+// the streaming callbacks (onFileDragMoved / onFileDragEnded) hang off the
+// FileDragSource / FileDragTarget COM objects that loop talks to. These tests
+// drive those objects directly — the cursor reader is injected, so no live
+// drag, cursor, or window is needed.
+
+#include <eacp/WebView/WebView/FileDrag-Windows.h>
+#include <NanoTest/NanoTest.h>
+
+#include <vector>
+
+using namespace nano;
+using namespace eacp::Graphics;
+
+namespace
+{
+WebView::FileDragPoint point(double x, double y, bool inside)
+{
+    return {.x = x, .y = y, .inside = inside};
+}
+
+RECT clientRect(long width, long height)
+{
+    return {.left = 0, .top = 0, .right = width, .bottom = height};
+}
+} // namespace
+
+auto tPointMapsPhysicalToCssPixels =
+    test("FileDrag/pointMapsPhysicalPixelsToCssPixels") = []
+{
+    // 200% DPI: a cursor at physical (100, 50) is CSS (50, 25) — the same
+    // coordinates the page reads as clientX/clientY.
+    auto mapped = toFileDragPoint({.x = 100, .y = 50}, clientRect(200, 100), 2.f);
+
+    check(mapped.x == 50.0);
+    check(mapped.y == 25.0);
+    check(mapped.inside);
+};
+
+auto tPointOutsideClientRect = test("FileDrag/pointOutsideClientRectIsOutside") = []
+{
+    auto rect = clientRect(200, 100);
+
+    check(!toFileDragPoint({.x = -1, .y = 50}, rect, 1.f).inside);
+    // PtInRect excludes the right/bottom edge, matching a client rect's bounds.
+    check(!toFileDragPoint({.x = 200, .y = 50}, rect, 1.f).inside);
+    check(!toFileDragPoint({.x = 100, .y = 100}, rect, 1.f).inside);
+    check(toFileDragPoint({.x = 0, .y = 0}, rect, 1.f).inside);
+};
+
+auto tZeroDpiFallsBackUnscaled = test("FileDrag/zeroDpiScaleFallsBackToUnscaled") = []
+{
+    auto mapped = toFileDragPoint({.x = 40, .y = 30}, clientRect(200, 100), 0.f);
+
+    check(mapped.x == 40.0);
+    check(mapped.y == 30.0);
+};
+
+auto tHeldButtonStreamsCursor =
+    test("FileDrag/heldLeftButtonContinuesAndStreamsCursor") = []
+{
+    auto moves = std::vector<WebView::FileDragPoint> {};
+    auto source = FileDragSource {[] { return point(12, 34, true); },
+                                  [&](WebView::FileDragPoint p)
+                                  { moves.push_back(p); }};
+
+    check(source.QueryContinueDrag(FALSE, MK_LBUTTON) == S_OK);
+    check(source.QueryContinueDrag(FALSE, MK_LBUTTON) == S_OK);
+
+    check(moves.size() == 2);
+    check(moves[0].x == 12.0);
+    check(moves[0].y == 34.0);
+    check(moves[0].inside);
+};
+
+auto tReleaseIsTheDrop = test("FileDrag/leftButtonReleaseIsTheDrop") = []
+{
+    auto moves = 0;
+    auto source = FileDragSource {[] { return point(0, 0, true); },
+                                  [&](WebView::FileDragPoint) { ++moves; }};
+
+    check(source.QueryContinueDrag(FALSE, 0) == DRAGDROP_S_DROP);
+    check(moves == 0);
+};
+
+auto tEscapeCancels = test("FileDrag/escapeCancels") = []
+{
+    auto source = FileDragSource {[] { return point(0, 0, true); },
+                                  [](WebView::FileDragPoint) {}};
+
+    check(source.QueryContinueDrag(TRUE, MK_LBUTTON) == DRAGDROP_S_CANCEL);
+};
+
+auto tRightButtonCancels = test("FileDrag/rightButtonCancels") = []
+{
+    auto source = FileDragSource {[] { return point(0, 0, true); },
+                                  [](WebView::FileDragPoint) {}};
+
+    check(source.QueryContinueDrag(FALSE, MK_LBUTTON | MK_RBUTTON)
+          == DRAGDROP_S_CANCEL);
+};
+
+auto tSourceUsesDefaultCursors = test("FileDrag/sourceUsesDefaultCursors") = []
+{
+    auto source = FileDragSource {[] { return point(0, 0, true); },
+                                  [](WebView::FileDragPoint) {}};
+
+    check(source.GiveFeedback(DROPEFFECT_COPY) == DRAGDROP_S_USEDEFAULTCURSORS);
+};
+
+auto tTargetReportsCopy = test("FileDrag/targetReportsCopyForCursorFeedback") = []
+{
+    // Without a registered target the shell paints the ⊘ "no drop" badge over
+    // our own window; the target's one job is to report COPY everywhere so the
+    // cursor matches what the page will actually do with the drop.
+    auto target = FileDragTarget {};
+
+    auto effect = DWORD {DROPEFFECT_NONE};
+    check(target.DragEnter(nullptr, 0, {}, &effect) == S_OK);
+    check(effect == DROPEFFECT_COPY);
+
+    effect = DROPEFFECT_NONE;
+    check(target.DragOver(0, {}, &effect) == S_OK);
+    check(effect == DROPEFFECT_COPY);
+
+    effect = DROPEFFECT_NONE;
+    check(target.Drop(nullptr, 0, {}, &effect) == S_OK);
+    check(effect == DROPEFFECT_COPY);
+
+    check(target.DragLeave() == S_OK);
+};
+
+auto tComContract = test("FileDrag/comIdentityAndRefCount") = []
+{
+    // Born with one ref (the Attach convention in WebView-Windows.cpp); the
+    // final Release deletes, so this test manages the object manually.
+    auto* source = new FileDragSource {[] { return point(0, 0, true); },
+                                       [](WebView::FileDragPoint) {}};
+
+    void* asDropSource = nullptr;
+    check(source->QueryInterface(IID_IDropSource, &asDropSource) == S_OK);
+    check(asDropSource == static_cast<IDropSource*>(source));
+
+    void* asDropTarget = nullptr;
+    check(source->QueryInterface(IID_IDropTarget, &asDropTarget)
+          == E_NOINTERFACE);
+    check(asDropTarget == nullptr);
+
+    // QueryInterface took a ref: 2 total. Releases count down to deletion.
+    check(source->Release() == 1);
+    check(source->Release() == 0);
+};


### PR DESCRIPTION
## What

A file drag-out on Windows runs inside `SHDoDragDrop`'s **blocking modal loop**, so the page (and the host app) is blind to its own gesture the moment the drag starts — no mousemove, no release. Apps that want to react to the drag (e.g. show a drop-assist UI aimed by the cursor) have no way to follow it.

This PR gives the loop a real `IDropSource` that narrates the drag while it runs:

- **`onFileDragMoved`** — streamed from `QueryContinueDrag` on every tick, in the page's own client CSS pixels (same space as `clientX`/`clientY`, DPI-corrected), with an `inside` flag for when the cursor leaves the window.
- **`onFileDragEnded`** — the release point, reported when the modal loop returns.
- A minimal `IDropTarget` registered on our own window for the drag's duration, purely for cursor feedback: without it the shell paints the ⊘ no-drop badge over the app's own window.

The two new `std::function` members on `WebView` follow the existing `onFileDragStarted` pattern exactly, with no-op defaults. On macOS the drag is an async `NSDraggingSession` and hosts poll the cursor themselves, so the callbacks stay unused there (documented in the header).

Also fixes a silent no-op: `SHParseDisplayName` rejects forward-slash paths (as produced by `std::filesystem` generic paths), yielding no PIDL — the drag simply never started. Paths are normalized to backslashes first.

## Proof / how to test

The drop source/target live in `FileDrag-Windows.h` with the **cursor reader injected**, so the logic is unit-tested without a live drag loop, cursor, or window — `Tests/WebView/FileDragTests-Windows.cpp` (runs in the existing `windows-latest` / `windows-11-arm` CI ctest jobs):

- physical→CSS pixel mapping incl. DPI scaling, inside/outside edges, and the zero-DPI fallback
- `QueryContinueDrag` verdicts: held left button → `S_OK` + cursor streamed; release → `DRAGDROP_S_DROP`; Escape / right button → `DRAGDROP_S_CANCEL`
- `GiveFeedback` → default cursors; target reports `DROPEFFECT_COPY` on enter/over/drop
- COM identity + refcount contract

All 10 pass locally on windows-11-arm, and the full tree builds clean.

This is what drives the drag-following crate drawer in Tamber Librarian on Windows, so it's exercised by a real app too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Lf1bSVBuidjv7t93kDBnvM