### PR TITLE
Windows: GPUView transparency + font parity (memory fonts, PostScript names, whitespace measurement)

### DIFF
--- a/Lib/eacp/GPU/View/GPUView-Windows.cpp
+++ b/Lib/eacp/GPU/View/GPUView-Windows.cpp
@@ -1,5 +1,6 @@
 #include "GPUView.h"
 #include <eacp/Graphics/DComp-Windows.h>
+#include <eacp/Graphics/Window/CompositionHostWindow-Windows.h>
 
 #include "../Device/Device.h"
 #include "../Frame/Frame.h"
@@ -189,7 +190,15 @@ struct GPUView::Native : DeviceResourceHolder
         descriptor.BufferUsage = DXGI_USAGE_RENDER_TARGET_OUTPUT;
         descriptor.BufferCount = bufferCount;
         descriptor.SwapEffect = DXGI_SWAP_EFFECT_FLIP_SEQUENTIAL;
-        descriptor.AlphaMode = DXGI_ALPHA_MODE_IGNORE;
+
+        // In a transparentBackground window the swapchain composites straight
+        // to the screen, so its alpha must reach DWM — IGNORE would fill the
+        // window with an opaque black box. Opaque windows keep IGNORE: their
+        // GPU content never meant its alpha for the desktop behind the window.
+        descriptor.AlphaMode =
+            Graphics::isHostWindowTransparent(Graphics::findHostHwndForView(&view))
+                ? DXGI_ALPHA_MODE_PREMULTIPLIED
+                : DXGI_ALPHA_MODE_IGNORE;
 
         // A waitable swapchain is what makes the present queue's depth ours to
         // choose. Without it DXGI queues up to three frames of its own accord,

--- a/Lib/eacp/Graphics/CMakeLists.txt
+++ b/Lib/eacp/Graphics/CMakeLists.txt
@@ -84,6 +84,7 @@ elseif (WIN32)
             Layers/TextLayer-Windows.cpp
             Menu/Menu-Windows.cpp
             Primitives/Font-Windows.cpp
+            Primitives/FontRegistry-Windows.cpp
             Primitives/Path-Windows.cpp
             Primitives/TextMetrics-Windows.cpp
             Tray/TrayIcon-Windows.cpp

--- a/Lib/eacp/Graphics/D2D-Windows.h
+++ b/Lib/eacp/Graphics/D2D-Windows.h
@@ -9,3 +9,24 @@
 #include <d2d1_1.h>
 #include <dwrite.h>
 #include <wrl/client.h>
+
+#include <string>
+
+namespace eacp::Graphics
+{
+// The shared font collection (FontRegistry-Windows.cpp) — the Windows stand-in
+// for CoreText's process-wide registry: the system fonts plus every font
+// registered from memory. Font, TextMetrics and the eacp-text rasterizer all
+// resolve against this one collection so an embedded face is visible
+// everywhere at once.
+Microsoft::WRL::ComPtr<IDWriteFontCollection> getFontCollection();
+
+// Registers in-memory OTF/TTF bytes with the shared collection (the bytes are
+// copied). The Windows half of eacp::Text::registerMemoryFont.
+bool registerMemoryFontData(const void* data, std::size_t size);
+
+// Resolves `name` the way CTFontCreateWithName does — as a family name, then a
+// PostScript or full face name — so the one name a caller ships works on both
+// platforms. Empty when nothing in the collection matches.
+std::wstring resolveFontFamilyName(const std::wstring& name);
+} // namespace eacp::Graphics

--- a/Lib/eacp/Graphics/Primitives/Font-Windows.cpp
+++ b/Lib/eacp/Graphics/Primitives/Font-Windows.cpp
@@ -26,8 +26,14 @@ struct Font::Native
 
         auto wideName = toWideString(options.name);
 
-        factory->CreateTextFormat(wideName.c_str(),
-                                  nullptr,
+        // The shared collection carries fonts registered from memory, and the
+        // resolver accepts the PostScript/full names CoreText accepts — an
+        // unresolvable name keeps the caller's spelling and falls back below.
+        auto collection = getFontCollection();
+        auto family = resolveFontFamilyName(wideName);
+
+        factory->CreateTextFormat(family.empty() ? wideName.c_str() : family.c_str(),
+                                  collection.Get(),
                                   DWRITE_FONT_WEIGHT_NORMAL,
                                   DWRITE_FONT_STYLE_NORMAL,
                                   DWRITE_FONT_STRETCH_NORMAL,

--- a/Lib/eacp/Graphics/Primitives/FontRegistry-Windows.cpp
+++ b/Lib/eacp/Graphics/Primitives/FontRegistry-Windows.cpp
@@ -1,0 +1,222 @@
+#include "../D2D-Windows.h"
+
+#include <dwrite_3.h>
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+// The shared font collection — the Windows stand-in for CoreText's process-wide
+// registry. CTFontManagerRegisterGraphicsFont makes an embedded font visible to
+// every CoreText call site at once; DirectWrite has no such registry, so the
+// one collection lives here and Font, TextMetrics and the eacp-text rasterizer
+// all resolve against it. Needs no device, render target or window, so it is
+// as happy in a headless test as in a frame.
+
+namespace eacp::Graphics
+{
+IDWriteFactory* getDWriteFactory();
+
+namespace
+{
+using Microsoft::WRL::ComPtr;
+
+// Only memory-font registration needs this newer interface, so a machine too
+// old to offer it still resolves installed fonts.
+IDWriteFactory5* memoryFontFactory()
+{
+    static auto instance = []
+    {
+        auto created = ComPtr<IDWriteFactory5>();
+
+        if (auto* factory = getDWriteFactory())
+            factory->QueryInterface(
+                __uuidof(IDWriteFactory5),
+                reinterpret_cast<void**>(created.GetAddressOf()));
+
+        return created;
+    }();
+
+    return instance.Get();
+}
+
+// The system collection until a font is registered from memory, and a rebuilt
+// system-plus-embedded one afterwards.
+class FontRegistry
+{
+public:
+    ComPtr<IDWriteFontCollection> collection()
+    {
+        const auto lock = std::lock_guard {mutex};
+
+        if (!current)
+            if (auto* factory = getDWriteFactory())
+                factory->GetSystemFontCollection(current.GetAddressOf(), FALSE);
+
+        return current;
+    }
+
+    bool add(const void* data, std::size_t size)
+    {
+        auto* factory = memoryFontFactory();
+
+        if (factory == nullptr || data == nullptr || size == 0)
+            return false;
+
+        const auto lock = std::lock_guard {mutex};
+
+        if (!loader)
+        {
+            if (FAILED(factory->CreateInMemoryFontFileLoader(loader.GetAddressOf()))
+                || FAILED(factory->RegisterFontFileLoader(loader.Get())))
+                return false;
+        }
+
+        auto file = ComPtr<IDWriteFontFile>();
+
+        // A null owner tells DirectWrite to copy the data, so the caller's
+        // buffer does not have to outlive the registration.
+        if (FAILED(loader->CreateInMemoryFontFileReference(factory,
+                                                           data,
+                                                           static_cast<UINT32>(size),
+                                                           nullptr,
+                                                           file.GetAddressOf())))
+            return false;
+
+        files.push_back(file);
+
+        return rebuild(factory);
+    }
+
+private:
+    // Called with the lock held. A font set is immutable once built, so adding a
+    // face means building a fresh one over every file plus the system set.
+    bool rebuild(IDWriteFactory5* factory)
+    {
+        auto builder = ComPtr<IDWriteFontSetBuilder1>();
+
+        if (FAILED(factory->CreateFontSetBuilder(builder.GetAddressOf())))
+            return false;
+
+        for (const auto& file: files)
+            builder->AddFontFile(file.Get());
+
+        auto systemSet = ComPtr<IDWriteFontSet>();
+
+        if (SUCCEEDED(factory->GetSystemFontSet(systemSet.GetAddressOf())))
+            builder->AddFontSet(systemSet.Get());
+
+        auto set = ComPtr<IDWriteFontSet>();
+
+        if (FAILED(builder->CreateFontSet(set.GetAddressOf())))
+            return false;
+
+        auto built = ComPtr<IDWriteFontCollection1>();
+
+        if (FAILED(factory->CreateFontCollectionFromFontSet(set.Get(),
+                                                            built.GetAddressOf())))
+            return false;
+
+        current = built;
+
+        return true;
+    }
+
+    std::mutex mutex;
+    ComPtr<IDWriteInMemoryFontFileLoader> loader;
+    std::vector<ComPtr<IDWriteFontFile>> files;
+    ComPtr<IDWriteFontCollection> current;
+};
+
+FontRegistry& fontRegistry()
+{
+    static auto registry = FontRegistry {};
+    return registry;
+}
+
+bool hasFamily(const ComPtr<IDWriteFontCollection>& collection,
+               const std::wstring& name)
+{
+    auto index = UINT32 {};
+    auto exists = BOOL {};
+
+    return collection
+           && SUCCEEDED(collection->FindFamilyName(name.c_str(), &index, &exists))
+           && exists;
+}
+
+// Resolves a PostScript or full face name to its family name through the
+// collection's font set, empty when nothing matches (or the collection
+// predates IDWriteFontCollection1 — registered memory fonts never do).
+std::wstring familyOfNamedFace(const ComPtr<IDWriteFontCollection>& collection,
+                               const std::wstring& name)
+{
+    auto withFontSet = ComPtr<IDWriteFontCollection1>();
+
+    if (!collection || FAILED(collection.As(&withFontSet)) || !withFontSet)
+        return {};
+
+    auto set = ComPtr<IDWriteFontSet>();
+
+    if (FAILED(withFontSet->GetFontSet(set.GetAddressOf())))
+        return {};
+
+    for (auto property: {DWRITE_FONT_PROPERTY_ID_POSTSCRIPT_NAME,
+                         DWRITE_FONT_PROPERTY_ID_FULL_NAME})
+    {
+        const auto filter = DWRITE_FONT_PROPERTY {property, name.c_str(), L""};
+        auto matches = ComPtr<IDWriteFontSet>();
+
+        if (FAILED(set->GetMatchingFonts(&filter, 1, matches.GetAddressOf()))
+            || !matches || matches->GetFontCount() == 0)
+            continue;
+
+        auto exists = BOOL {};
+        auto values = ComPtr<IDWriteLocalizedStrings>();
+
+        if (FAILED(matches->GetPropertyValues(0,
+                                              DWRITE_FONT_PROPERTY_ID_FAMILY_NAME,
+                                              &exists,
+                                              values.GetAddressOf()))
+            || !exists || !values)
+            continue;
+
+        auto length = UINT32 {};
+
+        if (FAILED(values->GetStringLength(0, &length)) || length == 0)
+            continue;
+
+        auto family = std::wstring(length, L'\0');
+
+        if (SUCCEEDED(values->GetString(0, family.data(), length + 1)))
+            return family;
+    }
+
+    return {};
+}
+} // namespace
+
+ComPtr<IDWriteFontCollection> getFontCollection()
+{
+    return fontRegistry().collection();
+}
+
+bool registerMemoryFontData(const void* data, std::size_t size)
+{
+    return fontRegistry().add(data, size);
+}
+
+std::wstring resolveFontFamilyName(const std::wstring& name)
+{
+    const auto collection = getFontCollection();
+
+    if (hasFamily(collection, name))
+        return name;
+
+    // CTFontCreateWithName also matches PostScript and full names
+    // ("ABCDiatypeMono-Regular"), so a name that works on the Apple side must
+    // find the same face here rather than silently substituting.
+    return familyOfNamedFace(collection, name);
+}
+
+} // namespace eacp::Graphics

--- a/Lib/eacp/Graphics/Primitives/TextMetrics-Windows.cpp
+++ b/Lib/eacp/Graphics/Primitives/TextMetrics-Windows.cpp
@@ -36,7 +36,10 @@ float TextMetrics::measureWidth(const std::string& text, const Font& font)
     auto metrics = DWRITE_TEXT_METRICS();
     textLayout->GetMetrics(&metrics);
 
-    return metrics.width;
+    // `width` stops at the last ink, so a trailing space — or a lone one, as a
+    // caller measuring codepoint by codepoint sends — measures zero and words
+    // fuse. CTLine's typographic width counts trailing whitespace; match it.
+    return metrics.widthIncludingTrailingWhitespace;
 }
 
 float TextMetrics::getOffsetForIndex(const std::string& text,

--- a/Lib/eacp/Graphics/Window/CompositionHostWindow-Windows.cpp
+++ b/Lib/eacp/Graphics/Window/CompositionHostWindow-Windows.cpp
@@ -161,6 +161,18 @@ Vector<CompositionHostWindow*>& compositionHosts()
 }
 } // namespace
 
+bool isHostWindowTransparent(HWND hwnd)
+{
+    if (hwnd == nullptr)
+        return false;
+
+    for (auto* host: compositionHosts())
+        if (host->hwnd == hwnd)
+            return host->transparentBackground;
+
+    return false;
+}
+
 // Called by the rendering-device recovery in D2DFactory-Windows.cpp. Unlike
 // Windows.UI.Composition — which could hot-swap the rendering device and keep
 // its surfaces (they merely lost their pixels) — DirectComposition binds the

--- a/Lib/eacp/Graphics/Window/CompositionHostWindow-Windows.h
+++ b/Lib/eacp/Graphics/Window/CompositionHostWindow-Windows.h
@@ -17,6 +17,12 @@ void registerContentViewHwnd(View* root, HWND hwnd);
 void unregisterContentViewHwnd(View* root);
 HWND findHostHwndForView(View* view);
 
+// Whether `hwnd` hosts a WindowOptions::transparentBackground surface. Content
+// that composites straight to the screen (a GPUView's swapchain) must respect
+// its own alpha there — an opaque swapchain would paint the black box the
+// option exists to remove. False for an unknown/null HWND.
+bool isHostWindowTransparent(HWND hwnd);
+
 // Marks `view` and all its subviews for repaint, e.g. after a DPI change or a
 // rendering-device replacement invalidates every backing surface.
 void repaintViewTree(View* view);

--- a/Lib/eacp/Text/GlyphRasterizer-Windows.cpp
+++ b/Lib/eacp/Text/GlyphRasterizer-Windows.cpp
@@ -1,6 +1,7 @@
 #include "GlyphRasterizer.h"
 
 #include <eacp/Core/Utils/WinInclude.h>
+#include <eacp/Graphics/D2D-Windows.h>
 #include <eacp/Graphics/Helpers/StringUtils-Windows.h>
 
 // d2d1.h first: DWRITE_COLOR_F is an alias for the D2D colour struct, and
@@ -10,7 +11,6 @@
 #include <wrl/client.h>
 
 #include <algorithm>
-#include <mutex>
 #include <string>
 #include <vector>
 
@@ -60,121 +60,6 @@ IDWriteFactory2* dwriteFactory()
     }();
 
     return instance.Get();
-}
-
-// Only registerMemoryFont needs this newer interface, so a machine too old to
-// offer it still rasterizes installed fonts.
-IDWriteFactory5* memoryFontFactory()
-{
-    static auto instance = []
-    {
-        auto created = ComPtr<IDWriteFactory5>();
-
-        if (auto* factory = dwriteFactory())
-            factory->QueryInterface(
-                __uuidof(IDWriteFactory5),
-                reinterpret_cast<void**>(created.GetAddressOf()));
-
-        return created;
-    }();
-
-    return instance.Get();
-}
-
-// The collection rasterizers resolve family names against: the system one until
-// a font is registered from memory, and a rebuilt system-plus-embedded one
-// afterwards. DirectWrite has no process-wide registry the way CoreText does,
-// so the collection has to be threaded through explicitly.
-class FontRegistry
-{
-public:
-    ComPtr<IDWriteFontCollection> collection()
-    {
-        const auto lock = std::lock_guard {mutex};
-
-        if (!current)
-            if (auto* factory = dwriteFactory())
-                factory->GetSystemFontCollection(current.GetAddressOf(), FALSE);
-
-        return current;
-    }
-
-    bool add(const void* data, std::size_t size)
-    {
-        auto* factory = memoryFontFactory();
-
-        if (factory == nullptr || data == nullptr || size == 0)
-            return false;
-
-        const auto lock = std::lock_guard {mutex};
-
-        if (!loader)
-        {
-            if (FAILED(factory->CreateInMemoryFontFileLoader(loader.GetAddressOf()))
-                || FAILED(factory->RegisterFontFileLoader(loader.Get())))
-                return false;
-        }
-
-        auto file = ComPtr<IDWriteFontFile>();
-
-        // A null owner tells DirectWrite to copy the data, so the caller's
-        // buffer does not have to outlive the registration.
-        if (FAILED(loader->CreateInMemoryFontFileReference(factory,
-                                                           data,
-                                                           static_cast<UINT32>(size),
-                                                           nullptr,
-                                                           file.GetAddressOf())))
-            return false;
-
-        files.push_back(file);
-
-        return rebuild(factory);
-    }
-
-private:
-    // Called with the lock held. A font set is immutable once built, so adding a
-    // face means building a fresh one over every file plus the system set.
-    bool rebuild(IDWriteFactory5* factory)
-    {
-        auto builder = ComPtr<IDWriteFontSetBuilder1>();
-
-        if (FAILED(factory->CreateFontSetBuilder(builder.GetAddressOf())))
-            return false;
-
-        for (const auto& file: files)
-            builder->AddFontFile(file.Get());
-
-        auto systemSet = ComPtr<IDWriteFontSet>();
-
-        if (SUCCEEDED(factory->GetSystemFontSet(systemSet.GetAddressOf())))
-            builder->AddFontSet(systemSet.Get());
-
-        auto set = ComPtr<IDWriteFontSet>();
-
-        if (FAILED(builder->CreateFontSet(set.GetAddressOf())))
-            return false;
-
-        auto built = ComPtr<IDWriteFontCollection1>();
-
-        if (FAILED(factory->CreateFontCollectionFromFontSet(set.Get(),
-                                                            built.GetAddressOf())))
-            return false;
-
-        current = built;
-
-        return true;
-    }
-
-    std::mutex mutex;
-    ComPtr<IDWriteInMemoryFontFileLoader> loader;
-    std::vector<ComPtr<IDWriteFontFile>> files;
-    ComPtr<IDWriteFontCollection> current;
-};
-
-FontRegistry& fontRegistry()
-{
-    static auto registry = FontRegistry {};
-    return registry;
 }
 
 int encodeUtf16(char32_t codepoint, wchar_t* units)
@@ -309,7 +194,10 @@ struct GlyphRasterizer::Native
         if (factory == nullptr)
             return;
 
-        collection = fontRegistry().collection();
+        // The collection shared with eacp-graphics (FontRegistry-Windows.cpp):
+        // system fonts plus everything registerMemoryFont added, so the
+        // rasterizer and the Graphics text sites resolve the same faces.
+        collection = Graphics::getFontCollection();
 
         if (!collection)
             return;
@@ -333,10 +221,13 @@ struct GlyphRasterizer::Native
     // the platform ships.
     std::wstring resolveFamily() const
     {
-        const auto wanted = toWideString(request.family);
-
-        if (hasFamily(wanted))
-            return wanted;
+        // The shared resolver accepts family, PostScript and full names — the
+        // CoreText matching rules, so the one name callers ship works on both
+        // platforms.
+        if (auto resolved =
+                Graphics::resolveFontFamilyName(toWideString(request.family));
+            !resolved.empty())
+            return resolved;
 
         for (const auto* candidate: {L"Segoe UI", L"Arial", L"Consolas"})
             if (hasFamily(candidate))
@@ -865,6 +756,9 @@ const FontRequest& GlyphRasterizer::request() const
 
 bool registerMemoryFont(const void* data, std::size_t size)
 {
-    return fontRegistry().add(data, size);
+    // Registration lives in eacp-graphics so its text sites (Font,
+    // TextMetrics) see the face too — the same process-wide visibility
+    // CTFontManagerRegisterGraphicsFont gives the Apple side.
+    return Graphics::registerMemoryFontData(data, size);
 }
 } // namespace eacp::Text

--- a/Tests/Text/CMakeLists.txt
+++ b/Tests/Text/CMakeLists.txt
@@ -15,3 +15,9 @@ nano_add_executable(TextTests
 
 # The end-to-end rendering tests draw through the sprite renderer.
 target_link_libraries(TextTests PRIVATE eacp-sprites)
+
+# The shared font registry (memory fonts + PostScript-name resolution) is a
+# Windows construction — CoreText gives the Apple side both for free.
+if (WIN32)
+    target_sources(TextTests PRIVATE FontResolution-WindowsTests.cpp)
+endif ()

--- a/Tests/Text/FontResolution-WindowsTests.cpp
+++ b/Tests/Text/FontResolution-WindowsTests.cpp
@@ -1,0 +1,134 @@
+#include "Common.h"
+
+#include <eacp/Graphics/D2D-Windows.h>
+#include <eacp/Graphics/Primitives/Font.h>
+#include <eacp/Graphics/Primitives/TextMetrics.h>
+
+#include <algorithm>
+#include <cstdio>
+#include <vector>
+
+// The shared font registry (Graphics/Primitives/FontRegistry-Windows.cpp) —
+// the Windows stand-in for CoreText's process-wide font registry.
+//
+// The bug these pin down: a font registered from memory was visible only to
+// the eacp-text rasterizer (Graphics::Font resolved against the system
+// collection), and a PostScript name — the spelling CTFontCreateWithName
+// accepts, so the one cross-platform callers ship — resolved on Apple but
+// silently substituted a fallback family on Windows.
+//
+// Windows guarantees Arial, whose PostScript name (ArialMT) usefully differs
+// from its family name, so these run against it rather than shipping a font.
+
+using namespace nano;
+using namespace eacp;
+using namespace eacp::Graphics;
+
+namespace
+{
+std::vector<unsigned char> readFile(const wchar_t* path)
+{
+    auto* file = _wfopen(path, L"rb");
+
+    if (file == nullptr)
+        return {};
+
+    std::fseek(file, 0, SEEK_END);
+    const auto size = std::ftell(file);
+    std::fseek(file, 0, SEEK_SET);
+
+    auto bytes = std::vector<unsigned char>((std::size_t) std::max(0L, size));
+    const auto read = std::fread(bytes.data(), 1, bytes.size(), file);
+    std::fclose(file);
+
+    bytes.resize(read);
+
+    return bytes;
+}
+} // namespace
+
+auto tPostScriptNameResolves =
+    test("FontResolution/postScriptNameResolvesToItsFamily") = []
+{
+    check(resolveFontFamilyName(L"Arial") == L"Arial");
+    check(resolveFontFamilyName(L"ArialMT") == L"Arial");
+    check(resolveFontFamilyName(L"NoSuchFace-Regular").empty());
+};
+
+// The rasterizer must land on the named face, not on a substitute — the same
+// glyphs, so the same advances as asking by family name.
+auto tRasterizerAcceptsAPostScriptName =
+    test("FontResolution/rasterizerResolvesAPostScriptName") = []
+{
+    auto byFamily = Text::FontRequest {};
+    byFamily.family = "Arial";
+    byFamily.pointSize = 16.f;
+
+    auto byPostScript = byFamily;
+    byPostScript.family = "ArialMT";
+
+    const auto family = Text::GlyphRasterizer {byFamily};
+    const auto postScript = Text::GlyphRasterizer {byPostScript};
+
+    if (!family.isValid())
+        return;
+
+    check(postScript.isValid());
+    check(postScript.rasterize(U'W', Text::FontStyle::Regular).advance
+          == family.rasterize(U'W', Text::FontStyle::Regular).advance);
+};
+
+// Graphics::Font is the path the bug hid in: it used to hand DirectWrite the
+// raw name against the system collection, and an embedded or PostScript name
+// silently became the fallback family.
+auto tGraphicsFontResolvesAPostScriptName =
+    test("FontResolution/graphicsFontResolvesAPostScriptName") = []
+{
+    const auto font = Font {FontOptions().withName("ArialMT").withSize(12.f)};
+    auto* format = static_cast<IDWriteTextFormat*>(font.getHandle());
+
+    if (format == nullptr)
+        return;
+
+    wchar_t family[64] = {};
+    format->GetFontFamilyName(family, 64);
+
+    check(std::wstring {family} == L"Arial");
+};
+
+// DWRITE_TEXT_METRICS.width stops at the last ink, so a lone space used to
+// measure zero and letter-spaced captions fused their words. CTLine's
+// typographic width counts trailing whitespace; Windows must agree.
+auto tSpaceMeasuresItsAdvance = test("TextMetrics/aLoneSpaceMeasuresItsAdvance") = []
+{
+    const auto font = Font {FontOptions().withName("Arial").withSize(12.f)};
+
+    if (font.getHandle() == nullptr)
+        return;
+
+    check(TextMetrics::measureWidth(" ", font) > 0.f);
+    check(TextMetrics::measureWidth("a b", font)
+          > TextMetrics::measureWidth("ab", font));
+};
+
+// Registration rebuilds the shared collection over every registered file plus
+// the system set — a broken rebuild would drop the system fonts on the floor.
+auto tMemoryFontRegistrationKeepsTheCollectionWhole =
+    test("FontResolution/memoryFontRegistrationKeepsSystemFonts") = []
+{
+    wchar_t windows[MAX_PATH] = {};
+    GetWindowsDirectoryW(windows, MAX_PATH);
+
+    const auto bytes =
+        readFile((std::wstring {windows} + L"\\Fonts\\arial.ttf").c_str());
+
+    if (bytes.empty())
+        return;
+
+    check(registerMemoryFontData(bytes.data(), bytes.size()));
+
+    // The rebuilt collection still resolves everything it did before.
+    check(resolveFontFamilyName(L"ArialMT") == L"Arial");
+    check(!resolveFontFamilyName(L"Segoe UI").empty());
+    check(Text::GlyphRasterizer {Text::FontRequest {.family = "Arial"}}.isValid());
+};


### PR DESCRIPTION
Found while bringing Tamber's loading screen (a GPU glyph-field logo floating in a borderless `transparentBackground` window, with an embedded-font caption) to Windows. macOS rendered it correctly; Windows showed an opaque black box, a fallback font, and fused words. Three parity gaps, two commits:

## GPUView: composite with premultiplied alpha in transparent windows

The composition swapchain was created with `DXGI_ALPHA_MODE_IGNORE` unconditionally, so a GPUView inside a `WindowOptions::transparentBackground` window filled it with an opaque black box regardless of the alpha its pass cleared to. The swapchain now derives its alpha mode from the host window — which already knows it was created transparent — via an internal `isHostWindowTransparent(HWND)` beside the existing host registry. Opaque windows keep `DXGI_ALPHA_MODE_IGNORE`, so nothing changes for them.

## Text: shared font registry, PostScript names, trailing whitespace

* **Memory fonts were invisible to Graphics.** `eacp::Text::registerMemoryFont` registered into a collection private to the rasterizer, while `Graphics::Font` resolved against the system collection — so embedded fonts silently fell back in `drawText`/`TextMetrics`. On macOS `CTFontManagerRegisterGraphicsFont` is process-wide; the Windows registry now lives in eacp-graphics (`FontRegistry-Windows.cpp`) and `Font`, `TextMetrics` and the rasterizer all resolve against the one shared collection.
* **PostScript names didn't resolve.** `CTFontCreateWithName` matches PostScript and full names, DirectWrite's `FindFamilyName` only families — so the one name cross-platform callers ship (e.g. `ABCDiatypeMono-Regular`) worked on Apple and substituted Segoe UI on Windows. `resolveFontFamilyName` now also matches PostScript/full names through the collection's font set.
* **A lone space measured zero.** `TextMetrics::measureWidth` returned `DWRITE_TEXT_METRICS.width`, which stops at the last ink — letter-spaced text drawn codepoint-by-codepoint fused its words. CTLine's typographic width counts trailing whitespace; switched to `widthIncludingTrailingWhitespace`.

## Tests

`Tests/Text/FontResolution-WindowsTests.cpp` pins all three down against fonts Windows ships (`ArialMT` → `Arial` at the registry, rasterizer and `Graphics::Font` layers; lone-space width; registration keeping the system set intact). 67/67 passing on Windows ARM64.

Unrelated but known: `EACP_UNITY_BUILD=ON` on Windows currently fails on a duplicated `widen()` in the two Video TUs — happy to send that one-liner (`FilePath::wide()`) separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017N6R2YYxCoeqXr5nHRPLE9