### PR TITLE
Move eacp onto EA::Vector/Array/Span and int-sized interfaces

### DIFF
--- a/Apps/Camera/CaptureProbe/Main.cpp
+++ b/Apps/Camera/CaptureProbe/Main.cpp
@@ -35,13 +35,13 @@ std::uint64_t checksum(const Cameras::CameraFrame& frame)
         return 0;
 
     auto sum = std::uint64_t {0};
-    auto rowLength = (std::size_t) frame.width() * 4;
+    auto rowLength = frame.width() * 4;
 
     for (auto y = 0; y < frame.height(); ++y)
     {
-        const auto* row = data + (std::size_t) y * frame.bytesPerRow();
+        const auto* row = data + y * frame.bytesPerRow();
 
-        for (std::size_t i = 0; i < rowLength; ++i)
+        for (auto i = 0; i < rowLength; ++i)
             sum += row[i];
     }
 
@@ -73,7 +73,7 @@ void captureFrames(const Cameras::CameraDevice& device)
 
             if (n <= 10)
                 std::printf(
-                    "  frame %2d: %dx%d  stride=%zu  t=%.3fs  checksum=%llu\n",
+                    "  frame %2d: %dx%d  stride=%d  t=%.3fs  checksum=%llu\n",
                     n,
                     frame.width(),
                     frame.height(),

--- a/Apps/Camera/IpcCameraDemo/Main.cpp
+++ b/Apps/Camera/IpcCameraDemo/Main.cpp
@@ -27,7 +27,7 @@ using namespace Graphics;
 namespace
 {
 constexpr auto channelName = "com.eacp.ipccamdemo";
-constexpr auto frameHeaderBytes = std::size_t {8};
+constexpr auto frameHeaderBytes = 8;
 
 void appendU32(std::string& out, std::uint32_t value)
 {
@@ -39,7 +39,7 @@ std::uint32_t readU32(const char* bytes)
 {
     auto value = std::uint32_t {0};
 
-    for (auto index = std::size_t {0}; index < 4; ++index)
+    for (auto index = 0; index < 4; ++index)
         value |= (std::uint32_t) (unsigned char) bytes[index] << (index * 8);
 
     return value;
@@ -47,23 +47,24 @@ std::uint32_t readU32(const char* bytes)
 
 std::string encodeFrame(const Cameras::CameraFrame& frame)
 {
-    auto width = (std::size_t) frame.width();
-    auto height = (std::size_t) frame.height();
+    auto width = frame.width();
+    auto height = frame.height();
     auto rowBytes = width * 4;
 
     auto message = std::string {};
-    message.reserve(frameHeaderBytes + rowBytes * height);
+    message.reserve((std::size_t) (frameHeaderBytes + rowBytes * height));
 
-    appendU32(message, (std::uint32_t) frame.width());
-    appendU32(message, (std::uint32_t) frame.height());
+    appendU32(message, (std::uint32_t) width);
+    appendU32(message, (std::uint32_t) height);
 
     const auto* pixels = (const char*) frame.data();
 
     if (frame.bytesPerRow() == rowBytes)
-        message.append(pixels, rowBytes * height);
+        message.append(pixels, (std::size_t) (rowBytes * height));
     else
-        for (auto row = std::size_t {0}; row < height; ++row)
-            message.append(pixels + row * frame.bytesPerRow(), rowBytes);
+        for (auto row = 0; row < height; ++row)
+            message.append(pixels + row * frame.bytesPerRow(),
+                           (std::size_t) rowBytes);
 
     return message;
 }
@@ -330,15 +331,16 @@ struct IpcCameraApp
 
     void showFrame(std::string message)
     {
-        if (message.size() < frameHeaderBytes)
+        auto messageBytes = (std::int64_t) message.size();
+
+        if (messageBytes < frameHeaderBytes)
             return;
 
         auto width = (int) readU32(message.data());
         auto height = (int) readU32(message.data() + 4);
-        auto expected = (std::size_t) width * (std::size_t) height * 4;
+        auto expected = (std::int64_t) width * height * 4;
 
-        if (width <= 0 || height <= 0
-            || message.size() - frameHeaderBytes != expected)
+        if (width <= 0 || height <= 0 || messageBytes - frameHeaderBytes != expected)
             return;
 
         remoteView->showFrame(width, height, std::move(message));

--- a/Apps/GPU/AsyncCompute/Main.cpp
+++ b/Apps/GPU/AsyncCompute/Main.cpp
@@ -24,7 +24,7 @@ namespace
 // nothing to overlap with work that finishes before the CPU gets going - and
 // that a wrong answer shows up as more than one bad element.
 constexpr int elementCount = 1 << 23;
-constexpr auto elementBytes = sizeof(float) * (std::size_t) elementCount;
+constexpr auto elementBytes = (int) sizeof(float) * elementCount;
 
 // Iterations of the stand-in CPU work below. Sized so the CPU side outlasts the
 // dispatch in an optimised build as well as a debug one: when the GPU finishes

--- a/Apps/GPU/Blending/Main.cpp
+++ b/Apps/GPU/Blending/Main.cpp
@@ -1,7 +1,5 @@
 #include <eacp/GPU/GPU.h>
 
-#include <vector>
-
 using namespace eacp;
 using namespace GPU;
 using namespace Maths;
@@ -58,7 +56,7 @@ constexpr CircleSpec circles[] = {
 
 // Real triangle-list mesh per circle: segments triangles of shape
 // (centre, rim[i], rim[i+1]). No fragment discard, no shader masking.
-void appendCircle(std::vector<Vertex>& out, const CircleSpec& c)
+void appendCircle(Vector<Vertex>& out, const CircleSpec& c)
 {
     for (auto i = 0; i < circleSegments; ++i)
     {
@@ -73,16 +71,16 @@ void appendCircle(std::vector<Vertex>& out, const CircleSpec& c)
                             c.centerY + circleRadius * std::sin(a1)},
                            {c.r, c.g, c.b, circleAlpha}};
 
-        out.push_back(centre);
-        out.push_back(rim0);
-        out.push_back(rim1);
+        out.add(centre);
+        out.add(rim0);
+        out.add(rim1);
     }
 }
 
-std::vector<Vertex> buildCircleMesh()
+Vector<Vertex> buildCircleMesh()
 {
-    auto out = std::vector<Vertex> {};
-    out.reserve(sizeof(circles) / sizeof(circles[0]) * circleSegments * 3);
+    auto out = Vector<Vertex> {};
+    out.reserve((int) (sizeof(circles) / sizeof(circles[0])) * circleSegments * 3);
     for (const auto& c: circles)
         appendCircle(out, c);
     return out;
@@ -123,7 +121,7 @@ struct BlendingView final : GPUView
         : shader(makeBlendingShader())
         , vertexData(buildCircleMesh())
         , vertexBuffer(Device::shared().makeBuffer(
-              vertexData.data(), vertexData.size() * sizeof(Vertex)))
+              vertexData.data(), vertexData.size() * (int) sizeof(Vertex)))
         , library(Device::shared().makeShaderLibrary(shader.source))
         , none(makePipeline(BlendMode::None))
         , alphaBlend(makePipeline(BlendMode::AlphaBlend))
@@ -149,7 +147,7 @@ struct BlendingView final : GPUView
         pass.setPipeline(pipeline);
         pass.setVertexBuffer(vertexBuffer);
         pass.setVertexBytes(&uniforms, sizeof(uniforms), 0);
-        pass.draw((int) vertexData.size());
+        pass.draw(vertexData.size());
     }
 
     void render(Frame& frame) override
@@ -164,7 +162,7 @@ struct BlendingView final : GPUView
     }
 
     GeneratedShader shader;
-    std::vector<Vertex> vertexData;
+    Vector<Vertex> vertexData;
     Buffer vertexBuffer;
     ShaderLibrary library;
     RenderPipeline none;

--- a/Apps/GPU/ComputeParticles/Main.cpp
+++ b/Apps/GPU/ComputeParticles/Main.cpp
@@ -39,7 +39,7 @@ struct Particle
 constexpr int floatsPerParticle = (int) (sizeof(Particle) / sizeof(float));
 static_assert(floatsPerParticle == 4, "the kernel reads state with read4");
 
-constexpr auto stateBytes = sizeof(Particle) * (std::size_t) particleCount;
+constexpr auto stateBytes = (int) sizeof(Particle) * particleCount;
 
 // The quad every particle is drawn as: two triangles of corners in [-1, 1],
 // scaled to the particle radius by the vertex shader. One instance per

--- a/Apps/GPU/CubeMap/Main.cpp
+++ b/Apps/GPU/CubeMap/Main.cpp
@@ -7,7 +7,6 @@
 #include <cstdio>
 #include <cstring>
 #include <string>
-#include <vector>
 
 // Cube textures: a sky and a mirror ball, which are the two things six square
 // faces sampled by a direction are for.
@@ -145,15 +144,15 @@ std::uint32_t packColor(Vec3 color, float brightness)
 // top - the same layout every 2D texture here is uploaded in, six times over.
 // There is no per-face call and no per-face offset to get wrong, which is the
 // whole ergonomics of it: assemble the block, hand it over.
-std::vector<std::uint32_t> buildSkyPixels()
+Vector<std::uint32_t> buildSkyPixels()
 {
-    auto pixels = std::vector<std::uint32_t> {};
+    auto pixels = Vector<std::uint32_t> {};
     pixels.reserve(6 * faceSize * faceSize);
 
     for (const auto& face: skyFaces)
         for (auto y = 0; y < faceSize; ++y)
             for (auto x = 0; x < faceSize; ++x)
-                pixels.push_back(packColor(face.color, faceBrightness(x, y)));
+                pixels.add(packColor(face.color, faceBrightness(x, y)));
 
     return pixels;
 }
@@ -186,8 +185,8 @@ struct Vertex
 
 struct Mesh
 {
-    std::vector<Vertex> vertices;
-    std::vector<std::uint32_t> indices;
+    Vector<Vertex> vertices;
+    Vector<std::uint32_t> indices;
 };
 
 // A UV sphere: rings of latitude, segments of longitude, two triangles per
@@ -213,7 +212,7 @@ Mesh buildSphere(float radius, int rings, int segments)
                                 std::cos(polar),
                                 std::sin(polar) * std::sin(azimuth)};
 
-            mesh.vertices.push_back({normal * radius, normal});
+            mesh.vertices.add(Vertex {normal * radius, normal});
         }
     }
 
@@ -225,7 +224,7 @@ Mesh buildSphere(float radius, int rings, int segments)
             auto c = b + 1;
             auto d = a + 1;
 
-            mesh.indices.insert(mesh.indices.end(), {a, d, c, a, c, b});
+            mesh.indices.add({a, d, c, a, c, b});
         }
 
     return mesh;
@@ -370,9 +369,8 @@ struct CubeMapView final : GPUView
         skyShader.sky = sky;
         skyShader.prepare(skyPipeline());
 
-        mirrorShader.setVertices(sphere.vertices.data(),
-                                 (int) sphere.vertices.size());
-        mirrorShader.setIndices(sphere.indices.data(), (int) sphere.indices.size());
+        mirrorShader.setVertices(sphere.vertices.data(), sphere.vertices.size());
+        mirrorShader.setIndices(sphere.indices.data(), sphere.indices.size());
         mirrorShader.sky = sky;
         mirrorShader.prepare(mirrorPipeline());
 

--- a/Apps/GPU/DepthSampling/Main.cpp
+++ b/Apps/GPU/DepthSampling/Main.cpp
@@ -6,7 +6,6 @@
 #include <cstring>
 #include <optional>
 #include <string>
-#include <vector>
 
 // A pass reading the depth an earlier pass wrote, and the effect that is the
 // whole reason to want it: soft particles.
@@ -505,7 +504,7 @@ constexpr Puff puffs[] = {
 constexpr auto puffCount = (int) (sizeof(puffs) / sizeof(puffs[0]));
 constexpr auto puffVertexCount = puffCount * 6;
 
-void appendQuad(std::vector<SceneVertex>& out,
+void appendQuad(Vector<SceneVertex>& out,
                 Vec3 a,
                 Vec3 b,
                 Vec3 c,
@@ -513,15 +512,15 @@ void appendQuad(std::vector<SceneVertex>& out,
                 Vec3 normal,
                 Vec3 color)
 {
-    out.push_back({a, normal, color});
-    out.push_back({b, normal, color});
-    out.push_back({c, normal, color});
-    out.push_back({a, normal, color});
-    out.push_back({c, normal, color});
-    out.push_back({d, normal, color});
+    out.add(SceneVertex {a, normal, color});
+    out.add(SceneVertex {b, normal, color});
+    out.add(SceneVertex {c, normal, color});
+    out.add(SceneVertex {a, normal, color});
+    out.add(SceneVertex {c, normal, color});
+    out.add(SceneVertex {d, normal, color});
 }
 
-void appendBox(std::vector<SceneVertex>& out, const Box& box)
+void appendBox(Vector<SceneVertex>& out, const Box& box)
 {
     auto c = box.centre;
     auto h = box.halfSize;
@@ -569,9 +568,9 @@ void appendBox(std::vector<SceneVertex>& out, const Box& box)
                box.color);
 }
 
-std::vector<SceneVertex> buildScene()
+Vector<SceneVertex> buildScene()
 {
-    auto vertices = std::vector<SceneVertex> {};
+    auto vertices = Vector<SceneVertex> {};
     vertices.reserve(sceneVertexCount);
 
     appendQuad(vertices,
@@ -632,8 +631,9 @@ struct DepthSamplingView final : GPUView
 {
     DepthSamplingView()
         : sceneVertices(buildScene())
-        , sceneBuffer(Device::shared().makeBuffer(
-              sceneVertices.data(), sceneVertices.size() * sizeof(SceneVertex)))
+        , sceneBuffer(Device::shared().makeBuffer(sceneVertices.data(),
+                                                  sceneVertices.size()
+                                                      * (int) sizeof(SceneVertex)))
         , puffBuffer(Device::shared().makeBuffer(
               nullptr, puffVertexCount * sizeof(PuffVertex)))
     {
@@ -723,7 +723,7 @@ struct DepthSamplingView final : GPUView
         depthCopy.sceneDepth = *sceneTarget;
         softPuffs.sceneDepth = *sceneTarget;
 
-        depthValues.assign((std::size_t) (width * height), 0.f);
+        depthValues.assign(width * height, 0.f);
     }
 
     void update(Threads::FrameTime time) override
@@ -755,7 +755,7 @@ struct DepthSamplingView final : GPUView
     // screen, and the fade would then be measuring the wrong distance.
     void updatePuffBuffer(const Camera& camera)
     {
-        auto vertices = std::vector<PuffVertex> {};
+        auto vertices = Vector<PuffVertex> {};
         vertices.reserve(puffVertexCount);
 
         constexpr Vec2 corners[6] = {{-1.f, -1.f},
@@ -771,10 +771,11 @@ struct DepthSamplingView final : GPUView
                 auto offset = camera.right * (corner.x * puff.radius)
                               + camera.up * (corner.y * puff.radius);
 
-                vertices.push_back({puff.centre + offset, corner});
+                vertices.add(PuffVertex {puff.centre + offset, corner});
             }
 
-        puffBuffer.update(vertices.data(), vertices.size() * sizeof(PuffVertex));
+        puffBuffer.update(vertices.data(),
+                          vertices.size() * (int) sizeof(PuffVertex));
     }
 
     void drawScene(RenderPass& pass, SceneShader& shader, const Camera& camera)
@@ -787,7 +788,7 @@ struct DepthSamplingView final : GPUView
         // From the vector rather than from the constant beside it: the buffer
         // holds what buildScene made, and a draw past the end of it is a read
         // of whatever follows.
-        pass.draw((int) sceneVertices.size());
+        pass.draw(sceneVertices.size());
     }
 
     template <typename Shader>
@@ -924,12 +925,12 @@ struct DepthSamplingView final : GPUView
     // What --check reads back, and the reason the copy pass is not conditional:
     // the frame it measures has to be the frame the window would have drawn.
     bool readBackDepth = false;
-    std::vector<float> depthValues;
+    Vector<float> depthValues;
 
     int targetWidth = 0;
     int targetHeight = 0;
 
-    std::vector<SceneVertex> sceneVertices;
+    Vector<SceneVertex> sceneVertices;
     Buffer sceneBuffer;
     Buffer puffBuffer;
 
@@ -1191,8 +1192,7 @@ int runCheck()
         maxDepth = std::max(maxDepth, value);
     }
 
-    auto probe =
-        view.depthValues[(std::size_t) (worstY * view.targetWidth + worstX)];
+    auto probe = view.depthValues[worstY * view.targetWidth + worstX];
 
     auto asByte = quantiseToByte(probe);
     auto asHalf = quantiseToHalf(probe);

--- a/Apps/GPU/GlyphAtlas/Main.cpp
+++ b/Apps/GPU/GlyphAtlas/Main.cpp
@@ -4,7 +4,6 @@
 
 #include <optional>
 #include <string>
-#include <vector>
 
 // Text drawn from a glyph atlas: rasterize on demand, cache, upload only what
 // changed, then draw each glyph as a textured quad.
@@ -169,7 +168,7 @@ struct AtlasTextView final : GPU::GPUView
         if (event.keyCode == Graphics::KeyCode::Delete)
         {
             // Trim a whole UTF-8 sequence, not a byte.
-            while (typed.size() > prefixLength)
+            while ((int) typed.size() > prefixLength)
             {
                 const auto last = (unsigned char) typed.back();
                 typed.pop_back();
@@ -277,8 +276,8 @@ struct AtlasTextView final : GPU::GPUView
     int proportionalFace = 0;
     float builtAtScale = 0.f;
 
-    std::vector<Line> lines;
-    std::size_t prefixLength = std::string("Type to add glyphs: ").size();
+    Vector<Line> lines;
+    int prefixLength = (int) std::string("Type to add glyphs: ").size();
 };
 
 Graphics::WindowOptions windowOptions()

--- a/Apps/GPU/Instancing/Main.cpp
+++ b/Apps/GPU/Instancing/Main.cpp
@@ -1,8 +1,6 @@
 #include <eacp/GPU/GPU.h>
 #include <algorithm>
 
-#include <vector>
-
 using namespace eacp;
 using namespace GPU;
 
@@ -169,37 +167,37 @@ Graphics::Color colorFor(int index, int cols, int rows)
     return hueColor((float) row / (float) rows);
 }
 
-std::vector<PerInstanceTransform> buildInstancedTransforms()
+Vector<PerInstanceTransform> buildInstancedTransforms()
 {
-    auto out = std::vector<PerInstanceTransform> {};
+    auto out = Vector<PerInstanceTransform> {};
     out.reserve(instanceCount);
     for (auto i = 0; i < instanceCount; ++i)
     {
         float x, y;
         cellCentre(
             i, gridCols, gridRows, gridLeftX, gridRightX, gpuBotY, gpuTopY, x, y);
-        out.push_back({{x, y}, rotationSpeedFor(i, instanceCount)});
+        out.add(PerInstanceTransform {{x, y}, rotationSpeedFor(i, instanceCount)});
     }
     return out;
 }
 
-std::vector<PerInstanceColor> buildInstancedColors()
+Vector<PerInstanceColor> buildInstancedColors()
 {
-    auto out = std::vector<PerInstanceColor> {};
+    auto out = Vector<PerInstanceColor> {};
     out.reserve(instanceCount);
     for (auto i = 0; i < instanceCount; ++i)
     {
         auto c = colorFor(i, gridCols, gridRows);
-        out.push_back({{c.r, c.g, c.b}});
+        out.add(PerInstanceColor {{c.r, c.g, c.b}});
     }
     return out;
 }
 
 // Non-instanced expansion: 3 fat verts per triangle, each carrying the
 // triangle's centre / speed / colour on top of its own corner + uv.
-std::vector<FatVertex> buildNonInstancedVerts()
+Vector<FatVertex> buildNonInstancedVerts()
 {
-    auto out = std::vector<FatVertex> {};
+    auto out = Vector<FatVertex> {};
     out.reserve(nonInstCount * 3);
 
     for (auto tri = 0; tri < nonInstCount; ++tri)
@@ -212,7 +210,7 @@ std::vector<FatVertex> buildNonInstancedVerts()
 
         for (const auto& v: unitTriangleVerts)
         {
-            out.push_back({
+            out.add(FatVertex {
                 {v.position[0], v.position[1]},
                 {v.uv[0], v.uv[1]},
                 {cx, cy},
@@ -325,7 +323,7 @@ struct NonInstancedView final : GPUView
     NonInstancedView()
         : fatVertsData(buildNonInstancedVerts())
     {
-        shader.setVertices(fatVertsData.data(), (int) fatVertsData.size());
+        shader.setVertices(fatVertsData.data(), fatVertsData.size());
         shader.prepare(sampleCount());
         setContinuous(true);
     }
@@ -341,7 +339,7 @@ struct NonInstancedView final : GPUView
         pass.draw(shader);
     }
 
-    std::vector<FatVertex> fatVertsData;
+    Vector<FatVertex> fatVertsData;
     NonInstancedProgram shader;
     float elapsed = 0.f;
 };
@@ -353,8 +351,8 @@ struct InstancedView final : GPUView
         , colorsData(buildInstancedColors())
     {
         shader.setVertices(unitTriangleVerts);
-        shader.setInstances(1, transformsData.data(), (int) transformsData.size());
-        shader.setInstances(2, colorsData.data(), (int) colorsData.size());
+        shader.setInstances(1, transformsData.data(), transformsData.size());
+        shader.setInstances(2, colorsData.data(), colorsData.size());
         shader.prepare(sampleCount());
         setContinuous(true);
     }
@@ -370,8 +368,8 @@ struct InstancedView final : GPUView
         pass.drawInstanced(shader, instanceCount);
     }
 
-    std::vector<PerInstanceTransform> transformsData;
-    std::vector<PerInstanceColor> colorsData;
+    Vector<PerInstanceTransform> transformsData;
+    Vector<PerInstanceColor> colorsData;
     InstancedProgram shader;
     float elapsed = 0.f;
 };
@@ -389,8 +387,8 @@ struct RowScanView final : GPUView
         , colorsData(buildInstancedColors())
     {
         shader.setVertices(unitTriangleVerts);
-        shader.setInstances(1, transformsData.data(), (int) transformsData.size());
-        shader.setInstances(2, colorsData.data(), (int) colorsData.size());
+        shader.setInstances(1, transformsData.data(), transformsData.size());
+        shader.setInstances(2, colorsData.data(), colorsData.size());
         shader.setIndices(indices);
         shader.prepare(sampleCount());
         setContinuous(true);
@@ -413,8 +411,8 @@ struct RowScanView final : GPUView
         pass.drawInstanced(shader, gridCols, firstInstance);
     }
 
-    std::vector<PerInstanceTransform> transformsData;
-    std::vector<PerInstanceColor> colorsData;
+    Vector<PerInstanceTransform> transformsData;
+    Vector<PerInstanceColor> colorsData;
     InstancedProgram shader;
     float elapsed = 0.f;
 };

--- a/Apps/GPU/StencilShadows/Main.cpp
+++ b/Apps/GPU/StencilShadows/Main.cpp
@@ -4,7 +4,6 @@
 #include <cmath>
 #include <cstring>
 #include <string>
-#include <vector>
 
 // Stencil shadow volumes: the algorithm the stencil buffer exists for, and the
 // one a Doom-3-era renderer is built out of.
@@ -112,9 +111,9 @@ struct CubeEdge
     int endB = 0;
 };
 
-std::vector<CubeEdge> buildCubeEdges()
+Vector<CubeEdge> buildCubeEdges()
 {
-    auto edges = std::vector<CubeEdge> {};
+    auto edges = Vector<CubeEdge> {};
 
     for (auto face = 0; face < 6; ++face)
         for (auto corner = 0; corner < 4; ++corner)
@@ -136,7 +135,7 @@ std::vector<CubeEdge> buildCubeEdges()
                 continue;
             }
 
-            edges.push_back({face, start, end, -1, 0, 0});
+            edges.add(CubeEdge {face, start, end, -1, 0, 0});
         }
 
     return edges;
@@ -244,9 +243,9 @@ struct StencilShadowsView final : GPUView
     StencilShadowsView()
         : edges(buildCubeEdges())
         , sceneBuffer(Device::shared().makeBuffer(
-              nullptr, sceneVertexCount * sizeof(SceneVertex)))
+              nullptr, sceneVertexCount * (int) sizeof(SceneVertex)))
         , volumeBuffer(Device::shared().makeBuffer(
-              nullptr, maxVolumeVertices * sizeof(VolumeVertex)))
+              nullptr, maxVolumeVertices * (int) sizeof(VolumeVertex)))
     {
         // Multisampling would feather the shadow's edge, and the edge is the
         // thing being demonstrated. One sample keeps the boundary exactly where
@@ -392,24 +391,20 @@ struct StencilShadowsView final : GPUView
         }
     }
 
-    void appendSceneQuad(std::vector<SceneVertex>& out,
-                         Vec3 a,
-                         Vec3 b,
-                         Vec3 c,
-                         Vec3 d,
-                         Vec3 normal) const
+    void appendSceneQuad(
+        Vector<SceneVertex>& out, Vec3 a, Vec3 b, Vec3 c, Vec3 d, Vec3 normal) const
     {
-        out.push_back({a, normal});
-        out.push_back({b, normal});
-        out.push_back({c, normal});
-        out.push_back({a, normal});
-        out.push_back({c, normal});
-        out.push_back({d, normal});
+        out.add(SceneVertex {a, normal});
+        out.add(SceneVertex {b, normal});
+        out.add(SceneVertex {c, normal});
+        out.add(SceneVertex {a, normal});
+        out.add(SceneVertex {c, normal});
+        out.add(SceneVertex {d, normal});
     }
 
     void updateSceneBuffer()
     {
-        auto vertices = std::vector<SceneVertex> {};
+        auto vertices = Vector<SceneVertex> {};
         vertices.reserve(sceneVertexCount);
 
         constexpr auto up = Vec3 {0.f, 1.f, 0.f};
@@ -429,7 +424,8 @@ struct StencilShadowsView final : GPUView
                             corners[cubeFaces[face][3]],
                             faceNormals[face]);
 
-        sceneBuffer.update(vertices.data(), vertices.size() * sizeof(SceneVertex));
+        sceneBuffer.update(vertices.data(),
+                           vertices.size() * (int) sizeof(SceneVertex));
     }
 
     Vec3 extrude(Vec3 point) const
@@ -437,14 +433,12 @@ struct StencilShadowsView final : GPUView
         return point + normalize(point - lightPosition) * extrusionLength;
     }
 
-    void appendVolumeTriangle(std::vector<VolumeVertex>& out,
-                              Vec3 a,
-                              Vec3 b,
-                              Vec3 c) const
+    void
+        appendVolumeTriangle(Vector<VolumeVertex>& out, Vec3 a, Vec3 b, Vec3 c) const
     {
-        out.push_back({a});
-        out.push_back({b});
-        out.push_back({c});
+        out.add(VolumeVertex {a});
+        out.add(VolumeVertex {b});
+        out.add(VolumeVertex {c});
     }
 
     // The closed solid the cube hides: the faces that see the light as its near
@@ -456,7 +450,7 @@ struct StencilShadowsView final : GPUView
     // silhouette is exactly the edges whose two faces disagree.
     void updateVolumeBuffer()
     {
-        auto vertices = std::vector<VolumeVertex> {};
+        auto vertices = Vector<VolumeVertex> {};
         vertices.reserve(maxVolumeVertices);
 
         for (auto face = 0; face < 6; ++face)
@@ -498,11 +492,11 @@ struct StencilShadowsView final : GPUView
             appendVolumeTriangle(vertices, start, endFar, end);
         }
 
-        volumeVertexCount = (int) vertices.size();
+        volumeVertexCount = vertices.size();
 
         if (volumeVertexCount > 0)
             volumeBuffer.update(vertices.data(),
-                                vertices.size() * sizeof(VolumeVertex));
+                                vertices.size() * (int) sizeof(VolumeVertex));
     }
 
     Camera cameraFor(float aspect) const
@@ -619,7 +613,7 @@ struct StencilShadowsView final : GPUView
 
     static constexpr float radiansPerSecond = 0.55f;
 
-    std::vector<CubeEdge> edges;
+    Vector<CubeEdge> edges;
     Buffer sceneBuffer;
     Buffer volumeBuffer;
 

--- a/Apps/GPU/StreamingStress/Main.cpp
+++ b/Apps/GPU/StreamingStress/Main.cpp
@@ -8,7 +8,6 @@
 #include <cstdio>
 #include <cstring>
 #include <numeric>
-#include <vector>
 
 // GPU::StreamingBuffers under the load it was rebuilt for: a renderer that
 // streams every draw's geometry, per draw, every frame.
@@ -193,8 +192,8 @@ Graphics::Color colorFor(int id)
 // pulsed by its own id so the picture is obviously live. The vectors are the
 // caller's and are cleared rather than rebuilt - two thousand of these happen
 // per frame, and a malloc each would be what the profile showed.
-void buildMesh(std::vector<MeshVertex>& vertices,
-               std::vector<std::uint32_t>& indices,
+void buildMesh(Vector<MeshVertex>& vertices,
+               Vector<std::uint32_t>& indices,
                const Layout& layout,
                int id,
                float time)
@@ -209,21 +208,22 @@ void buildMesh(std::vector<MeshVertex>& vertices,
 
     vertices.clear();
     indices.clear();
-    vertices.push_back({{centre.x, centre.y}, {color.r, color.g, color.b}});
+    vertices.add(MeshVertex {{centre.x, centre.y}, {color.r, color.g, color.b}});
 
     for (auto side = 0; side < sides; ++side)
     {
         const auto angle = spin + (float) side * (2.f * pi / (float) sides);
-        vertices.push_back({{centre.x + std::cos(angle) * radius,
-                             centre.y + std::sin(angle) * radius},
-                            {color.r * 0.34f, color.g * 0.34f, color.b * 0.34f}});
+        vertices.add(
+            MeshVertex {{centre.x + std::cos(angle) * radius,
+                         centre.y + std::sin(angle) * radius},
+                        {color.r * 0.34f, color.g * 0.34f, color.b * 0.34f}});
     }
 
     for (auto side = 0; side < sides; ++side)
     {
-        indices.push_back(0);
-        indices.push_back((std::uint32_t) (1 + side));
-        indices.push_back((std::uint32_t) (1 + (side + 1) % sides));
+        indices.add(0);
+        indices.add((std::uint32_t) (1 + side));
+        indices.add((std::uint32_t) (1 + (side + 1) % sides));
     }
 }
 
@@ -285,12 +285,12 @@ struct StreamingStressView final : GPUView
     // pipeline and the uniform block, which bind() puts in place for the first
     // draw and the rest inherit - re-binding a pipeline two thousand times
     // would be its own benchmark.
-    std::size_t drawMeshes(RenderPass& pass, const Layout& layout, int count)
+    int drawMeshes(RenderPass& pass, const Layout& layout, int count)
     {
         const auto stride = (std::int64_t) strideFor(count, frameCounter);
         const auto rotation = (std::int64_t) (frameCounter % (std::uint64_t) count);
 
-        auto streamed = std::size_t {0};
+        auto streamed = 0;
 
         for (auto slot = 0; slot < count; ++slot)
         {
@@ -299,8 +299,9 @@ struct StreamingStressView final : GPUView
 
             buildMesh(vertexScratch, indexScratch, layout, id, elapsed);
 
-            const auto vertexBytes = vertexScratch.size() * sizeof(MeshVertex);
-            const auto indexBytes = indexScratch.size() * sizeof(std::uint32_t);
+            const auto vertexBytes = vertexScratch.size() * (int) sizeof(MeshVertex);
+            const auto indexBytes =
+                indexScratch.size() * (int) sizeof(std::uint32_t);
 
             const auto vertexRange =
                 vertices.write(vertexScratch.data(), vertexBytes);
@@ -311,7 +312,7 @@ struct StreamingStressView final : GPUView
             else
                 pass.setVertexBuffer(vertexRange);
 
-            pass.drawIndexed(indexRange, (int) indexScratch.size());
+            pass.drawIndexed(indexRange, indexScratch.size());
 
             streamed += vertexBytes + indexBytes;
         }
@@ -341,7 +342,7 @@ struct StreamingStressView final : GPUView
         // column has something to report.
         descriptor.label = "meshes";
 
-        auto streamed = std::size_t {0};
+        auto streamed = 0;
 
         {
             auto pass = frame.beginPass(descriptor);
@@ -399,8 +400,8 @@ struct StreamingStressView final : GPUView
     StreamingBuffers vertices;
     StreamingBuffers indices;
 
-    std::vector<MeshVertex> vertexScratch;
-    std::vector<std::uint32_t> indexScratch;
+    Vector<MeshVertex> vertexScratch;
+    Vector<std::uint32_t> indexScratch;
 
     int baseCount = defaultMeshCount;
 
@@ -417,7 +418,7 @@ struct StreamingStressView final : GPUView
     bool printStats = false;
 
     int lastDraws = 0;
-    std::size_t lastStreamed = 0;
+    int lastStreamed = 0;
     Layout lastLayout {};
 
     double cpuSeconds = 0.0;
@@ -518,7 +519,7 @@ int runCheck()
     auto view = StreamingStressView {};
     view.setBounds({0.f, 0.f, (float) checkSize, (float) checkSize});
 
-    auto records = std::vector<FrameRecord> {};
+    auto records = Vector<FrameRecord> {};
     auto image = Graphics::Image {};
 
     records.reserve(checkFrames);
@@ -542,11 +543,11 @@ int runCheck()
             return 1;
         }
 
-        records.push_back(
-            {view.lastDraws,
-             (double) view.lastStreamed / 1024.0,
-             Device::shared().buffersCreated() - before,
-             view.vertices.bufferCount() + view.indices.bufferCount()});
+        records.add(
+            FrameRecord {view.lastDraws,
+                         (double) view.lastStreamed / 1024.0,
+                         Device::shared().buffersCreated() - before,
+                         view.vertices.bufferCount() + view.indices.bufferCount()});
     }
 
     std::printf(
@@ -560,9 +561,9 @@ int runCheck()
 
     std::printf("frame   draws   streamed KB   buffers created   arenas alive\n");
 
-    for (auto frame = 0; frame < (int) records.size(); ++frame)
+    for (auto frame = 0; frame < records.size(); ++frame)
     {
-        const auto& record = records[(std::size_t) frame];
+        const auto& record = records[frame];
 
         std::printf("%5d   %5d   %11.1f   %15d   %12d%s\n",
                     frame,
@@ -576,14 +577,13 @@ int runCheck()
     auto failures = 0;
 
     std::printf("\nnothing allocated on a steady frame\n");
-    for (auto frame = 0; frame < (int) records.size(); ++frame)
+    for (auto frame = 0; frame < records.size(); ++frame)
     {
-        if (!isSteadyFrame(frame) || records[(std::size_t) frame].created == 0)
+        if (!isSteadyFrame(frame) || records[frame].created == 0)
             continue;
 
-        std::printf("  frame %d created %d buffers\n",
-                    frame,
-                    records[(std::size_t) frame].created);
+        std::printf(
+            "  frame %d created %d buffers\n", frame, records[frame].created);
         ++failures;
     }
 

--- a/Apps/GPU/Teapot/Main.cpp
+++ b/Apps/GPU/Teapot/Main.cpp
@@ -3,8 +3,6 @@
 
 #include "TeapotData.h"
 
-#include <vector>
-
 using namespace eacp;
 using namespace GPU;
 using namespace Maths;

--- a/Apps/GPU/TextureAtlas/Main.cpp
+++ b/Apps/GPU/TextureAtlas/Main.cpp
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <vector>
 
 // Texture::update(region, ...) — filling one texture a tile at a time, which is
 // how a glyph atlas is built: glyphs are rasterized as they are first needed and
@@ -40,9 +39,9 @@ std::uint32_t packRGBA(int r, int g, int b)
 
 // Stands in for a rasterized glyph: a bordered block whose hue depends on the
 // slot, so each upload is individually recognisable once it lands.
-std::vector<std::uint32_t> makeTile(int index)
+Vector<std::uint32_t> makeTile(int index)
 {
-    auto pixels = std::vector<std::uint32_t>((std::size_t) (tileSize * tileSize));
+    auto pixels = Vector<std::uint32_t>(tileSize * tileSize);
 
     const auto r = 60 + (index * 37) % 190;
     const auto g = 60 + (index * 71) % 190;
@@ -55,7 +54,7 @@ std::vector<std::uint32_t> makeTile(int index)
             const auto edge =
                 x == 0 || y == 0 || x == tileSize - 1 || y == tileSize - 1;
 
-            pixels[(std::size_t) (y * tileSize + x)] =
+            pixels[y * tileSize + x] =
                 edge ? packRGBA(20, 22, 28) : packRGBA(r, g, b);
         }
     }
@@ -65,8 +64,8 @@ std::vector<std::uint32_t> makeTile(int index)
 
 GPU::Texture makeEmptyAtlas()
 {
-    const auto pixels = std::vector<std::uint32_t>(
-        (std::size_t) (atlasSize * atlasSize), packRGBA(24, 26, 32));
+    auto pixels = Vector<std::uint32_t> {};
+    pixels.resize(atlasSize * atlasSize, packRGBA(24, 26, 32));
 
     auto descriptor = GPU::TextureDescriptor {};
     descriptor.width = atlasSize;

--- a/Apps/GPU/VariableFont/Main.cpp
+++ b/Apps/GPU/VariableFont/Main.cpp
@@ -7,7 +7,6 @@
 #include <algorithm>
 #include <optional>
 #include <string>
-#include <vector>
 
 // A variable font, and what one is to the text tier.
 //
@@ -422,7 +421,7 @@ struct VariableFontView final : GPU::GPUView
     float specimenColumn = margin + labelColumnWidth;
     float staticColumn = 0.f;
 
-    std::vector<Note> notes;
+    Vector<Note> notes;
     int liveWeight = 400;
 };
 

--- a/Apps/Graphics/ComplexGUI/TaskBoard.cpp
+++ b/Apps/Graphics/ComplexGUI/TaskBoard.cpp
@@ -28,7 +28,7 @@ constexpr auto headerHeight = 44.f;
 
 Random randomGen {};
 
-std::size_t nextRandom(std::size_t min, std::size_t max)
+int nextRandom(int min, int max)
 {
     return randomGen.get(min, max);
 }
@@ -325,7 +325,7 @@ struct Board final : UI::Component
             auto data =
                 makeCard(getRandomElement(titles), getRandomElement(descriptions));
 
-            columns()[(int) nextRandom(0, 2)]->addCard(data);
+            columns()[nextRandom(0, 2)]->addCard(data);
         }
 
         repaint();

--- a/Apps/Graphics/KeyInspector/Main.cpp
+++ b/Apps/Graphics/KeyInspector/Main.cpp
@@ -120,7 +120,7 @@ struct InspectorContent final : UI::Component
         setWantsKeyboardFocus(true);
         setInterceptsMouseClicks(true);
 
-        rows.push_back("Press any key. Cmd+C copies this log, Cmd+V pastes.");
+        rows.add("Press any key. Cmd+C copies this log, Cmd+V pastes.");
     }
 
     // Returning true on everything, which is exactly right here and worth saying
@@ -169,10 +169,10 @@ struct InspectorContent final : UI::Component
 
     void add(std::string row)
     {
-        rows.push_back(std::move(row));
+        rows.add(std::move(row));
 
-        while ((int) rows.size() > maxRows)
-            rows.erase(rows.begin());
+        while (rows.size() > maxRows)
+            rows.removeAt(0);
 
         repaint();
     }
@@ -201,7 +201,7 @@ struct InspectorContent final : UI::Component
         }
     }
 
-    std::vector<std::string> rows;
+    Vector<std::string> rows;
 };
 
 struct InspectorHost final : UI::ComponentHost

--- a/Apps/Network/WebSocketDemo/Main.cpp
+++ b/Apps/Network/WebSocketDemo/Main.cpp
@@ -23,7 +23,6 @@
 #include <iostream>
 #include <set>
 #include <string>
-#include <vector>
 
 using namespace eacp;
 
@@ -341,7 +340,8 @@ std::uint16_t portFrom(const std::string& text)
 
 int main(int argc, char** argv)
 {
-    auto arguments = std::vector<std::string>(argv + 1, argv + argc);
+    auto arguments = Vector<std::string>();
+    arguments.assign(argv + 1, argv + argc);
 
     if (arguments.empty())
         return runBothEnds();

--- a/Apps/UI/WidgetGallery/Main.cpp
+++ b/Apps/UI/WidgetGallery/Main.cpp
@@ -1,6 +1,5 @@
 #include <eacp/UI/UI.h>
 
-#include <array>
 #include <cmath>
 #include <cstdio>
 #include <cstdlib>
@@ -49,8 +48,9 @@ std::string percentText(float value)
 
 std::string hertzText(float hertz)
 {
-    auto buffer = std::array<char, 32> {};
-    std::snprintf(buffer.data(), buffer.size(), "%.2f Hz", (double) hertz);
+    auto buffer = Array<char, 32> {};
+    std::snprintf(
+        buffer.data(), (std::size_t) buffer.size(), "%.2f Hz", (double) hertz);
 
     return buffer.data();
 }

--- a/Apps/WebView/UserAgent/Main.cpp
+++ b/Apps/WebView/UserAgent/Main.cpp
@@ -1,7 +1,5 @@
 #include <eacp/WebView/WebView.h>
 
-#include <array>
-
 using namespace eacp;
 using namespace Graphics;
 
@@ -29,7 +27,7 @@ struct Preset
     const char* userAgent;
 };
 
-constexpr auto presets = std::array {
+constexpr auto presets = Array {
     Preset {"Platform default", ""},
     Preset {"Safari 17 (macOS)",
             "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 "
@@ -127,7 +125,7 @@ struct DemoRoot final : View
 {
     DemoRoot()
     {
-        for (auto i = 0; i < (int) presets.size(); ++i)
+        for (auto i = 0; i < presets.size(); ++i)
         {
             presetButtons[i].setText(presets[i].name);
             presetButtons[i].onClick = [this, i] { selectPreset(i); };
@@ -183,7 +181,7 @@ private:
 
     void updateButtons()
     {
-        for (auto i = 0; i < (int) presets.size(); ++i)
+        for (auto i = 0; i < presets.size(); ++i)
             presetButtons[i].setSelected(i == presetIndex);
 
         inlineButton.setText(loadDeclinedPopupsInline ? "Inline load: ON"

--- a/Apps/WebView/WebViewDragOut/Main.cpp
+++ b/Apps/WebView/WebViewDragOut/Main.cpp
@@ -4,10 +4,8 @@
 #include <WebResources.h>
 #include <algorithm>
 
-#include <array>
 #include <cstdlib>
 #include <fstream>
-#include <vector>
 
 using namespace eacp;
 using namespace Graphics;
@@ -21,7 +19,7 @@ constexpr auto category = "DragOutApp";
 // the provider for it below (see diskFileProvider / dragOutOptions).
 constexpr auto audioScheme = "audiofile";
 
-constexpr std::array audioExtensions = {
+constexpr Array audioExtensions = {
     ".wav", ".mp3", ".aif", ".aiff", ".flac", ".m4a", ".aac", ".ogg"};
 
 std::string lowerExtension(const std::filesystem::path& path)
@@ -93,15 +91,15 @@ WebView::DraggableFileList buildFileList()
 
     // Then real audio files from ~/Downloads.
     auto ec = std::error_code {};
-    auto downloads = std::vector<std::string> {};
+    auto downloads = Vector<std::string> {};
 
     for (const auto& entry: std::filesystem::directory_iterator(downloadsDir(), ec))
     {
         if (entry.is_regular_file(ec) && isAudioFile(entry.path()))
-            downloads.push_back(entry.path().string());
+            downloads.add(entry.path().string());
     }
 
-    std::sort(downloads.begin(), downloads.end());
+    downloads.sort();
 
     for (const auto& path: downloads)
         list.files.push_back(

--- a/Apps/WebView/WebViewTodo/Tests/WebViewTodoTests.cpp
+++ b/Apps/WebView/WebViewTodo/Tests/WebViewTodoTests.cpp
@@ -2,8 +2,6 @@
 
 #include <eacp/WebView/Test/TestApp.h>
 
-#include <vector>
-
 using namespace eacp::WebView::Test;
 
 using nano::check;
@@ -148,9 +146,9 @@ auto tQueryAllReturnsEveryItem =
     auto items = driver().queryAll(itemSelector);
     check(items.size() == 3);
 
-    auto texts = std::vector<std::string> {};
+    auto texts = EA::Vector<std::string> {};
     for (auto& item: items)
-        texts.push_back(item.find(textSelector).text());
+        texts.add(item.find(textSelector).text());
 
     check(texts[0] == "Try editing me (double-click)");
     check(texts[1] == "Toggle a checkbox");
@@ -255,7 +253,7 @@ namespace
 struct RenderedTodos
 {
     int count = 0;
-    std::vector<std::string> texts;
+    EA::Vector<std::string> texts;
 
     MIRO_REFLECT(count, texts)
 };

--- a/Lib/eacp/Camera/Camera-Apple.mm
+++ b/Lib/eacp/Camera/Camera-Apple.mm
@@ -82,7 +82,7 @@ struct LatestFrame
 
         auto width = (int) CVPixelBufferGetWidth(buffer);
         auto height = (int) CVPixelBufferGetHeight(buffer);
-        auto stride = CVPixelBufferGetBytesPerRow(buffer);
+        auto stride = (int) CVPixelBufferGetBytesPerRow(buffer);
         const auto* base = (const std::uint8_t*) CVPixelBufferGetBaseAddress(buffer);
 
         out.width = width;
@@ -90,12 +90,12 @@ struct LatestFrame
         out.format = PixelFormat::BGRA8;
         out.data.resize(width * height * 4);
 
-        auto rowBytes = (std::size_t) width * 4;
+        auto rowBytes = width * 4;
 
         for (auto y = 0; y < height; ++y)
-            std::memcpy(out.data.data() + (std::size_t) y * rowBytes,
-                        base + (std::size_t) y * stride,
-                        rowBytes);
+            std::memcpy(out.data.data() + y * rowBytes,
+                        base + y * stride,
+                        (std::size_t) rowBytes);
 
         CVPixelBufferUnlockBaseAddress(buffer, kCVPixelBufferLock_ReadOnly);
         CFRelease(buffer);
@@ -174,7 +174,7 @@ void cameraDelegateCaptureOutput(id self,
 
     auto width = (int) CVPixelBufferGetWidth(pixelBuffer);
     auto height = (int) CVPixelBufferGetHeight(pixelBuffer);
-    auto bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+    auto bytesPerRow = (int) CVPixelBufferGetBytesPerRow(pixelBuffer);
     auto base = (const std::uint8_t*) CVPixelBufferGetBaseAddress(pixelBuffer);
 
     auto presentation = CMSampleBufferGetPresentationTimeStamp(sampleBuffer);

--- a/Lib/eacp/Camera/Camera-Windows.cpp
+++ b/Lib/eacp/Camera/Camera-Windows.cpp
@@ -104,17 +104,17 @@ frames::MediaFrameFormat
 // sets it; the render thread copies it out.
 struct LatestFrame
 {
-    void set(const std::uint8_t* base, int width, int height, std::size_t stride)
+    void set(const std::uint8_t* base, int width, int height, int stride)
     {
         std::lock_guard<std::mutex> lock(mutex);
 
         data.resize(width * height * 4);
-        auto rowBytes = (std::size_t) width * 4;
+        auto rowBytes = width * 4;
 
         for (auto y = 0; y < height; ++y)
-            std::memcpy(data.data() + (std::size_t) y * rowBytes,
-                        base + (std::size_t) y * stride,
-                        rowBytes);
+            std::memcpy(data.data() + y * rowBytes,
+                        base + y * stride,
+                        (std::size_t) rowBytes);
 
         frameWidth = width;
         frameHeight = height;
@@ -313,7 +313,7 @@ struct Camera::Native
             return;
 
         const auto* base = bytes + plane.StartIndex;
-        auto stride = (std::size_t) plane.Stride;
+        auto stride = (int) plane.Stride;
 
         auto timestampSeconds = 0.0;
         auto relative = frame.SystemRelativeTime();

--- a/Lib/eacp/Camera/Camera.cpp
+++ b/Lib/eacp/Camera/Camera.cpp
@@ -19,7 +19,7 @@ namespace
 void bgraToImage(const std::uint8_t* data,
                  int width,
                  int height,
-                 std::size_t bytesPerRow,
+                 int bytesPerRow,
                  Graphics::Image& out)
 {
     auto* dst = out.prepareForOverwrite(width, height);
@@ -33,7 +33,7 @@ void bgraToImage(const std::uint8_t* data,
 CameraFrame::CameraFrame(int width,
                          int height,
                          PixelFormat format,
-                         std::size_t bytesPerRow,
+                         int bytesPerRow,
                          double timestampSeconds,
                          const std::uint8_t* data,
                          void* nativeBuffer)

--- a/Lib/eacp/Camera/Camera.h
+++ b/Lib/eacp/Camera/Camera.h
@@ -65,7 +65,7 @@ public:
     CameraFrame(int width,
                 int height,
                 PixelFormat format,
-                std::size_t bytesPerRow,
+                int bytesPerRow,
                 double timestampSeconds,
                 const std::uint8_t* data,
                 void* nativeBuffer);
@@ -73,7 +73,7 @@ public:
     int width() const { return frameWidth; }
     int height() const { return frameHeight; }
     PixelFormat format() const { return pixelFormat; }
-    std::size_t bytesPerRow() const { return rowBytes; }
+    int bytesPerRow() const { return rowBytes; }
     double timestampSeconds() const { return timestamp; }
 
     // The raw pixel bytes (BGRA for PixelFormat::BGRA8), rows bytesPerRow apart
@@ -100,7 +100,7 @@ private:
     int frameWidth = 0;
     int frameHeight = 0;
     PixelFormat pixelFormat = PixelFormat::BGRA8;
-    std::size_t rowBytes = 0;
+    int rowBytes = 0;
     double timestamp = 0.0;
     const std::uint8_t* pixels = nullptr;
     void* buffer = nullptr;

--- a/Lib/eacp/Core/App/Clipboard-Windows.cpp
+++ b/Lib/eacp/Core/App/Clipboard-Windows.cpp
@@ -8,7 +8,6 @@
 
 #include <cstring>
 #include <cwchar>
-#include <vector>
 
 namespace eacp::Clipboard
 {
@@ -104,8 +103,8 @@ bool copyFiles(const Vector<std::string>& paths)
     if (paths.empty())
         return false;
 
-    auto widePaths = std::vector<std::wstring> {};
-    auto pathChars = std::size_t {1};
+    auto widePaths = Vector<std::wstring> {};
+    auto pathChars = 1;
 
     for (const auto& path: paths)
     {
@@ -114,14 +113,14 @@ bool copyFiles(const Vector<std::string>& paths)
         if (wide.empty())
             continue;
 
-        pathChars += wide.size() + 1;
+        pathChars += (int) wide.size() + 1;
         widePaths.push_back(std::move(wide));
     }
 
     if (widePaths.empty())
         return false;
 
-    auto bytes = sizeof(DROPFILES) + pathChars * sizeof(wchar_t);
+    auto bytes = sizeof(DROPFILES) + (std::size_t) pathChars * sizeof(wchar_t);
     auto handle = GlobalAlloc(GMEM_MOVEABLE | GMEM_ZEROINIT, bytes);
     if (!handle)
         return false;

--- a/Lib/eacp/Core/Process/Process-Posix.cpp
+++ b/Lib/eacp/Core/Process/Process-Posix.cpp
@@ -5,7 +5,6 @@
 #include <cstdlib>
 #include <mutex>
 #include <thread>
-#include <vector>
 
 #include <spawn.h>
 #include <sys/wait.h>
@@ -130,12 +129,13 @@ struct Process::Native
         if (inputFd < 0)
             return false;
 
-        auto total = std::size_t {0};
+        auto total = 0;
+        const auto size = (int) data.size();
 
-        while (total < data.size())
+        while (total < size)
         {
             auto written =
-                ::write(inputFd, data.data() + total, data.size() - total);
+                ::write(inputFd, data.data() + total, (std::size_t) (size - total));
 
             if (written < 0)
             {
@@ -145,7 +145,7 @@ struct Process::Native
                 return false;
             }
 
-            total += (std::size_t) written;
+            total += (int) written;
         }
 
         return true;

--- a/Lib/eacp/Core/Process/Process-Windows.cpp
+++ b/Lib/eacp/Core/Process/Process-Windows.cpp
@@ -7,7 +7,6 @@
 #include <cwctype>
 #include <mutex>
 #include <thread>
-#include <vector>
 
 namespace eacp::Processes
 {
@@ -24,7 +23,7 @@ std::wstring quoteArgument(const std::wstring& arg)
 
     for (auto it = arg.begin();; ++it)
     {
-        auto backslashes = std::size_t {0};
+        auto backslashes = 0;
 
         while (it != arg.end() && *it == L'\\')
         {
@@ -184,19 +183,19 @@ struct Process::Native
         if (inputWrite == nullptr)
             return false;
 
-        auto total = std::size_t {0};
+        auto total = 0;
+        const auto size = (int) data.size();
 
-        while (total < data.size())
+        while (total < size)
         {
-            auto chunk =
-                (DWORD) std::min<std::size_t>(data.size() - total, 1u << 20);
+            auto chunk = (DWORD) std::min(size - total, 1 << 20);
             DWORD written = 0;
 
             if (!WriteFile(
                     inputWrite, data.data() + total, chunk, &written, nullptr))
                 return false;
 
-            total += written;
+            total += (int) written;
         }
 
         return true;

--- a/Lib/eacp/Core/Utils/Base64.cpp
+++ b/Lib/eacp/Core/Utils/Base64.cpp
@@ -1,6 +1,6 @@
 #include "Base64.h"
+#include "Containers.h"
 
-#include <array>
 #include <cstdint>
 
 namespace eacp::Base64
@@ -12,27 +12,27 @@ constexpr auto alphabet = std::string_view(
 
 constexpr int invalid = -1;
 
-constexpr std::array<int, 256> makeReverseAlphabet()
+constexpr Array<int, 256> makeReverseAlphabet()
 {
-    auto table = std::array<int, 256>();
+    auto table = Array<int, 256>();
 
     for (auto& entry: table)
         entry = invalid;
 
     for (auto i = 0; i < (int) alphabet.size(); ++i)
-        table[(unsigned char) alphabet[(std::size_t) i]] = i;
+        table[(unsigned char) alphabet[i]] = i;
 
     return table;
 }
 
 constexpr auto reverseAlphabet = makeReverseAlphabet();
 
-std::uint32_t byteAt(std::string_view bytes, std::size_t index)
+std::uint32_t byteAt(std::string_view bytes, int index)
 {
     return (std::uint8_t) bytes[index];
 }
 
-std::uint32_t groupAt(std::string_view bytes, std::size_t index, std::size_t left)
+std::uint32_t groupAt(std::string_view bytes, int index, int left)
 {
     auto group = byteAt(bytes, index) << 16;
 
@@ -45,12 +45,12 @@ std::uint32_t groupAt(std::string_view bytes, std::size_t index, std::size_t lef
     return group;
 }
 
-int sextetAt(std::string_view text, std::size_t index)
+int sextetAt(std::string_view text, int index)
 {
     return reverseAlphabet[(unsigned char) text[index]];
 }
 
-std::size_t paddingLength(std::string_view text)
+int paddingLength(std::string_view text)
 {
     if (text.size() < 4 || text[text.size() - 1] != '=')
         return 0;
@@ -58,11 +58,11 @@ std::size_t paddingLength(std::string_view text)
     return text[text.size() - 2] == '=' ? 2 : 1;
 }
 
-bool appendDecodedQuad(std::string& out, std::string_view quad, std::size_t padding)
+bool appendDecodedQuad(std::string& out, std::string_view quad, int padding)
 {
     auto group = std::uint32_t {0};
 
-    for (auto i = std::size_t {0}; i < 4 - padding; ++i)
+    for (auto i = 0; i < 4 - padding; ++i)
     {
         auto sextet = sextetAt(quad, i);
 
@@ -72,7 +72,7 @@ bool appendDecodedQuad(std::string& out, std::string_view quad, std::size_t padd
         group |= (std::uint32_t) sextet << (18 - 6 * i);
     }
 
-    for (auto i = std::size_t {0}; i < 3 - padding; ++i)
+    for (auto i = 0; i < 3 - padding; ++i)
         out.push_back((char) ((group >> (16 - 8 * i)) & 0xFF));
 
     return true;
@@ -81,12 +81,14 @@ bool appendDecodedQuad(std::string& out, std::string_view quad, std::size_t padd
 
 std::string encode(std::string_view bytes)
 {
-    auto encoded = std::string();
-    encoded.reserve(((bytes.size() + 2) / 3) * 4);
+    const auto size = (int) bytes.size();
 
-    for (auto i = std::size_t {0}; i < bytes.size(); i += 3)
+    auto encoded = std::string();
+    encoded.reserve((std::size_t) (((size + 2) / 3) * 4));
+
+    for (auto i = 0; i < size; i += 3)
     {
-        auto left = bytes.size() - i;
+        auto left = size - i;
         auto group = groupAt(bytes, i, left);
 
         encoded.push_back(alphabet[(group >> 18) & 0x3F]);
@@ -100,17 +102,19 @@ std::string encode(std::string_view bytes)
 
 std::optional<std::string> decode(std::string_view text)
 {
-    if (text.size() % 4 != 0)
+    const auto size = (int) text.size();
+
+    if (size % 4 != 0)
         return std::nullopt;
 
     auto padding = paddingLength(text);
 
     auto decoded = std::string();
-    decoded.reserve(text.size() / 4 * 3);
+    decoded.reserve((std::size_t) (size / 4 * 3));
 
-    for (auto i = std::size_t {0}; i < text.size(); i += 4)
+    for (auto i = 0; i < size; i += 4)
     {
-        auto isLastQuad = i + 4 == text.size();
+        auto isLastQuad = i + 4 == size;
 
         if (!appendDecodedQuad(decoded, text.substr(i, 4), isLastQuad ? padding : 0))
             return std::nullopt;

--- a/Lib/eacp/Core/Utils/File.cpp
+++ b/Lib/eacp/Core/Utils/File.cpp
@@ -82,7 +82,7 @@ bool File::isOpen() const
     return impl->stream.is_open();
 }
 
-std::size_t File::read(std::uint64_t offset, std::span<std::uint8_t> out)
+int File::read(std::uint64_t offset, Span<std::uint8_t> out)
 {
     if (!openForRead() || out.empty())
         return 0;
@@ -100,8 +100,8 @@ std::size_t File::read(std::uint64_t offset, std::span<std::uint8_t> out)
     stream.read(reinterpret_cast<char*>(out.data()),
                 static_cast<std::streamsize>(out.size()));
 
-    auto got = static_cast<std::size_t>(stream.gcount());
-    impl->position += got;
+    auto got = static_cast<int>(stream.gcount());
+    impl->position += static_cast<std::uint64_t>(got);
     return got;
 }
 } // namespace eacp

--- a/Lib/eacp/Core/Utils/File.h
+++ b/Lib/eacp/Core/Utils/File.h
@@ -3,8 +3,6 @@
 #include "Common.h"
 #include "FilePath.h"
 
-#include <span>
-
 namespace eacp
 {
 // RAII handle for reading a file off disk in bounded chunks, without
@@ -49,7 +47,7 @@ public:
     // number actually read (0 at end of file). Opens the file on first use,
     // and only seeks when `offset` differs from the current position, so
     // sequential reads stay cheap.
-    std::size_t read(std::uint64_t offset, std::span<std::uint8_t> out);
+    int read(std::uint64_t offset, Span<std::uint8_t> out);
 
 private:
     struct Impl;

--- a/Lib/eacp/Core/Utils/Files.cpp
+++ b/Lib/eacp/Core/Utils/Files.cpp
@@ -82,7 +82,7 @@ std::string readFile(const FilePath& path)
     return contents;
 }
 
-void writeFile(const FilePath& path, std::span<const std::uint8_t> bytes)
+void writeFile(const FilePath& path, Span<const std::uint8_t> bytes)
 {
     auto fsPath = toStdPath(path);
 
@@ -100,7 +100,7 @@ void writeFile(const FilePath& path, std::span<const std::uint8_t> bytes)
         throw std::runtime_error("cannot write '" + path.str() + "'");
 }
 
-void writeFileAtomically(const FilePath& path, std::span<const std::uint8_t> bytes)
+void writeFileAtomically(const FilePath& path, Span<const std::uint8_t> bytes)
 {
     auto fsPath = toStdPath(path);
 

--- a/Lib/eacp/Core/Utils/Files.h
+++ b/Lib/eacp/Core/Utils/Files.h
@@ -3,15 +3,13 @@
 #include "Common.h"
 #include "FilePath.h"
 
-#include <span>
-
 namespace eacp::Files
 {
 std::string readFile(const FilePath& path);
 
 // Writes bytes to path, creating parent directories first. Throws
 // std::runtime_error when the file can't be opened or fully written.
-void writeFile(const FilePath& path, std::span<const std::uint8_t> bytes);
+void writeFile(const FilePath& path, Span<const std::uint8_t> bytes);
 
 // Writes bytes so a concurrent reader sees either the whole old file or the
 // whole new one, never a half-written mix: the data goes to a temporary
@@ -29,7 +27,7 @@ void writeFile(const FilePath& path, std::span<const std::uint8_t> bytes);
 //   does not silently un-execute it by handing the replacement the umask.
 //
 // Throws std::runtime_error, like writeFile, if the write or the rename fails.
-void writeFileAtomically(const FilePath& path, std::span<const std::uint8_t> bytes);
+void writeFileAtomically(const FilePath& path, Span<const std::uint8_t> bytes);
 
 std::string getBundleResourcePath(const std::string& filename);
 std::string filenameFromPath(const std::string& path);

--- a/Lib/eacp/Core/Utils/MemoryMappedFile-Posix.cpp
+++ b/Lib/eacp/Core/Utils/MemoryMappedFile-Posix.cpp
@@ -43,7 +43,7 @@ void closeMappingFile(MappingFile& file)
     file = {};
 }
 
-std::size_t mappingGranularity()
+int mappingGranularity()
 {
     static const auto pageSize = []
     {
@@ -52,8 +52,7 @@ std::size_t mappingGranularity()
         // sysconf answers -1 when it cannot tell. 4KB is the page size
         // everywhere this runs, and any multiple of the real one is a legal
         // mmap offset regardless.
-        return reported > 0 ? static_cast<std::size_t>(reported)
-                            : std::size_t {4096};
+        return reported > 0 ? static_cast<int>(reported) : 4096;
     }();
 
     return pageSize;

--- a/Lib/eacp/Core/Utils/MemoryMappedFile-Windows.cpp
+++ b/Lib/eacp/Core/Utils/MemoryMappedFile-Windows.cpp
@@ -46,14 +46,14 @@ void closeMappingFile(MappingFile& file)
     file = {};
 }
 
-std::size_t mappingGranularity()
+int mappingGranularity()
 {
     static const auto granularity = []
     {
         auto info = SYSTEM_INFO {};
         ::GetSystemInfo(&info);
 
-        return static_cast<std::size_t>(info.dwAllocationGranularity);
+        return static_cast<int>(info.dwAllocationGranularity);
     }();
 
     return granularity;

--- a/Lib/eacp/Core/Utils/MemoryMappedFile.cpp
+++ b/Lib/eacp/Core/Utils/MemoryMappedFile.cpp
@@ -2,7 +2,6 @@
 #include "MemoryMappedFilePlatform.h"
 
 #include <algorithm>
-#include <limits>
 
 namespace eacp
 {
@@ -37,14 +36,9 @@ Mapping mapOpenFile(const Detail::MappingFile& file,
     if (wanted == 0)
         return mapping;
 
-    auto alignedOffset = offset - (offset % Detail::mappingGranularity());
+    auto alignedOffset =
+        offset - (offset % (std::uint64_t) Detail::mappingGranularity());
     auto delta = static_cast<std::size_t>(offset - alignedOffset);
-
-    // A window can outrun the address space on a 32-bit build, where the
-    // mapping would fail anyway. Checked before the cast rather than after,
-    // which would wrap instead of failing.
-    if (wanted > std::numeric_limits<std::size_t>::max() - delta)
-        return {};
 
     mapping.region = Detail::mapRegion(
         file, alignedOffset, delta + static_cast<std::size_t>(wanted));
@@ -104,7 +98,7 @@ bool MemoryMappedFile::isValid() const
     return impl->mapping.valid;
 }
 
-std::span<const std::uint8_t> MemoryMappedFile::bytes() const
+Span<const std::uint8_t> MemoryMappedFile::bytes() const
 {
     return {impl->mapping.start, impl->mapping.length};
 }
@@ -116,7 +110,7 @@ std::string_view MemoryMappedFile::text() const
     if (view.empty())
         return {};
 
-    return {reinterpret_cast<const char*>(view.data()), view.size()};
+    return {reinterpret_cast<const char*>(view.data()), view.getSize()};
 }
 
 std::size_t MemoryMappedFile::size() const

--- a/Lib/eacp/Core/Utils/MemoryMappedFile.h
+++ b/Lib/eacp/Core/Utils/MemoryMappedFile.h
@@ -3,8 +3,6 @@
 #include "Common.h"
 #include "FilePath.h"
 
-#include <span>
-
 namespace eacp
 {
 // A read-only view of a file's bytes, placed in the address space rather than
@@ -49,7 +47,9 @@ public:
     // bytes at the very end of one, succeeds and yields an empty span: both
     // platforms reject a zero-length mapping, so that case is answered here
     // rather than turned into a failure every caller has to special-case.
-    std::span<const std::uint8_t> bytes() const;
+    // A file is the one thing a view is routinely too large to count in an
+    // int, so the size is the full size_t, as is bytes().getSize().
+    Span<const std::uint8_t> bytes() const;
     std::string_view text() const;
 
     std::size_t size() const;

--- a/Lib/eacp/Core/Utils/MemoryMappedFilePlatform.h
+++ b/Lib/eacp/Core/Utils/MemoryMappedFilePlatform.h
@@ -33,7 +33,7 @@ void closeMappingFile(MappingFile& file);
 // What a mapping offset has to be a multiple of: the page size on POSIX,
 // dwAllocationGranularity on Windows — 64KB, and deliberately not the page
 // size there.
-std::size_t mappingGranularity();
+int mappingGranularity();
 
 struct MappedRegion
 {

--- a/Lib/eacp/Core/Utils/Strings.cpp
+++ b/Lib/eacp/Core/Utils/Strings.cpp
@@ -1,7 +1,6 @@
 #include "Strings.h"
 
 #include <cctype>
-#include <cstddef>
 
 namespace eacp::Strings
 {
@@ -78,12 +77,12 @@ std::wstring widen(std::string_view utf8)
     auto out = std::wstring {};
     out.reserve(utf8.size());
 
-    const auto size = utf8.size();
-    for (auto i = std::size_t {0}; i < size;)
+    const auto size = (int) utf8.size();
+    for (auto i = 0; i < size;)
     {
         const auto lead = static_cast<unsigned char>(utf8[i]);
 
-        auto length = std::size_t {0};
+        auto length = 0;
         auto codepoint = char32_t {};
 
         if (lead < 0x80)
@@ -114,7 +113,7 @@ std::wstring widen(std::string_view utf8)
         }
 
         auto valid = i + length <= size;
-        for (auto j = std::size_t {1}; valid && j < length; ++j)
+        for (auto j = 1; valid && j < length; ++j)
         {
             const auto byte = static_cast<unsigned char>(utf8[i + j]);
             if ((byte & 0xC0) != 0x80)
@@ -152,7 +151,9 @@ std::string narrow(std::wstring_view wide)
     auto out = std::string {};
     out.reserve(wide.size());
 
-    for (auto i = std::size_t {0}; i < wide.size(); ++i)
+    const auto size = (int) wide.size();
+
+    for (auto i = 0; i < size; ++i)
     {
         auto codepoint = static_cast<char32_t>(
             static_cast<std::make_unsigned_t<wchar_t>>(wide[i]));
@@ -164,11 +165,10 @@ std::string narrow(std::wstring_view wide)
             if (isLeadSurrogate(codepoint))
             {
                 const auto next =
-                    i + 1 < wide.size()
-                        ? static_cast<char32_t>(
-                              static_cast<std::make_unsigned_t<wchar_t>>(
-                                  wide[i + 1]))
-                        : char32_t {0};
+                    i + 1 < size ? static_cast<char32_t>(
+                                       static_cast<std::make_unsigned_t<wchar_t>>(
+                                           wide[i + 1]))
+                                 : char32_t {0};
 
                 if (isTrailSurrogate(next))
                 {

--- a/Lib/eacp/GPU/Buffer/Buffer-Apple.mm
+++ b/Lib/eacp/GPU/Buffer/Buffer-Apple.mm
@@ -12,7 +12,7 @@ struct Buffer::Native
 {
     Native(Device& deviceToUse,
            const void* data,
-           std::size_t bytes,
+           int bytes,
            BufferUsage,
            BufferStorage)
         : device(&deviceToUse)
@@ -20,7 +20,7 @@ struct Buffer::Native
     {
         auto metalDevice = (__bridge id<MTLDevice>) device->nativeDevice();
 
-        if (metalDevice == nil || bytes == 0)
+        if (metalDevice == nil || bytes <= 0)
             return;
 
         // Shared storage keeps the buffer CPU-visible, so read() is a memcpy and
@@ -33,21 +33,21 @@ struct Buffer::Native
         // buys. Metal has nothing to opt into and no second path to keep right.
         if (data != nullptr)
             buffer = [metalDevice newBufferWithBytes:data
-                                              length:bytes
+                                              length:(NSUInteger) bytes
                                              options:MTLResourceStorageModeShared];
         else
-            buffer = [metalDevice newBufferWithLength:bytes
+            buffer = [metalDevice newBufferWithLength:(NSUInteger) bytes
                                               options:MTLResourceStorageModeShared];
     }
 
     ObjC::Ptr<NSObject<MTLBuffer>> buffer;
     Device* device = nullptr;
-    std::size_t length = 0;
+    int length = 0;
 };
 
 Buffer::Buffer(Device& device,
                const void* data,
-               std::size_t bytes,
+               int bytes,
                BufferUsage usage,
                BufferStorage storage)
     : impl(device, data, bytes, usage, storage)
@@ -58,7 +58,7 @@ Buffer::Buffer(Device& device,
         device.noteBufferCreated();
 }
 
-std::size_t Buffer::size() const
+int Buffer::size() const
 {
     return impl->length;
 }
@@ -68,9 +68,9 @@ bool Buffer::isValid() const
     return impl->buffer.get() != nil;
 }
 
-void Buffer::read(void* dst, std::size_t bytes, std::size_t offset) const
+void Buffer::read(void* dst, int bytes, int offset) const
 {
-    if (offset >= impl->length)
+    if (bytes <= 0 || offset < 0 || offset >= impl->length)
         return;
 
     // Shared storage makes the copy itself a memcpy, but the kernel that filled
@@ -85,20 +85,22 @@ void Buffer::read(void* dst, std::size_t bytes, std::size_t offset) const
     auto count = bytes < available ? bytes : available;
 
     if (auto metalBuffer = impl->buffer.get())
-        std::memcpy(dst, (const char*) [metalBuffer contents] + offset, count);
+        std::memcpy(
+            dst, (const char*) [metalBuffer contents] + offset, (std::size_t) count);
 }
 
-void Buffer::update(const void* data, std::size_t bytes, std::size_t offset)
+void Buffer::update(const void* data, int bytes, int offset)
 {
     auto metalBuffer = impl->buffer.get();
 
-    if (metalBuffer == nil || data == nullptr || bytes == 0
+    if (metalBuffer == nil || data == nullptr || bytes <= 0 || offset < 0
         || offset >= impl->length)
         return;
 
     auto available = impl->length - offset;
     auto count = bytes < available ? bytes : available;
-    std::memcpy((char*) [metalBuffer contents] + offset, data, count);
+    std::memcpy(
+        (char*) [metalBuffer contents] + offset, data, (std::size_t) count);
 }
 
 void* Buffer::nativeBuffer() const

--- a/Lib/eacp/GPU/Buffer/Buffer-Windows.cpp
+++ b/Lib/eacp/GPU/Buffer/Buffer-Windows.cpp
@@ -67,11 +67,13 @@ struct Buffer::Native
 {
     Native(Device& device,
            const void* data,
-           std::size_t bytes,
+           int byteCount,
            BufferUsage usage,
            BufferStorage storage)
         : context(getD3D12Context(device))
     {
+        const auto bytes = (std::size_t) (byteCount > 0 ? byteCount : 0);
+
         bufferData.size = bytes;
 
         if (!context.isValid() || bytes == 0)
@@ -263,7 +265,7 @@ struct Buffer::Native
 
 Buffer::Buffer(Device& device,
                const void* data,
-               std::size_t bytes,
+               int bytes,
                BufferUsage usage,
                BufferStorage storage)
     : impl(device, data, bytes, usage, storage)
@@ -274,9 +276,9 @@ Buffer::Buffer(Device& device,
         device.noteBufferCreated();
 }
 
-std::size_t Buffer::size() const
+int Buffer::size() const
 {
-    return impl->bufferData.size;
+    return (int) impl->bufferData.size;
 }
 
 bool Buffer::isValid() const
@@ -284,14 +286,18 @@ bool Buffer::isValid() const
     return impl->bufferData.resource != nullptr;
 }
 
-void Buffer::read(void* dst, std::size_t bytes, std::size_t offset) const
+void Buffer::read(void* dst, int byteCount, int byteOffset) const
 {
     auto* source = impl->bufferData.resource.get();
 
-    if (source == nullptr || offset >= impl->bufferData.size)
+    if (source == nullptr || byteCount <= 0 || byteOffset < 0
+        || (std::size_t) byteOffset >= impl->bufferData.size)
         return;
 
-    auto available = impl->bufferData.size - offset;
+    const auto offset = (std::size_t) byteOffset;
+    const auto bytes = (std::size_t) byteCount;
+
+    auto available = (std::size_t) impl->bufferData.size - offset;
     auto count = bytes < available ? bytes : available;
 
     // Host storage reads straight back out of the mapping, as Metal's shared
@@ -342,10 +348,10 @@ void Buffer::read(void* dst, std::size_t bytes, std::size_t offset) const
     }
 }
 
-void Buffer::update(const void* data, std::size_t bytes, std::size_t offset)
+void Buffer::update(const void* data, int byteCount, int byteOffset)
 {
-    if (impl->bufferData.resource == nullptr || data == nullptr || bytes == 0
-        || offset >= impl->bufferData.size)
+    if (impl->bufferData.resource == nullptr || data == nullptr || byteCount <= 0
+        || byteOffset < 0 || (std::size_t) byteOffset >= impl->bufferData.size)
         return;
 
     auto& context = impl->context;
@@ -353,7 +359,10 @@ void Buffer::update(const void* data, std::size_t bytes, std::size_t offset)
     if (!context.isValid())
         return;
 
-    auto available = impl->bufferData.size - offset;
+    const auto offset = (std::size_t) byteOffset;
+    const auto bytes = (std::size_t) byteCount;
+
+    auto available = (std::size_t) impl->bufferData.size - offset;
     auto count = bytes < available ? bytes : available;
 
     // The whole of a streamed write. No recording is touched, so nothing

--- a/Lib/eacp/GPU/Buffer/Buffer.h
+++ b/Lib/eacp/GPU/Buffer/Buffer.h
@@ -66,11 +66,11 @@ class Buffer
 public:
     Buffer(Device& device,
            const void* data,
-           std::size_t bytes,
+           int bytes,
            BufferUsage usage = BufferUsage::Vertex,
            BufferStorage storage = BufferStorage::Device);
 
-    std::size_t size() const;
+    int size() const;
     bool isValid() const;
 
     // Copies bytes back from the buffer into dst, starting at offset bytes
@@ -89,7 +89,7 @@ public:
     // update rather than the last committed one. It is a debugging and test
     // affordance rather than a frame-loop one - the memory is write-combined
     // on D3D12, and reading it is far slower than writing it.
-    void read(void* dst, std::size_t bytes, std::size_t offset = 0) const;
+    void read(void* dst, int bytes, int offset = 0) const;
 
     // Overwrites part of the buffer's contents from the CPU, starting at
     // offset bytes into the buffer — the per-frame path for dynamic
@@ -105,7 +105,7 @@ public:
     // be reading this instant, with no copy in the command stream to order it
     // behind. StreamingBuffers is what makes that safe, by never handing out
     // bytes from an arena a frame still in flight was drawn from.
-    void update(const void* data, std::size_t bytes, std::size_t offset = 0);
+    void update(const void* data, int bytes, int offset = 0);
 
     // Opaque native handle for cross-translation-unit use by other GPU types.
     void* nativeBuffer() const;
@@ -138,15 +138,12 @@ private:
 struct BufferRange
 {
     const Buffer* buffer = nullptr;
-    std::size_t offset = 0;
-    std::size_t bytes = 0;
+    int offset = 0;
+    int bytes = 0;
 
     // The whole of a buffer, for the calls that take a range when what a
     // caller has is a buffer it means to bind from the start.
-    static BufferRange of(const Buffer& whole)
-    {
-        return {&whole, 0, whole.size()};
-    }
+    static BufferRange of(const Buffer& whole) { return {&whole, 0, whole.size()}; }
 
     // False for a default-constructed range and for one over a buffer that
     // never got storage, which is the same test a bind makes before encoding.

--- a/Lib/eacp/GPU/Buffer/StreamingBuffers.cpp
+++ b/Lib/eacp/GPU/Buffer/StreamingBuffers.cpp
@@ -26,11 +26,11 @@ namespace
 // from one small allocation walks up through several doublings - each of which
 // is a GPU allocation - before it gets there. Three pools of this is the whole
 // cost of a stream that is barely used, which is why it is not larger.
-constexpr auto minimumArenaBytes = std::size_t {64 * 1024};
+constexpr auto minimumArenaBytes = 64 * 1024;
 
 // The cursor only ever advances by whole alignment units, so every slice
 // starts where the next bind may begin.
-std::size_t alignedUp(std::size_t bytes)
+int alignedUp(int bytes)
 {
     constexpr auto mask = StreamingBuffers::alignment - 1;
 
@@ -40,7 +40,7 @@ std::size_t alignedUp(std::size_t bytes)
 // Doubling rather than fitting each new high-water mark: what a batching
 // renderer writes swings by a lot between frames, and resizing to every peak
 // would allocate on most of them.
-std::size_t grownCapacity(std::size_t needed, std::size_t current)
+int grownCapacity(int needed, int current)
 {
     auto capacity = std::max(current, minimumArenaBytes);
 
@@ -100,7 +100,7 @@ void StreamingBuffers::beginFrame(Pool& pool, std::uint64_t frame)
 
 // The arena the next `bytes` go into: the current one when they fit after the
 // cursor, otherwise a new one appended beside it.
-Buffer& StreamingBuffers::arenaFor(Pool& pool, std::size_t bytes)
+Buffer& StreamingBuffers::arenaFor(Pool& pool, int bytes)
 {
     if (!pool.arenas.empty())
     {
@@ -117,8 +117,7 @@ Buffer& StreamingBuffers::arenaFor(Pool& pool, std::size_t bytes)
     // the arena it outgrew, so that a frame which keeps growing walks up in a
     // handful of steps rather than one per write - and so that the fold at the
     // pool's next reset can usually keep this arena as the one that stays.
-    const auto current =
-        pool.arenas.empty() ? std::size_t {0} : pool.arenas.back()->size();
+    const auto current = pool.arenas.empty() ? 0 : pool.arenas.back()->size();
 
     pool.used = 0;
 
@@ -129,7 +128,7 @@ Buffer& StreamingBuffers::arenaFor(Pool& pool, std::size_t bytes)
                                  BufferStorage::Streaming);
 }
 
-BufferRange StreamingBuffers::write(const void* data, std::size_t bytes)
+BufferRange StreamingBuffers::write(const void* data, int bytes)
 {
     const auto frame = Device::shared().frameIndex();
     auto& pool = pools[(int) (frame % (std::uint64_t) framesInFlight)];
@@ -140,7 +139,7 @@ BufferRange StreamingBuffers::write(const void* data, std::size_t bytes)
     // Nothing to copy takes no room, but still names a real buffer: a caller
     // that binds whatever it last wrote - a program whose instance count went
     // to zero this frame - binds the arena at the cursor rather than nothing.
-    if (data == nullptr || bytes == 0)
+    if (data == nullptr || bytes <= 0)
     {
         auto& arena = arenaFor(pool, 0);
 
@@ -171,9 +170,9 @@ int StreamingBuffers::bufferCount() const
     return total;
 }
 
-std::size_t StreamingBuffers::bytesReserved() const
+int StreamingBuffers::bytesReserved() const
 {
-    auto total = std::size_t {0};
+    auto total = 0;
 
     for (const auto& pool: pools)
         for (const auto& arena: pool.arenas)

--- a/Lib/eacp/GPU/Buffer/StreamingBuffers.h
+++ b/Lib/eacp/GPU/Buffer/StreamingBuffers.h
@@ -79,7 +79,7 @@ public:
     // A write of zero bytes takes no room and comes back as an empty range at
     // the arena's current position, so a caller that binds whatever it wrote
     // still binds something real.
-    BufferRange write(const void* data, std::size_t bytes);
+    BufferRange write(const void* data, int bytes);
 
     // How many GPU buffers exist across every pool. framesInFlight once each
     // pool is warm, and more only during a frame that outgrew its arena - the
@@ -95,7 +95,7 @@ public:
 
     // The bytes those buffers reserve, across every pool. Grows to the largest
     // frame any pool has seen and stays there.
-    std::size_t bytesReserved() const;
+    int bytesReserved() const;
 
     // Matches the deepest pipeline either backend runs: Metal's default
     // drawable pool is three, DXGI's present queue is two. GPUView can be set
@@ -108,7 +108,7 @@ public:
     // alike - vertex and index binds want far less. Paying the larger one
     // makes every slice bindable anywhere, and against arenas measured in
     // megabytes the padding does not register.
-    static constexpr std::size_t alignment = 256;
+    static constexpr int alignment = 256;
 
 private:
     // One frame's worth of storage. In steady state `arenas` holds exactly one
@@ -131,13 +131,13 @@ private:
     {
         OwnedVector<Buffer> arenas;
         std::uint64_t frame = 0;
-        std::size_t used = 0;
-        std::size_t streamed = 0;
-        std::size_t highWater = 0;
+        int used = 0;
+        int streamed = 0;
+        int highWater = 0;
     };
 
     void beginFrame(Pool& pool, std::uint64_t frame);
-    Buffer& arenaFor(Pool& pool, std::size_t bytes);
+    Buffer& arenaFor(Pool& pool, int bytes);
 
     BufferUsage usage;
     Pool pools[framesInFlight];

--- a/Lib/eacp/GPU/Codegen/ShaderProgram.h
+++ b/Lib/eacp/GPU/Codegen/ShaderProgram.h
@@ -59,8 +59,7 @@ namespace eacp::GPU
 // The CPU-side storage type mirroring each shader value type. A scalar is a
 // float; a vector is a packed Array, so a uniform reads like the data it is.
 // Array wraps std::array with no added state, so the packed layout the upload
-// walk memcpys is the same either way — and a plain std::array still assigns,
-// through the sub-type overload below.
+// walk memcpys is the same either way.
 template <typename T>
 struct CpuValueOf;
 
@@ -112,19 +111,19 @@ struct CpuValueOf<Int>
 template <>
 struct CpuValueOf<Int2>
 {
-    using type = std::array<std::int32_t, 2>;
+    using type = Array<std::int32_t, 2>;
 };
 
 template <>
 struct CpuValueOf<Int3>
 {
-    using type = std::array<std::int32_t, 3>;
+    using type = Array<std::int32_t, 3>;
 };
 
 template <>
 struct CpuValueOf<Int4>
 {
-    using type = std::array<std::int32_t, 4>;
+    using type = Array<std::int32_t, 4>;
 };
 
 // The shader value a CPU type maps to. Built in for float / float[N] / array; a
@@ -169,30 +168,6 @@ template <>
 struct ShaderValueOf<float[4]>
 {
     using type = Float4;
-};
-
-template <>
-struct ShaderValueOf<std::array<float, 2>>
-{
-    using type = Float2;
-};
-
-template <>
-struct ShaderValueOf<std::array<float, 3>>
-{
-    using type = Float3;
-};
-
-template <>
-struct ShaderValueOf<std::array<float, 4>>
-{
-    using type = Float4;
-};
-
-template <>
-struct ShaderValueOf<std::array<float, 16>>
-{
-    using type = Float4x4;
 };
 
 template <>
@@ -447,12 +422,12 @@ struct VertexFormatOf<T>
 // else against the CPU type its shader value implies - the same question asked
 // of whichever of the two is authoritative for that field.
 template <typename M, typename Handle>
-constexpr std::size_t expectedAttributeBytes()
+constexpr int expectedAttributeBytes()
 {
     if constexpr (requires { M::vertexFormat; })
-        return (std::size_t) bytesPerAttribute(M::vertexFormat);
+        return bytesPerAttribute(M::vertexFormat);
     else
-        return sizeof(typename CpuValueOf<Handle>::type);
+        return (int) sizeof(typename CpuValueOf<Handle>::type);
 }
 
 // The non-templated surface the uniform member walk bottoms out in. The templated
@@ -776,11 +751,10 @@ public:
     template <typename V>
     void setVertices(const V* data, int count)
     {
-        assert(sizeof(V) == (std::size_t) vertexLayout().stride
+        assert((int) sizeof(V) == vertexLayout().stride
                && "vertex element size does not match the shader's vertex layout");
 
-        vertexBufferData.emplace(
-            Device::shared(), data, sizeof(V) * (std::size_t) count);
+        vertexBufferData.emplace(Device::shared(), data, (int) sizeof(V) * count);
         vertexCountValue = count;
     }
 
@@ -800,12 +774,12 @@ public:
 
     void setIndices(const std::uint32_t* data, int count)
     {
-        uploadIndices(data, sizeof(std::uint32_t), count, IndexFormat::UInt32);
+        uploadIndices(data, (int) sizeof(std::uint32_t), count, IndexFormat::UInt32);
     }
 
     void setIndices(const std::uint16_t* data, int count)
     {
-        uploadIndices(data, sizeof(std::uint16_t), count, IndexFormat::UInt16);
+        uploadIndices(data, (int) sizeof(std::uint16_t), count, IndexFormat::UInt16);
     }
 
     // Uploads typed per-instance data for a buffer slot and owns the storage.
@@ -832,7 +806,7 @@ public:
     {
         assert(bufferIndex >= 0 && bufferIndex < vertexLayout().buffers.size()
                && "instance buffer slot was not declared via instanceInput");
-        assert(sizeof(I) == (std::size_t) vertexLayout().buffers[bufferIndex].stride
+        assert((int) sizeof(I) == vertexLayout().buffers[bufferIndex].stride
                && "instance element size does not match the shader's "
                   "per-instance layout");
 
@@ -847,8 +821,7 @@ public:
         if (!stream.has_value())
             stream.emplace(BufferUsage::Vertex);
 
-        instanceBuffers[bufferIndex] =
-            stream->write(data, sizeof(I) * (std::size_t) count);
+        instanceBuffers[bufferIndex] = stream->write(data, (int) sizeof(I) * count);
         instanceCountValue = count;
         setExternalInstanceBuffer(bufferIndex, nullptr);
     }
@@ -1038,7 +1011,7 @@ protected:
     typename ShaderValueOf<M>::type vertexInput(M C::* member)
     {
         using Handle = typename ShaderValueOf<M>::type;
-        static_assert(sizeof(M) == expectedAttributeBytes<M, Handle>(),
+        static_assert((int) sizeof(M) == expectedAttributeBytes<M, Handle>(),
                       "vertex field size does not match the format it declares");
 
         constexpr auto type = ValueTypeOf<Handle>::value;
@@ -1064,7 +1037,7 @@ protected:
     typename ShaderValueOf<M>::type instanceInput(M C::* member, int bufferIndex)
     {
         using Handle = typename ShaderValueOf<M>::type;
-        static_assert(sizeof(M) == expectedAttributeBytes<M, Handle>(),
+        static_assert((int) sizeof(M) == expectedAttributeBytes<M, Handle>(),
                       "instance field size does not match the format it declares");
 
         constexpr auto type = ValueTypeOf<Handle>::value;
@@ -1292,14 +1265,12 @@ private:
     // first draw keeps reading the bytes it was given. Making that cheap is the
     // backend's job -- see Buffer-Windows.cpp.
     void uploadIndices(const void* data,
-                       std::size_t elementSize,
+                       int elementSize,
                        int count,
                        IndexFormat format)
     {
-        indexBufferData.emplace(Device::shared(),
-                                data,
-                                elementSize * (std::size_t) count,
-                                BufferUsage::Index);
+        indexBufferData.emplace(
+            Device::shared(), data, elementSize * count, BufferUsage::Index);
         indexCountValue = count;
         indexFormatValue = format;
     }

--- a/Lib/eacp/GPU/Codegen/ShaderProgram.h
+++ b/Lib/eacp/GPU/Codegen/ShaderProgram.h
@@ -3,6 +3,7 @@
 #include <eacp/Core/Utils/Containers.h>
 
 #include <algorithm>
+#include <array>
 
 #include "../Buffer/StreamingBuffers.h"
 #include "../Device/Device.h"
@@ -168,6 +169,33 @@ template <>
 struct ShaderValueOf<float[4]>
 {
     using type = Float4;
+};
+
+// The shader EDSL reads a caller's own vertex-struct members and uniform
+// assignments, so it keeps recognising std::array alongside EA::Array -- the
+// container migration moved eacp's interfaces, not what a consumer may hand in.
+template <>
+struct ShaderValueOf<std::array<float, 2>>
+{
+    using type = Float2;
+};
+
+template <>
+struct ShaderValueOf<std::array<float, 3>>
+{
+    using type = Float3;
+};
+
+template <>
+struct ShaderValueOf<std::array<float, 4>>
+{
+    using type = Float4;
+};
+
+template <>
+struct ShaderValueOf<std::array<float, 16>>
+{
+    using type = Float4x4;
 };
 
 template <>

--- a/Lib/eacp/GPU/Device/Device.h
+++ b/Lib/eacp/GPU/Device/Device.h
@@ -40,7 +40,7 @@ public:
     static Device& shared();
 
     Buffer makeBuffer(const void* data,
-                      std::size_t bytes,
+                      int bytes,
                       BufferUsage usage = BufferUsage::Vertex,
                       BufferStorage storage = BufferStorage::Device)
     {
@@ -50,11 +50,11 @@ public:
     template <typename T, std::size_t N>
     Buffer makeBuffer(const T (&array)[N], BufferUsage usage = BufferUsage::Vertex)
     {
-        return makeBuffer(array, sizeof(array), usage);
+        return makeBuffer(array, (int) sizeof(array), usage);
     }
 
     // An uninitialised buffer of the given size, e.g. a compute output target.
-    Buffer makeBuffer(std::size_t bytes, BufferUsage usage = BufferUsage::Storage)
+    Buffer makeBuffer(int bytes, BufferUsage usage = BufferUsage::Storage)
     {
         return {*this, nullptr, bytes, usage};
     }

--- a/Lib/eacp/GPU/Frame/ComputePass-Apple.mm
+++ b/Lib/eacp/GPU/Frame/ComputePass-Apple.mm
@@ -91,11 +91,11 @@ void ComputePass::setOutputTexture(const Texture& texture, int slot)
     [activeEncoder setTexture:metalTexture atIndex:(NSUInteger) slot];
 }
 
-void ComputePass::setBytes(const void* data, std::size_t bytes, int slot)
+void ComputePass::setBytes(const void* data, int bytes, int slot)
 {
     if (auto activeEncoder = impl->encoder.get())
         [activeEncoder setBytes:data
-                         length:bytes
+                         length:(NSUInteger) bytes
                         atIndex:(NSUInteger) (uniformBase + slot)];
 }
 

--- a/Lib/eacp/GPU/Frame/ComputePass-Windows.cpp
+++ b/Lib/eacp/GPU/Frame/ComputePass-Windows.cpp
@@ -116,13 +116,14 @@ void ComputePass::setOutputTexture(const Texture& texture, int slot)
     list->SetComputeRootDescriptorTable(computeTextureUAVParam(slot), data->uav.gpu);
 }
 
-void ComputePass::setBytes(const void* data, std::size_t bytes, int slot)
+void ComputePass::setBytes(const void* data, int bytes, int slot)
 {
     if (!impl->encoder || slot < 0 || slot >= maxUniformSlots)
         return;
 
     auto& commands = *impl->encoder->commands;
-    auto address = commands.context->uploadConstants(commands, data, bytes);
+    auto address =
+        commands.context->uploadConstants(commands, data, (std::size_t) bytes);
 
     if (address != 0)
         commands.list->SetComputeRootConstantBufferView(computeCBVParam(slot),

--- a/Lib/eacp/GPU/Frame/ComputePass.h
+++ b/Lib/eacp/GPU/Frame/ComputePass.h
@@ -65,12 +65,12 @@ public:
 
     // Uploads a small uniform block without a buffer object, like the render
     // pass's setVertexBytes. slot is the uniform-block slot (0 = first block).
-    void setBytes(const void* data, std::size_t bytes, int slot = 0);
+    void setBytes(const void* data, int bytes, int slot = 0);
 
     template <typename T>
     void setUniform(const T& value, int slot = 0)
     {
-        setBytes(&value, sizeof(T), slot);
+        setBytes(&value, (int) sizeof(T), slot);
     }
 
     // Runs the kernel over count work items, in groups of threadGroupWidth.
@@ -102,7 +102,7 @@ public:
         // Sequenced separately: packing must happen before the size is read,
         // and argument evaluation order would not guarantee that.
         const auto* uniforms = program.packedUniforms(count);
-        setBytes(uniforms, (std::size_t) program.uniformByteSize());
+        setBytes(uniforms, program.uniformByteSize());
         dispatch(count);
     }
 
@@ -115,7 +115,7 @@ public:
         program.bindResources(*this);
 
         const auto* uniforms = program.packedUniforms(width, height);
-        setBytes(uniforms, (std::size_t) program.uniformByteSize());
+        setBytes(uniforms, program.uniformByteSize());
         dispatch(width, height);
     }
 
@@ -144,7 +144,7 @@ public:
         program.bindResources(*this);
 
         const auto* uniforms = program.packedUniforms(guardCount);
-        setBytes(uniforms, (std::size_t) program.uniformByteSize());
+        setBytes(uniforms, program.uniformByteSize());
         dispatchIndirect(arguments, offsetInBytes);
     }
 

--- a/Lib/eacp/GPU/Frame/RenderPass-Apple.mm
+++ b/Lib/eacp/GPU/Frame/RenderPass-Apple.mm
@@ -321,25 +321,25 @@ void RenderPass::setFragmentStorageBuffer(const Buffer& buffer, int slot)
                                  atIndex:(NSUInteger) (bufferBase + slot)];
 }
 
-void RenderPass::setVertexBytes(const void* data, std::size_t bytes, int slot)
+void RenderPass::setVertexBytes(const void* data, int bytes, int slot)
 {
     // Uniforms live at buffer(uniformBase + slot) so multi-slot vertex
     // layouts (e.g. instancing with slots 0..N) never collide with the
     // uniform bind. Matches ComputePass::uniformBase.
     if (auto activeEncoder = impl->encoder.get())
         [activeEncoder setVertexBytes:data
-                               length:bytes
+                               length:(NSUInteger) bytes
                               atIndex:(NSUInteger) (uniformBase + slot)];
 }
 
-void RenderPass::setFragmentBytes(const void* data, std::size_t bytes, int slot)
+void RenderPass::setFragmentBytes(const void* data, int bytes, int slot)
 {
     // Same uniformBase mapping as the vertex stage, so one slot rule covers
     // both; the generated fragment functions declare the block at
     // buffer(uniformBase).
     if (auto activeEncoder = impl->encoder.get())
         [activeEncoder setFragmentBytes:data
-                                 length:bytes
+                                 length:(NSUInteger) bytes
                                 atIndex:(NSUInteger) (uniformBase + slot)];
 }
 
@@ -395,8 +395,8 @@ void RenderPass::drawIndexed(const BufferRange& indices,
 
     auto indexType = format == IndexFormat::UInt16 ? MTLIndexTypeUInt16
                                                    : MTLIndexTypeUInt32;
-    auto indexSize = format == IndexFormat::UInt16 ? sizeof(std::uint16_t)
-                                                   : sizeof(std::uint32_t);
+    auto indexSize = format == IndexFormat::UInt16 ? (int) sizeof(std::uint16_t)
+                                                   : (int) sizeof(std::uint32_t);
 
     // The eight-argument selector rather than the five-argument one because
     // only this form carries a base vertex; instanceCount:1 makes it the same
@@ -407,8 +407,7 @@ void RenderPass::drawIndexed(const BufferRange& indices,
                                indexType:indexType
                              indexBuffer:metalBuffer
                        indexBufferOffset:(NSUInteger) (indices.offset
-                                                       + (std::size_t) firstIndex
-                                                             * indexSize)
+                                                       + firstIndex * indexSize)
                            instanceCount:1
                               baseVertex:(NSInteger) baseVertex
                             baseInstance:0];
@@ -449,16 +448,15 @@ void RenderPass::drawIndexedInstanced(const BufferRange& indices,
 
     auto indexType = format == IndexFormat::UInt16 ? MTLIndexTypeUInt16
                                                    : MTLIndexTypeUInt32;
-    auto indexSize = format == IndexFormat::UInt16 ? sizeof(std::uint16_t)
-                                                   : sizeof(std::uint32_t);
+    auto indexSize = format == IndexFormat::UInt16 ? (int) sizeof(std::uint16_t)
+                                                   : (int) sizeof(std::uint32_t);
 
     [activeEncoder drawIndexedPrimitives:impl->primitiveType
                               indexCount:(NSUInteger) indexCount
                                indexType:indexType
                              indexBuffer:metalBuffer
                        indexBufferOffset:(NSUInteger) (indices.offset
-                                                       + (std::size_t) firstIndex
-                                                             * indexSize)
+                                                       + firstIndex * indexSize)
                            instanceCount:(NSUInteger) instanceCount
                               baseVertex:(NSInteger) baseVertex
                             baseInstance:(NSUInteger) firstInstance];

--- a/Lib/eacp/GPU/Frame/RenderPass-Windows.cpp
+++ b/Lib/eacp/GPU/Frame/RenderPass-Windows.cpp
@@ -172,7 +172,8 @@ void RenderPass::setVertexBuffer(const BufferRange& range, int index)
 
     auto* data = static_cast<D3D12BufferData*>(range.buffer->nativeBuffer());
 
-    if (data == nullptr || data->resource == nullptr || range.offset >= data->size)
+    if (data == nullptr || data->resource == nullptr
+        || (UINT64) range.offset >= data->size)
         return;
 
     auto& commands = *impl->encoder->commands;
@@ -183,8 +184,9 @@ void RenderPass::setVertexBuffer(const BufferRange& range, int index)
     // offset and the size comes down by it, so the view still ends where the
     // buffer does and vertex zero is the byte at the offset.
     D3D12_VERTEX_BUFFER_VIEW view = {};
-    view.BufferLocation = data->resource->GetGPUVirtualAddress() + range.offset;
-    view.SizeInBytes = static_cast<UINT>(data->size - range.offset);
+    view.BufferLocation =
+        data->resource->GetGPUVirtualAddress() + (UINT64) range.offset;
+    view.SizeInBytes = static_cast<UINT>(data->size - (UINT64) range.offset);
     view.StrideInBytes = strideForSlot(impl->encoder->strides, index);
 
     commands.list->IASetVertexBuffers(static_cast<UINT>(index), 1, &view);
@@ -289,26 +291,28 @@ void RenderPass::setFragmentStorageBuffer(const Buffer& buffer, int slot)
                                                          address);
 }
 
-void RenderPass::setVertexBytes(const void* data, std::size_t bytes, int slot)
+void RenderPass::setVertexBytes(const void* data, int bytes, int slot)
 {
     if (!impl->encoder || slot < 0 || slot >= maxUniformSlots)
         return;
 
     auto& commands = *impl->encoder->commands;
-    auto address = commands.context->uploadConstants(commands, data, bytes);
+    auto address =
+        commands.context->uploadConstants(commands, data, (std::size_t) bytes);
 
     if (address != 0)
         commands.list->SetGraphicsRootConstantBufferView(renderVertexCBVParam(slot),
                                                          address);
 }
 
-void RenderPass::setFragmentBytes(const void* data, std::size_t bytes, int slot)
+void RenderPass::setFragmentBytes(const void* data, int bytes, int slot)
 {
     if (!impl->encoder || slot < 0 || slot >= maxUniformSlots)
         return;
 
     auto& commands = *impl->encoder->commands;
-    auto address = commands.context->uploadConstants(commands, data, bytes);
+    auto address =
+        commands.context->uploadConstants(commands, data, (std::size_t) bytes);
 
     if (address != 0)
         commands.list->SetGraphicsRootConstantBufferView(renderPixelCBVParam(slot),
@@ -355,14 +359,16 @@ bool bindIndexRange(CommandContext& commands,
 
     auto* data = static_cast<D3D12BufferData*>(indices.buffer->nativeBuffer());
 
-    if (data == nullptr || data->resource == nullptr || indices.offset >= data->size)
+    if (data == nullptr || data->resource == nullptr
+        || (UINT64) indices.offset >= data->size)
         return false;
 
     transitionForUse(commands, *data, D3D12_RESOURCE_STATE_INDEX_BUFFER);
 
     D3D12_INDEX_BUFFER_VIEW view = {};
-    view.BufferLocation = data->resource->GetGPUVirtualAddress() + indices.offset;
-    view.SizeInBytes = static_cast<UINT>(data->size - indices.offset);
+    view.BufferLocation =
+        data->resource->GetGPUVirtualAddress() + (UINT64) indices.offset;
+    view.SizeInBytes = static_cast<UINT>(data->size - (UINT64) indices.offset);
     view.Format =
         format == IndexFormat::UInt16 ? DXGI_FORMAT_R16_UINT : DXGI_FORMAT_R32_UINT;
 

--- a/Lib/eacp/GPU/Frame/RenderPass.h
+++ b/Lib/eacp/GPU/Frame/RenderPass.h
@@ -197,22 +197,22 @@ public:
     // is the
     // uniform-block slot the generated shader declares (slot 0 = the first
     // uniform block). Ideal for values that change every frame, e.g. a transform.
-    void setVertexBytes(const void* data, std::size_t bytes, int slot = 0);
+    void setVertexBytes(const void* data, int bytes, int slot = 0);
 
     // The fragment-stage sibling of setVertexBytes, with the same slot mapping,
     // so one uniform block can be bound to both stages.
-    void setFragmentBytes(const void* data, std::size_t bytes, int slot = 0);
+    void setFragmentBytes(const void* data, int bytes, int slot = 0);
 
     template <typename T>
     void setVertexUniform(const T& value, int slot = 0)
     {
-        setVertexBytes(&value, sizeof(T), slot);
+        setVertexBytes(&value, (int) sizeof(T), slot);
     }
 
     template <typename T>
     void setFragmentUniform(const T& value, int slot = 0)
     {
-        setFragmentBytes(&value, sizeof(T), slot);
+        setFragmentBytes(&value, (int) sizeof(T), slot);
     }
 
     // Uploads a ShaderProgram's uniform block in one call: packs the program's

--- a/Lib/eacp/GPU/Texture/MipChain.cpp
+++ b/Lib/eacp/GPU/Texture/MipChain.cpp
@@ -40,7 +40,7 @@ TexelBlock texelBlockFor(int x, int y, int sourceWidth, int sourceHeight)
 // averaging four texels channel by channel gives the same answer whichever
 // order those channels are stored in.
 void halveBytes(const std::uint8_t* source,
-                std::size_t sourcePitch,
+                int sourcePitch,
                 int sourceWidth,
                 int sourceHeight,
                 std::uint8_t* destination,
@@ -57,10 +57,7 @@ void halveBytes(const std::uint8_t* source,
             for (auto channel = 0; channel < channels; ++channel)
             {
                 const auto at = [&](int sx, int sy)
-                {
-                    return (int) source[(std::size_t) sy * sourcePitch
-                                        + (std::size_t) (sx * channels + channel)];
-                };
+                { return (int) source[sy * sourcePitch + sx * channels + channel]; };
 
                 const auto sum = at(block.x0, block.y0) + at(block.x1, block.y0)
                                  + at(block.x0, block.y1) + at(block.x1, block.y1);
@@ -68,17 +65,15 @@ void halveBytes(const std::uint8_t* source,
                 // +2 before the shift rounds to nearest rather than always
                 // down, which over a ten-level chain is the difference between
                 // a mip that holds its brightness and one that drifts dark.
-                destination[(std::size_t) y
-                                * (std::size_t) (destinationWidth * channels)
-                            + (std::size_t) (x * channels + channel)] =
-                    (std::uint8_t) ((sum + 2) / 4);
+                destination[y * destinationWidth * channels + x * channels
+                            + channel] = (std::uint8_t) ((sum + 2) / 4);
             }
         }
     }
 }
 
 void halveFloats(const std::uint8_t* source,
-                 std::size_t sourcePitch,
+                 int sourcePitch,
                  int sourceWidth,
                  int sourceHeight,
                  std::uint8_t* destination,
@@ -95,15 +90,13 @@ void halveFloats(const std::uint8_t* source,
             {
                 const auto at = [&](int sx, int sy)
                 {
-                    const auto* row = source + (std::size_t) sy * sourcePitch;
+                    const auto* row = source + sy * sourcePitch;
                     const auto* texel = reinterpret_cast<const float*>(row);
                     return texel[sx * channels + channel];
                 };
 
                 auto* row = destination
-                            + (std::size_t) y
-                                  * (std::size_t) (destinationWidth * channels)
-                                  * sizeof(float);
+                            + y * destinationWidth * channels * (int) sizeof(float);
 
                 reinterpret_cast<float*>(row)[x * channels + channel] =
                     (at(block.x0, block.y0) + at(block.x1, block.y0)
@@ -117,7 +110,7 @@ void halveFloats(const std::uint8_t* source,
 // patterns would be meaningless - they are a sign, an exponent and a mantissa,
 // not a number - which is the trap this exists to avoid.
 void halveHalves(const std::uint8_t* source,
-                 std::size_t sourcePitch,
+                 int sourcePitch,
                  int sourceWidth,
                  int sourceHeight,
                  std::uint8_t* destination,
@@ -135,7 +128,7 @@ void halveHalves(const std::uint8_t* source,
             {
                 const auto at = [&](int sx, int sy)
                 {
-                    const auto* row = source + (std::size_t) sy * sourcePitch;
+                    const auto* row = source + sy * sourcePitch;
                     const auto* texel = reinterpret_cast<const std::uint16_t*>(row);
                     return halfToFloat(texel[sx * channels + channel]);
                 };
@@ -145,10 +138,9 @@ void halveHalves(const std::uint8_t* source,
                      + at(block.x0, block.y1) + at(block.x1, block.y1))
                     * 0.25f;
 
-                auto* row = destination
-                            + (std::size_t) y
-                                  * (std::size_t) (destinationWidth * channels)
-                                  * sizeof(std::uint16_t);
+                auto* row =
+                    destination
+                    + y * destinationWidth * channels * (int) sizeof(std::uint16_t);
 
                 reinterpret_cast<std::uint16_t*>(row)[x * channels + channel] =
                     halfFromFloat(average);
@@ -161,11 +153,8 @@ void halveHalves(const std::uint8_t* source,
 // are arithmetic over a size, and a caller whose size is known at compile time
 // should be able to size a buffer with them.
 
-MipChain buildMipChain(const void* pixels,
-                       int width,
-                       int height,
-                       TextureFormat format,
-                       std::size_t bytesPerRow)
+MipChain buildMipChain(
+    const void* pixels, int width, int height, TextureFormat format, int bytesPerRow)
 {
     auto chain = MipChain {};
 
@@ -179,8 +168,7 @@ MipChain buildMipChain(const void* pixels,
         return chain;
 
     const auto texelBytes = bytesPerPixel(format);
-    const auto sourcePitch =
-        bytesPerRow > 0 ? bytesPerRow : (std::size_t) (width * texelBytes);
+    const auto sourcePitch = bytesPerRow > 0 ? bytesPerRow : width * texelBytes;
 
     const auto levels = mipLevelCount(width, height);
     chain.levels.resize(levels);
@@ -188,14 +176,11 @@ MipChain buildMipChain(const void* pixels,
     // Level 0, repacked to a tight stride so every level below it reads the
     // same way and the backends upload them all through one loop.
     auto& base = chain.levels[0];
-    base.resize((int) ((std::size_t) width * (std::size_t) height
-                       * (std::size_t) texelBytes));
+    base.resize(width * height * texelBytes);
 
     for (auto row = 0; row < height; ++row)
-        std::memcpy(base.data()
-                        + (std::size_t) row * (std::size_t) (width * texelBytes),
-                    static_cast<const std::uint8_t*>(pixels)
-                        + (std::size_t) row * sourcePitch,
+        std::memcpy(base.data() + row * width * texelBytes,
+                    static_cast<const std::uint8_t*>(pixels) + row * sourcePitch,
                     (std::size_t) (width * texelBytes));
 
     for (auto level = 1; level < levels; ++level)
@@ -206,12 +191,10 @@ MipChain buildMipChain(const void* pixels,
         const auto destinationHeight = mipExtent(height, level);
 
         auto& destination = chain.levels[level];
-        destination.resize(
-            (int) ((std::size_t) destinationWidth * (std::size_t) destinationHeight
-                   * (std::size_t) texelBytes));
+        destination.resize(destinationWidth * destinationHeight * texelBytes);
 
         const auto* source = chain.levels[level - 1].data();
-        const auto pitch = (std::size_t) (sourceWidth * texelBytes);
+        const auto pitch = sourceWidth * texelBytes;
 
         switch (format)
         {

--- a/Lib/eacp/GPU/Texture/MipChain.h
+++ b/Lib/eacp/GPU/Texture/MipChain.h
@@ -43,10 +43,9 @@ constexpr int mipExtent(int extent, int level)
 //
 // constexpr, as the two above are, so that a caller with a size known at compile
 // time can size a buffer with it rather than a magic number.
-constexpr std::size_t
-    mipChainBytes(TextureFormat format, int width, int height, int levels)
+constexpr int mipChainBytes(TextureFormat format, int width, int height, int levels)
 {
-    auto total = std::size_t {0};
+    auto total = 0;
 
     for (auto level = 0; level < levels; ++level)
         total +=
@@ -116,5 +115,5 @@ MipChain buildMipChain(const void* pixels,
                        int width,
                        int height,
                        TextureFormat format,
-                       std::size_t bytesPerRow = 0);
+                       int bytesPerRow = 0);
 } // namespace eacp::GPU

--- a/Lib/eacp/GPU/Texture/Texture-Apple.mm
+++ b/Lib/eacp/GPU/Texture/Texture-Apple.mm
@@ -417,7 +417,7 @@ struct Texture::Native
     // definition - a compressed texture, or a chain the caller supplied - and a
     // nonzero one there is dropped rather than used as a pitch it cannot be.
     // See Texture::update.
-    void update(const void* pixels, std::size_t bytesPerRow)
+    void update(const void* pixels, int bytesPerRow)
     {
         if (texture.get() == nil || pixels == nullptr || width <= 0 || height <= 0)
             return;
@@ -432,13 +432,13 @@ struct Texture::Native
         // concerned: its own slice, and its own chain built from its own pixels
         // rather than from its neighbours'. See TextureDescriptor::cube for the
         // order the six are in and why it is the same order on both backends.
-        const auto faceBytes = stride * (std::size_t) levelRows(format, height);
+        const auto faceBytes = stride * levelRows(format, height);
         const auto faces = cube ? 6 : 1;
 
         for (auto face = 0; face < faces; ++face)
         {
             const auto* facePixels =
-                (const unsigned char*) pixels + (std::size_t) face * faceBytes;
+                (const unsigned char*) pixels + face * faceBytes;
 
             if (suppliedChain)
                 uploadSuppliedChain(face, facePixels);
@@ -453,7 +453,7 @@ struct Texture::Native
     // generateMipmapsForTexture, which would work here and has no counterpart on
     // D3D12 - see MipChain.h for why one filter shared by both backends is worth
     // more than a free one on this side only.
-    void uploadChain(int slice, const void* pixels, std::size_t bytesPerRow)
+    void uploadChain(int slice, const void* pixels, int bytesPerRow)
     {
         const auto chain = buildMipChain(pixels, width, height, format, bytesPerRow);
 
@@ -513,7 +513,7 @@ struct Texture::Native
                       int regionWidth,
                       int regionHeight,
                       const void* pixels,
-                      std::size_t bytesPerRow)
+                      int bytesPerRow)
     {
         [texture.get() replaceRegion:MTLRegionMake2D(0,
                                                     0,
@@ -533,7 +533,7 @@ struct Texture::Native
                       int regionWidth,
                       int regionHeight,
                       const void* pixels,
-                      std::size_t bytesPerRow)
+                      int bytesPerRow)
     {
         if (texture.get() == nil || pixels == nullptr || width <= 0 || height <= 0)
             return;
@@ -583,7 +583,7 @@ struct Texture::Native
                     int regionWidth,
                     int regionHeight,
                     void* dst,
-                    std::size_t bytesPerRow) const
+                    int bytesPerRow) const
     {
         auto source = (id<MTLTexture>) texture.get();
 
@@ -649,15 +649,15 @@ struct Texture::Native
             [commandBuffer commit];
             [commandBuffer waitUntilCompleted];
 
-            const auto stride =
-                bytesPerRow != 0 ? bytesPerRow : (std::size_t) rowBytes;
+            const auto stride = bytesPerRow != 0 ? (NSUInteger) bytesPerRow
+                                                 : rowBytes;
 
             auto* out = (unsigned char*) dst;
             auto* in = (const unsigned char*) [staging contents];
 
             for (auto row = 0; row < regionHeight; ++row)
-                std::memcpy(out + (std::size_t) row * stride,
-                            in + (std::size_t) row * rowBytes,
+                std::memcpy(out + (NSUInteger) row * stride,
+                            in + (NSUInteger) row * rowBytes,
                             (std::size_t) rowBytes);
         }
     }
@@ -721,14 +721,14 @@ Texture::Texture(Device& device, void* nativePixelBuffer)
 {
 }
 
-void Texture::update(const void* pixels, std::size_t bytesPerRow)
+void Texture::update(const void* pixels, int bytesPerRow)
 {
     impl->update(pixels, bytesPerRow);
 }
 
 void Texture::update(const Graphics::Rect& region,
                      const void* pixels,
-                     std::size_t bytesPerRow)
+                     int bytesPerRow)
 {
     // Texels are whole; round rather than truncate so a rect built from
     // accumulated float arithmetic lands on the texel it is nearest to.
@@ -740,14 +740,12 @@ void Texture::update(const Graphics::Rect& region,
                        bytesPerRow);
 }
 
-void Texture::read(void* dst, std::size_t bytesPerRow) const
+void Texture::read(void* dst, int bytesPerRow) const
 {
     impl->readRegion(0, 0, impl->width, impl->height, dst, bytesPerRow);
 }
 
-void Texture::read(const Graphics::Rect& region,
-                   void* dst,
-                   std::size_t bytesPerRow) const
+void Texture::read(const Graphics::Rect& region, void* dst, int bytesPerRow) const
 {
     // Rounded rather than truncated, as update()'s region is: a rect built from
     // accumulated float arithmetic lands on the texel it is nearest to.

--- a/Lib/eacp/GPU/Texture/Texture-Windows.cpp
+++ b/Lib/eacp/GPU/Texture/Texture-Windows.cpp
@@ -263,7 +263,7 @@ struct Texture::Native
     bool copyPixels(D3D12Context& context,
                     CommandContext* commands,
                     const void* pixels,
-                    std::size_t sourcePitch,
+                    int sourcePitch,
                     int destX,
                     int destY,
                     int regionWidth,
@@ -312,7 +312,8 @@ struct Texture::Native
             std::memcpy(static_cast<unsigned char*>(mapped)
                             + row * footprint.Footprint.RowPitch,
                         static_cast<const unsigned char*>(pixels)
-                            + row * sourcePitch,
+                            + static_cast<std::size_t>(row)
+                                  * static_cast<std::size_t>(sourcePitch),
                         copyBytes);
 
         staging->Unmap(0, nullptr);
@@ -388,11 +389,11 @@ struct Texture::Native
     bool recordLevels(D3D12Context& context,
                       CommandContext* commands,
                       const void* pixels,
-                      std::size_t sourcePitch)
+                      int sourcePitch)
     {
         const auto faces = cube ? 6 : 1;
-        const auto faceBytes =
-            sourcePitch * static_cast<std::size_t>(levelRows(format, height));
+        const auto faceBytes = static_cast<std::size_t>(sourcePitch)
+                               * static_cast<std::size_t>(levelRows(format, height));
 
         for (auto face = 0; face < faces; ++face)
         {
@@ -417,7 +418,7 @@ struct Texture::Native
     bool recordFace(D3D12Context& context,
                     CommandContext* commands,
                     const void* pixels,
-                    std::size_t sourcePitch,
+                    int sourcePitch,
                     int face,
                     bool transitionAfterwards)
     {
@@ -501,7 +502,7 @@ struct Texture::Native
         return true;
     }
 
-    void update(const void* pixels, std::size_t bytesPerRow)
+    void update(const void* pixels, int bytesPerRow)
     {
         // Tightly packed by definition, so a stride is a number that can only be
         // wrong - dropped rather than used as a pitch it cannot be, in the same
@@ -538,7 +539,7 @@ struct Texture::Native
     // compressed and every supplied-chain update now comes through here, so it
     // is worth closing rather than leaving on a path only staging failure
     // reaches.
-    void updateWholeTexture(const void* pixels, std::size_t bytesPerRow)
+    void updateWholeTexture(const void* pixels, int bytesPerRow)
     {
         if (data.resource == nullptr || pixels == nullptr)
             return;
@@ -573,7 +574,7 @@ struct Texture::Native
                       int regionWidth,
                       int regionHeight,
                       const void* pixels,
-                      std::size_t bytesPerRow)
+                      int bytesPerRow)
     {
         if (data.resource == nullptr || pixels == nullptr || width <= 0
             || height <= 0)
@@ -647,7 +648,7 @@ struct Texture::Native
                     int regionWidth,
                     int regionHeight,
                     void* dst,
-                    std::size_t bytesPerRow) const
+                    int bytesPerRow) const
     {
         if (data.resource == nullptr || dst == nullptr || !context.isValid())
             return;
@@ -749,7 +750,8 @@ struct Texture::Native
             static_cast<std::size_t>(rowBytes) / static_cast<std::size_t>(copyWidth);
         const auto regionRowBytes =
             texelBytes * static_cast<std::size_t>(regionWidth);
-        const auto stride = bytesPerRow != 0 ? bytesPerRow : regionRowBytes;
+        const auto stride = bytesPerRow != 0 ? static_cast<std::size_t>(bytesPerRow)
+                                             : regionRowBytes;
 
         // Where the region starts inside what was copied: the origin unless the
         // whole subresource came back.
@@ -1216,14 +1218,14 @@ Texture::Texture(Device& device, void* nativePixelBuffer)
 {
 }
 
-void Texture::update(const void* pixels, std::size_t bytesPerRow)
+void Texture::update(const void* pixels, int bytesPerRow)
 {
     impl->update(pixels, bytesPerRow);
 }
 
 void Texture::update(const Graphics::Rect& region,
                      const void* pixels,
-                     std::size_t bytesPerRow)
+                     int bytesPerRow)
 {
     // Texels are whole; round rather than truncate so a rect built from
     // accumulated float arithmetic lands on the texel it is nearest to.
@@ -1235,14 +1237,12 @@ void Texture::update(const Graphics::Rect& region,
                        bytesPerRow);
 }
 
-void Texture::read(void* dst, std::size_t bytesPerRow) const
+void Texture::read(void* dst, int bytesPerRow) const
 {
     impl->readRegion(0, 0, impl->width, impl->height, dst, bytesPerRow);
 }
 
-void Texture::read(const Graphics::Rect& region,
-                   void* dst,
-                   std::size_t bytesPerRow) const
+void Texture::read(const Graphics::Rect& region, void* dst, int bytesPerRow) const
 {
     // Rounded rather than truncated, as update()'s region is.
     impl->readRegion(static_cast<int>(std::lround(region.x)),

--- a/Lib/eacp/GPU/Texture/Texture.h
+++ b/Lib/eacp/GPU/Texture/Texture.h
@@ -172,12 +172,12 @@ constexpr int bytesPerPixel(TextureFormat format)
 // A level's row pitch when it is tightly packed: bytes per row of texels, or
 // bytes per row of *blocks* for a compressed format, where one row covers four
 // rows of texels.
-constexpr std::size_t levelBytesPerRow(TextureFormat format, int width)
+constexpr int levelBytesPerRow(TextureFormat format, int width)
 {
     if (isCompressedFormat(format))
-        return (std::size_t) ((width + 3) / 4) * (std::size_t) bytesPerBlock(format);
+        return ((width + 3) / 4) * bytesPerBlock(format);
 
-    return (std::size_t) width * (std::size_t) bytesPerPixel(format);
+    return width * bytesPerPixel(format);
 }
 
 // How many rows of that pitch a level holds: its height in texels, or in blocks
@@ -190,9 +190,9 @@ constexpr int levelRows(TextureFormat format, int height)
 // One level of a texture this size, tightly packed - and the unit every layout
 // in this header is written in: a whole 2D texture, one face of a cube, one
 // level of a chain the caller supplied.
-constexpr std::size_t levelBytes(TextureFormat format, int width, int height)
+constexpr int levelBytes(TextureFormat format, int width, int height)
 {
-    return levelBytesPerRow(format, width) * (std::size_t) levelRows(format, height);
+    return levelBytesPerRow(format, width) * levelRows(format, height);
 }
 
 constexpr bool isFloatFormat(TextureFormat format)
@@ -561,7 +561,7 @@ public:
     // packed by definition, so a stride there is a number that can only be
     // wrong; a nonzero one is a no-op rather than an upload at a pitch nothing
     // means.
-    void update(const void* pixels, std::size_t bytesPerRow = 0);
+    void update(const void* pixels, int bytesPerRow = 0);
 
     // Re-uploads one sub-rectangle, leaving the rest of the texture untouched.
     //
@@ -592,7 +592,7 @@ public:
     // uploaded a glyph at a time as it is rasterized.
     void update(const Graphics::Rect& region,
                 const void* pixels,
-                std::size_t bytesPerRow = 0);
+                int bytesPerRow = 0);
 
     // Copies the texture's pixels back to the CPU — update()'s mirror, and the
     // only way what the GPU produced becomes bytes a program can look at: a
@@ -625,10 +625,8 @@ public:
     // would need a decoder here - while the things this exists for, a screenshot
     // and a test's assertion, read a render target, which a compressed texture
     // cannot be.
-    void read(void* dst, std::size_t bytesPerRow = 0) const;
-    void read(const Graphics::Rect& region,
-              void* dst,
-              std::size_t bytesPerRow = 0) const;
+    void read(void* dst, int bytesPerRow = 0) const;
+    void read(const Graphics::Rect& region, void* dst, int bytesPerRow = 0) const;
 
     // Opaque native handles for cross-translation-unit use by the render pass.
     // There is no sampler handle: the render pass gets that from the sampling

--- a/Lib/eacp/GPU/View/GPUView-Apple.mm
+++ b/Lib/eacp/GPU/View/GPUView-Apple.mm
@@ -433,8 +433,8 @@ Graphics::Image GPUView::renderNativeContent(float scale)
         // BGRA8 premultiplied (how Core Animation composites the Metal layer) ->
         // straight-alpha RGBA (what Image holds).
         auto* src = (const std::uint8_t*) readback.contents;
-        auto count = (std::size_t) pixelWidth * pixelHeight;
-        for (std::size_t i = 0; i < count; ++i)
+        auto count = (int) (pixelWidth * pixelHeight);
+        for (auto i = 0; i < count; ++i)
         {
             auto b = src[i * 4 + 0];
             auto g = src[i * 4 + 1];

--- a/Lib/eacp/GPUWidgets/Path/CoverageBatch.cpp
+++ b/Lib/eacp/GPUWidgets/Path/CoverageBatch.cpp
@@ -19,7 +19,7 @@ void uploadTo(std::optional<GPU::Buffer>& buffer,
               const Vector<float>& values,
               int& updates)
 {
-    auto bytes = sizeof(float) * (std::size_t) values.size();
+    auto bytes = (int) sizeof(float) * values.size();
 
     if (!buffer.has_value() || buffer->size() < bytes)
         buffer.emplace(
@@ -42,12 +42,12 @@ void padEmpty(Vector<float>& values)
 // The arrays the binning and backdrop stages work in. Never uploaded and never
 // read back - a kernel is what puts a value in one - so these are allocations
 // and nothing else, grown when a batch needs more than the last one did.
-void ensureRoom(std::optional<GPU::Buffer>& buffer, std::size_t bytes)
+void ensureRoom(std::optional<GPU::Buffer>& buffer, int bytes)
 {
     if (!buffer.has_value() || buffer->size() < bytes)
         buffer.emplace(GPU::Device::shared(),
                        nullptr,
-                       std::max<std::size_t>(4, bytes),
+                       std::max(4, bytes),
                        GPU::BufferUsage::Storage);
 }
 
@@ -164,14 +164,14 @@ void CoverageBatch::upload()
     uploadTo(recordBuffer, records, bufferUpdates);
     uploadTo(blockBuffer, blockOffsets, bufferUpdates);
 
-    ensureRoom(cellBuffer, sizeof(std::uint32_t) * (std::size_t) cells);
+    ensureRoom(cellBuffer, (int) sizeof(std::uint32_t) * cells);
 
     // One past the last tile, holding the total: it is what makes the last
     // tile's run end a read of the same array rather than a special case, and
     // what the prefix sum leaves the entry count in.
-    ensureRoom(tileCountBuffer, sizeof(std::uint32_t) * (std::size_t) (tiles + 1));
-    ensureRoom(tileOffsetBuffer, sizeof(std::uint32_t) * (std::size_t) (tiles + 1));
-    ensureRoom(entryBuffer, sizeof(float) * 4 * (std::size_t) entries);
+    ensureRoom(tileCountBuffer, (int) sizeof(std::uint32_t) * (tiles + 1));
+    ensureRoom(tileOffsetBuffer, (int) sizeof(std::uint32_t) * (tiles + 1));
+    ensureRoom(entryBuffer, (int) sizeof(float) * 4 * entries);
 }
 
 // Zero, count, sum, sort - the tiles, for every path in the batch, and the

--- a/Lib/eacp/GPUWidgets/Path/PrefixSum.cpp
+++ b/Lib/eacp/GPUWidgets/Path/PrefixSum.cpp
@@ -21,7 +21,7 @@ int groupsFor(int count)
 // nobody's business.
 void ensureRoom(std::optional<GPU::Buffer>& buffer, int count)
 {
-    auto bytes = sizeof(std::uint32_t) * (std::size_t) std::max(1, count);
+    auto bytes = (int) sizeof(std::uint32_t) * std::max(1, count);
 
     if (!buffer.has_value() || buffer->size() < bytes)
         buffer.emplace(

--- a/Lib/eacp/GPUWidgets/Path/PrefixSum.cpp
+++ b/Lib/eacp/GPUWidgets/Path/PrefixSum.cpp
@@ -19,7 +19,7 @@ int groupsFor(int count)
 // Grown when a batch needs more than the last one did, and never uploaded: the
 // scan writes every element it reads, so what these hold on the way in is
 // nobody's business.
-void ensureRoom(std::optional<GPU::Buffer>& buffer, int count)
+void ensureElementRoom(std::optional<GPU::Buffer>& buffer, int count)
 {
     auto bytes = (int) sizeof(std::uint32_t) * std::max(1, count);
 
@@ -49,10 +49,10 @@ void PrefixSum::run(GPU::ComputePass& pass,
         auto& level = levels[levelCount];
         level.count = size;
         level.groups = groupsFor(size);
-        ensureRoom(level.totals, level.groups);
+        ensureElementRoom(level.totals, level.groups);
 
         if (levelCount > 0)
-            ensureRoom(level.offsets, size);
+            ensureElementRoom(level.offsets, size);
 
         ++levelCount;
 

--- a/Lib/eacp/GPUWidgets/Path/PrefixSum.h
+++ b/Lib/eacp/GPUWidgets/Path/PrefixSum.h
@@ -176,7 +176,7 @@ private:
     // buffers and is therefore not a thing to move around.
     static constexpr int maxLevels = 4;
 
-    std::array<Level, maxLevels> levels;
+    Array<Level, maxLevels> levels;
     int levelCount = 0;
     int dispatches = 0;
 };

--- a/Lib/eacp/Graphics/D2D-Windows.h
+++ b/Lib/eacp/Graphics/D2D-Windows.h
@@ -34,7 +34,7 @@ struct RegisteredFontNames
 // copied). The Windows half of eacp::Text::registerMemoryFont. Nothing when
 // the bytes are not a usable font.
 std::optional<RegisteredFontNames> registerMemoryFontData(const void* data,
-                                                          std::size_t size);
+                                                          int size);
 
 // Resolves `name` the way CTFontCreateWithName does — as a family name, then a
 // PostScript or full face name — so the one name a caller ships works on both

--- a/Lib/eacp/Graphics/Helpers/ImageConversion-Windows.cpp
+++ b/Lib/eacp/Graphics/Helpers/ImageConversion-Windows.cpp
@@ -45,7 +45,7 @@ HICON toHIcon(const Image& image)
     // RGBA (source) -> BGRA (DIB byte order).
     auto* dst = static_cast<std::uint8_t*>(bits);
     const auto* src = image.pixels().data();
-    eacp::simd::swapRedBlue(src, dst, (std::size_t) width * height);
+    eacp::simd::swapRedBlue(src, dst, width * height);
 
     auto maskBitmap = CreateBitmap(width, height, 1, 1, nullptr);
 

--- a/Lib/eacp/Graphics/IconTool/IconContainers.cpp
+++ b/Lib/eacp/Graphics/IconTool/IconContainers.cpp
@@ -1,8 +1,6 @@
 #include "IconContainers.h"
 
 #include "../Image/ImageOps.h"
-#include <array>
-#include <vector>
 
 namespace eacp::Graphics::Icons
 {
@@ -10,7 +8,7 @@ namespace eacp::Graphics::Icons
 namespace
 {
 
-using Bytes = std::vector<std::uint8_t>;
+using Bytes = Vector<std::uint8_t>;
 
 void appendBE32(Bytes& out, std::uint32_t value)
 {
@@ -36,7 +34,8 @@ void appendLE32(Bytes& out, std::uint32_t value)
 
 void appendTag(Bytes& out, const char* tag)
 {
-    out.insert(out.end(), tag, tag + 4);
+    for (auto i = 0; i < 4; ++i)
+        out.add(static_cast<std::uint8_t>(tag[i]));
 }
 
 int maxDimension(const Image& src)
@@ -46,9 +45,7 @@ int maxDimension(const Image& src)
 
 Bytes pngFrame(const Image& src, int size)
 {
-    const auto frame = downscaleTo(src, size);
-    const auto png = frame.toPng();
-    return Bytes(png.data(), png.data() + png.size());
+    return downscaleTo(src, size).toPng();
 }
 
 // A standard size belongs in the container when the source is at least that
@@ -78,7 +75,7 @@ void writeIcns(const Image& src, const FilePath& out)
         const char* type;
     };
 
-    static constexpr std::array chunks = {
+    static constexpr Array chunks = {
         Chunk {1024, "ic10"},
         Chunk {512, "ic09"},
         Chunk {256, "ic08"},
@@ -99,32 +96,32 @@ void writeIcns(const Image& src, const FilePath& out)
         const auto png = pngFrame(src, chunk.size);
         appendTag(body, chunk.type);
         appendBE32(body, static_cast<std::uint32_t>(8 + png.size()));
-        body.insert(body.end(), png.begin(), png.end());
+        body.addFrom(png);
     }
 
     Bytes file;
     appendTag(file, "icns");
     appendBE32(file, static_cast<std::uint32_t>(8 + body.size()));
-    file.insert(file.end(), body.begin(), body.end());
+    file.addFrom(body);
 
     Files::writeFile(out, file);
 }
 
 void writeIco(const Image& src, const FilePath& out)
 {
-    static constexpr std::array sizes = {16, 24, 32, 48, 64, 128, 256};
+    static constexpr Array sizes = {16, 24, 32, 48, 64, 128, 256};
 
     const auto limit = maxDimension(src);
 
-    std::vector<Bytes> frames;
-    std::vector<int> frameSizes;
+    Vector<Bytes> frames;
+    Vector<int> frameSizes;
     for (const auto size: sizes)
     {
         if (!keepSize(size, limit, 16))
             continue;
 
-        frames.push_back(pngFrame(src, size));
-        frameSizes.push_back(size);
+        frames.add(pngFrame(src, size));
+        frameSizes.add(size);
     }
 
     const auto count = static_cast<std::uint16_t>(frames.size());
@@ -135,7 +132,7 @@ void writeIco(const Image& src, const FilePath& out)
     appendLE16(dir, count);
 
     auto offset = static_cast<std::uint32_t>(6 + 16 * frames.size());
-    for (auto i = 0u; i < frames.size(); ++i)
+    for (auto i = 0; i < frames.size(); ++i)
     {
         const auto size = frameSizes[i];
         const auto bytesInRes = static_cast<std::uint32_t>(frames[i].size());
@@ -154,14 +151,15 @@ void writeIco(const Image& src, const FilePath& out)
 
     Bytes file = dir;
     for (const auto& frame: frames)
-        file.insert(file.end(), frame.begin(), frame.end());
+        file.addFrom(frame);
 
     Files::writeFile(out, file);
 }
 
 void writeIconset(const Image& src, const FilePath& outDir)
 {
-    Files::writeFile(outDir / "icon_1024.png", pngFrame(src, 1024));
+    const auto png = pngFrame(src, 1024);
+    Files::writeFile(outDir / "icon_1024.png", png);
 
     static constexpr auto contents = "{\n"
                                      "  \"images\" : [\n"
@@ -179,7 +177,10 @@ void writeIconset(const Image& src, const FilePath& outDir)
                                      "}\n";
 
     const std::string json = contents;
-    Files::writeFile(outDir / "Contents.json", Bytes(json.begin(), json.end()));
+
+    Bytes jsonBytes;
+    jsonBytes.assign(json.begin(), json.end());
+    Files::writeFile(outDir / "Contents.json", jsonBytes);
 }
 
 } // namespace eacp::Graphics::Icons

--- a/Lib/eacp/Graphics/Image/Image.cpp
+++ b/Lib/eacp/Graphics/Image/Image.cpp
@@ -67,8 +67,8 @@ ImageData readFileBytes(const FilePath& path, std::string& error)
     }
 
     auto bytes = ImageData(static_cast<int>(size));
-    auto got = file.read(0, {bytes.data(), static_cast<std::size_t>(bytes.size())});
-    if (got != size)
+    auto got = file.read(0, bytes);
+    if (static_cast<std::uint64_t>(got) != size)
     {
         error = "failed to read '" + path.str() + "'";
         return {};
@@ -234,7 +234,7 @@ void Image::save(const FilePath& path) const
 void Image::save(const FilePath& path, ImageFormat format, float quality) const
 {
     auto bytes = encode(format, quality);
-    Files::writeFile(path, {bytes.data(), static_cast<std::size_t>(bytes.size())});
+    Files::writeFile(path, bytes);
 }
 
 bool Image::equals(const Image& other) const

--- a/Lib/eacp/Graphics/Primitives/FontRegistry-Windows.cpp
+++ b/Lib/eacp/Graphics/Primitives/FontRegistry-Windows.cpp
@@ -1,10 +1,11 @@
 #include "../D2D-Windows.h"
 
+#include <eacp/Core/Utils/Containers.h>
+
 #include <dwrite_3.h>
 
 #include <mutex>
 #include <string>
-#include <vector>
 
 // The shared font collection — the Windows stand-in for CoreText's process-wide
 // registry. CTFontManagerRegisterGraphicsFont makes an embedded font visible to
@@ -125,10 +126,8 @@ ComPtr<IDWriteFontFace3> faceOf(IDWriteFactory5* factory,
 {
     auto reference = ComPtr<IDWriteFontFaceReference>();
 
-    if (FAILED(factory->CreateFontFaceReference(file.Get(),
-                                                0,
-                                                DWRITE_FONT_SIMULATIONS_NONE,
-                                                reference.GetAddressOf()))
+    if (FAILED(factory->CreateFontFaceReference(
+            file.Get(), 0, DWRITE_FONT_SIMULATIONS_NONE, reference.GetAddressOf()))
         || !reference)
         return {};
 
@@ -182,11 +181,11 @@ public:
         return current;
     }
 
-    std::optional<RegisteredFontNames> add(const void* data, std::size_t size)
+    std::optional<RegisteredFontNames> add(const void* data, int size)
     {
         auto* factory = memoryFontFactory();
 
-        if (factory == nullptr || data == nullptr || size == 0)
+        if (factory == nullptr || data == nullptr || size <= 0)
             return std::nullopt;
 
         const auto lock = std::lock_guard {mutex};
@@ -216,7 +215,7 @@ public:
         if (names.postScriptName.empty())
             return std::nullopt;
 
-        files.push_back(file);
+        files.add(file);
 
         if (!rebuild(factory))
             return std::nullopt;
@@ -271,7 +270,7 @@ private:
 
     std::mutex mutex;
     ComPtr<IDWriteInMemoryFontFileLoader> loader;
-    std::vector<ComPtr<IDWriteFontFile>> files;
+    Vector<ComPtr<IDWriteFontFile>> files;
     ComPtr<IDWriteFontCollection> current;
 };
 
@@ -287,8 +286,7 @@ ComPtr<IDWriteFontCollection> getFontCollection()
     return fontRegistry().collection();
 }
 
-std::optional<RegisteredFontNames> registerMemoryFontData(const void* data,
-                                                          std::size_t size)
+std::optional<RegisteredFontNames> registerMemoryFontData(const void* data, int size)
 {
     return fontRegistry().add(data, size);
 }

--- a/Lib/eacp/Graphics/Primitives/TextMetrics-Windows.cpp
+++ b/Lib/eacp/Graphics/Primitives/TextMetrics-Windows.cpp
@@ -43,19 +43,19 @@ float TextMetrics::measureWidth(const std::string& text, const Font& font)
 }
 
 float TextMetrics::getOffsetForIndex(const std::string& text,
-                                     size_t index,
+                                     int index,
                                      const Font& font)
 {
-    if (index == 0)
+    if (index <= 0)
         return 0.0f;
 
-    auto substring = text.substr(0, index);
+    auto substring = text.substr(0, (size_t) index);
     return measureWidth(substring, font);
 }
 
-size_t TextMetrics::getIndexForOffset(const std::string& text,
-                                      float xOffset,
-                                      const Font& font)
+int TextMetrics::getIndexForOffset(const std::string& text,
+                                   float xOffset,
+                                   const Font& font)
 {
     auto* textFormat = static_cast<IDWriteTextFormat*>(font.getHandle());
     auto* factory = getDWriteFactory();
@@ -80,7 +80,7 @@ size_t TextMetrics::getIndexForOffset(const std::string& text,
     auto hitMetrics = DWRITE_HIT_TEST_METRICS();
     textLayout->HitTestPoint(xOffset, 0.0f, &isTrailingHit, &isInside, &hitMetrics);
 
-    return hitMetrics.textPosition + (isTrailingHit ? 1 : 0);
+    return (int) hitMetrics.textPosition + (isTrailingHit ? 1 : 0);
 }
 
 float TextMetrics::getLineHeight(const Font& font)

--- a/Lib/eacp/Graphics/Primitives/TextMetrics.h
+++ b/Lib/eacp/Graphics/Primitives/TextMetrics.h
@@ -9,8 +9,8 @@ struct TextMetrics
 {
     static float measureWidth(const std::string& text, const Font& font);
     static float
-        getOffsetForIndex(const std::string& text, size_t index, const Font& font);
-    static size_t
+        getOffsetForIndex(const std::string& text, int index, const Font& font);
+    static int
         getIndexForOffset(const std::string& text, float xOffset, const Font& font);
     static float getLineHeight(const Font& font);
     static float getAscent(const Font& font);

--- a/Lib/eacp/Graphics/Primitives/TextMetrics.mm
+++ b/Lib/eacp/Graphics/Primitives/TextMetrics.mm
@@ -33,10 +33,10 @@ float TextMetrics::measureWidth(const std::string& text, const Font& font)
 }
 
 float TextMetrics::getOffsetForIndex(const std::string& text,
-                                     size_t index,
+                                     int index,
                                      const Font& font)
 {
-    if (text.empty() || index == 0)
+    if (text.empty() || index <= 0)
         return 0.f;
 
     CTFontRef ctFont = (CTFontRef) font.getHandle();
@@ -60,9 +60,9 @@ float TextMetrics::getOffsetForIndex(const std::string& text,
     return (float) offset;
 }
 
-size_t TextMetrics::getIndexForOffset(const std::string& text,
-                                      float xOffset,
-                                      const Font& font)
+int TextMetrics::getIndexForOffset(const std::string& text,
+                                   float xOffset,
+                                   const Font& font)
 {
     if (text.empty())
         return 0;
@@ -88,9 +88,9 @@ size_t TextMetrics::getIndexForOffset(const std::string& text,
         CTLineGetStringIndexForPosition(line, CGPointMake(xOffset, 0.f));
 
     if (index == kCFNotFound)
-        return text.length();
+        return (int) text.length();
 
-    return (size_t) index;
+    return (int) index;
 }
 
 float TextMetrics::getLineHeight(const Font& font)

--- a/Lib/eacp/Graphics/View/View-Windows.cpp
+++ b/Lib/eacp/Graphics/View/View-Windows.cpp
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <memory>
 #include <unordered_set>
-#include <vector>
 
 namespace eacp::Graphics
 {
@@ -275,7 +274,7 @@ private:
     Color currentColor {1.0f, 1.0f, 1.0f, 1.0f};
     float lineWidth = 1.0f;
 
-    std::vector<SavedState> savedStates;
+    Vector<SavedState> savedStates;
     bool drawing = false;
     bool failed = false;
     bool adopted = false;
@@ -835,10 +834,9 @@ void drawImageIntoContext(ID2D1DeviceContext* dc,
 
     // Straight RGBA -> premultiplied BGRA, the byte order a B8G8R8A8 D2D bitmap
     // composites with.
-    auto bgra = std::vector<std::uint32_t>(static_cast<std::size_t>(width)
-                                           * static_cast<std::size_t>(height));
+    auto bgra = Vector<std::uint32_t>(width * height);
 
-    for (std::size_t i = 0; i < bgra.size(); ++i)
+    for (auto i = 0; i < bgra.size(); ++i)
     {
         auto r = pixels[i * 4 + 0];
         auto g = pixels[i * 4 + 1];

--- a/Lib/eacp/Graphics/Widgets/TextInput.cpp
+++ b/Lib/eacp/Graphics/Widgets/TextInput.cpp
@@ -14,7 +14,7 @@ TextInput::TextInput(const FontOptions& options)
 
 TextInput::TextInput(const std::string& initialText)
     : text(initialText)
-    , cursorIndex(initialText.length())
+    , cursorIndex((int) initialText.length())
 {
     initialize();
 }
@@ -46,8 +46,8 @@ void TextInput::initialize()
 void TextInput::setText(const std::string& newText)
 {
     text = newText;
-    if (cursorIndex > text.length())
-        cursorIndex = text.length();
+    if (cursorIndex > (int) text.length())
+        cursorIndex = (int) text.length();
 
     updateTextDisplay();
     updateCursorPosition();
@@ -58,13 +58,13 @@ std::string TextInput::getText() const
     return text;
 }
 
-void TextInput::setCursorPosition(size_t position)
+void TextInput::setCursorPosition(int position)
 {
-    cursorIndex = std::min(position, text.length());
+    cursorIndex = std::clamp(position, 0, (int) text.length());
     updateCursorPosition();
 }
 
-size_t TextInput::getCursorPosition() const
+int TextInput::getCursorPosition() const
 {
     return cursorIndex;
 }
@@ -146,7 +146,7 @@ void TextInput::keyDown(const KeyEvent& event)
     {
         if (event.keyCode == KeyCode::A)
         {
-            cursorIndex = text.length();
+            cursorIndex = (int) text.length();
             updateCursorPosition();
         }
         return;
@@ -166,7 +166,7 @@ void TextInput::keyDown(const KeyEvent& event)
     }
     else if (event.keyCode == KeyCode::RightArrow)
     {
-        if (cursorIndex < text.length())
+        if (cursorIndex < (int) text.length())
         {
             cursorIndex++;
             updateCursorPosition();
@@ -182,8 +182,8 @@ void TextInput::keyDown(const KeyEvent& event)
         char c = event.characters[0];
         if (c >= 32 && c < 127)
         {
-            text.insert(cursorIndex, event.characters);
-            cursorIndex += event.characters.length();
+            text.insert((size_t) cursorIndex, event.characters);
+            cursorIndex += (int) event.characters.length();
             updateTextDisplay();
             updateCursorPosition();
 
@@ -241,7 +241,7 @@ void TextInput::handleBackspace()
 {
     if (cursorIndex > 0 && !text.empty())
     {
-        text.erase(cursorIndex - 1, 1);
+        text.erase((size_t) (cursorIndex - 1), 1);
         cursorIndex--;
         updateTextDisplay();
         updateCursorPosition();
@@ -253,9 +253,9 @@ void TextInput::handleBackspace()
 
 void TextInput::handleDelete()
 {
-    if (cursorIndex < text.length())
+    if (cursorIndex < (int) text.length())
     {
-        text.erase(cursorIndex, 1);
+        text.erase((size_t) cursorIndex, 1);
         updateTextDisplay();
         updateCursorPosition();
 

--- a/Lib/eacp/Graphics/Widgets/TextInput.h
+++ b/Lib/eacp/Graphics/Widgets/TextInput.h
@@ -16,8 +16,8 @@ public:
     void setText(const std::string& text);
     std::string getText() const;
 
-    void setCursorPosition(size_t position);
-    size_t getCursorPosition() const;
+    void setCursorPosition(int position);
+    int getCursorPosition() const;
 
     void setPlaceholder(const std::string& placeholder);
 
@@ -45,7 +45,7 @@ private:
 
     std::string text;
     std::string placeholder;
-    size_t cursorIndex = 0;
+    int cursorIndex = 0;
     Font font;
     float padding = 8.f;
     Color textColor {0.f, 0.f, 0.f};

--- a/Lib/eacp/Network/HTTP/Http.cpp
+++ b/Lib/eacp/Network/HTTP/Http.cpp
@@ -514,12 +514,10 @@ Response Request::downloadTo(const std::string& filePath) const
 
 namespace
 {
-void appendDecodedPercentEscape(std::string& out,
-                                const std::string& src,
-                                std::size_t& i)
+void appendDecodedPercentEscape(std::string& out, const std::string& src, int& i)
 {
-    auto hi = Strings::hexCharToInt(src[i + 1]);
-    auto lo = Strings::hexCharToInt(src[i + 2]);
+    auto hi = Strings::hexCharToInt(src[(std::size_t) i + 1]);
+    auto lo = Strings::hexCharToInt(src[(std::size_t) i + 2]);
 
     if (hi < 0 || lo < 0)
     {
@@ -570,13 +568,13 @@ std::string urlDecode(const std::string& encoded)
     auto result = std::string();
     result.reserve(encoded.size());
 
-    for (auto i = std::size_t {0}; i < encoded.size(); ++i)
+    for (auto i = 0; i < (int) encoded.size(); ++i)
     {
-        auto c = encoded[i];
+        auto c = encoded[(std::size_t) i];
 
         if (c == '+')
             result.push_back(' ');
-        else if (c == '%' && i + 2 < encoded.size())
+        else if (c == '%' && i + 2 < (int) encoded.size())
             appendDecodedPercentEscape(result, encoded, i);
         else
             result.push_back(c);

--- a/Lib/eacp/Network/HTTP/HttpProtocol.cpp
+++ b/Lib/eacp/Network/HTTP/HttpProtocol.cpp
@@ -8,6 +8,10 @@ namespace eacp::HTTP
 namespace
 {
 
+// A body past this cannot be indexed with int offsets, so a Content-Length
+// beyond it is clamped rather than believed.
+constexpr auto largestBody = std::int64_t {0x7FFFFFFF};
+
 const char* reasonPhraseForStatus(int code)
 {
     switch (code)
@@ -152,9 +156,9 @@ std::string serializeResponse(const Response& response)
     return out.str();
 }
 
-RequestParser::State RequestParser::feed(const char* data, std::size_t length)
+RequestParser::State RequestParser::feed(const char* data, int length)
 {
-    buffer.append(data, length);
+    buffer.append(data, (std::size_t) length);
 
     if (!headersParsed)
     {
@@ -188,7 +192,7 @@ RequestParser::State RequestParser::tryParseHeaders()
     parseQueryParamsFromUrl(parsed);
     parseHeaderLines(headerSection, parsed);
 
-    bodyStart = headerEnd + 4;
+    bodyStart = (int) headerEnd + 4;
     headersParsed = true;
     readContentLengthFromHeaders();
 
@@ -204,7 +208,10 @@ void RequestParser::readContentLengthFromHeaders()
 
     try
     {
-        bodyExpected = (std::size_t) std::stoul(contentLength);
+        auto declared = std::stoll(contentLength);
+        bodyExpected = declared > 0
+                           ? (int) (declared < largestBody ? declared : largestBody)
+                           : 0;
     }
     catch (...)
     {
@@ -213,7 +220,7 @@ void RequestParser::readContentLengthFromHeaders()
 
 bool RequestParser::isBodyComplete() const
 {
-    return buffer.size() - bodyStart >= bodyExpected;
+    return (int) buffer.size() - bodyStart >= bodyExpected;
 }
 
 RequestParser::State RequestParser::finishIfBodyComplete()
@@ -221,7 +228,7 @@ RequestParser::State RequestParser::finishIfBodyComplete()
     if (!isBodyComplete())
         return State::NeedMore;
 
-    parsed.body = buffer.substr(bodyStart, bodyExpected);
+    parsed.body = buffer.substr((std::size_t) bodyStart, (std::size_t) bodyExpected);
     return State::Ready;
 }
 

--- a/Lib/eacp/Network/HTTP/HttpProtocol.h
+++ b/Lib/eacp/Network/HTTP/HttpProtocol.h
@@ -30,7 +30,7 @@ public:
         Invalid
     };
 
-    State feed(const char* data, std::size_t length);
+    State feed(const char* data, int length);
     Request& request() { return parsed; }
 
 private:
@@ -41,8 +41,8 @@ private:
 
     std::string buffer;
     Request parsed;
-    std::size_t bodyStart = 0;
-    std::size_t bodyExpected = 0;
+    int bodyStart = 0;
+    int bodyExpected = 0;
     bool headersParsed = false;
 };
 

--- a/Lib/eacp/Network/HTTPServer/HttpServer-Linux.cpp
+++ b/Lib/eacp/Network/HTTPServer/HttpServer-Linux.cpp
@@ -25,17 +25,18 @@ void ignoreSigPipe()
 
 void sendAll(int fd, const std::string& payload)
 {
-    auto sent = std::size_t {0};
+    auto total = (int) payload.size();
+    auto sent = 0;
 
-    while (sent < payload.size())
+    while (sent < total)
     {
-        auto n =
-            ::send(fd, payload.data() + sent, payload.size() - sent, MSG_NOSIGNAL);
+        auto n = ::send(
+            fd, payload.data() + sent, (std::size_t) (total - sent), MSG_NOSIGNAL);
 
         if (n <= 0)
             break;
 
-        sent += (std::size_t) n;
+        sent += (int) n;
     }
 }
 
@@ -248,7 +249,7 @@ void Server::Impl::handleConnection(int fd,
             return;
         }
 
-        auto state = parser.feed(buf, (std::size_t) n);
+        auto state = parser.feed(buf, (int) n);
 
         if (state == RequestParser::State::Invalid)
         {

--- a/Lib/eacp/Network/HTTPServer/HttpServer-Windows.cpp
+++ b/Lib/eacp/Network/HTTPServer/HttpServer-Windows.cpp
@@ -37,16 +37,17 @@ void ensureWinsockInitialized()
 
 void sendAll(SOCKET fd, const std::string& payload)
 {
-    auto sent = std::size_t {0};
+    auto total = (int) payload.size();
+    auto sent = 0;
 
-    while (sent < payload.size())
+    while (sent < total)
     {
-        auto n = ::send(fd, payload.data() + sent, (int) (payload.size() - sent), 0);
+        auto n = ::send(fd, payload.data() + sent, total - sent, 0);
 
         if (n <= 0)
             break;
 
-        sent += (std::size_t) n;
+        sent += (int) n;
     }
 }
 
@@ -257,7 +258,7 @@ void Server::Impl::handleConnection(SOCKET fd,
             return;
         }
 
-        auto state = parser.feed(buf, (std::size_t) n);
+        auto state = parser.feed(buf, (int) n);
 
         if (state == RequestParser::State::Invalid)
         {

--- a/Lib/eacp/Network/HTTPServer/HttpServer.mm
+++ b/Lib/eacp/Network/HTTPServer/HttpServer.mm
@@ -33,16 +33,17 @@ void ignoreSigPipe()
 
 void sendAll(int fd, const std::string& payload)
 {
-    auto sent = std::size_t {0};
+    auto total = (int) payload.size();
+    auto sent = 0;
 
-    while (sent < payload.size())
+    while (sent < total)
     {
-        auto n = ::send(fd, payload.data() + sent, payload.size() - sent, 0);
+        auto n = ::send(fd, payload.data() + sent, (std::size_t) (total - sent), 0);
 
         if (n <= 0)
             break;
 
-        sent += (std::size_t) n;
+        sent += (int) n;
     }
 }
 
@@ -313,7 +314,7 @@ void Server::Impl::onClientReadable(CFSocketRef cf)
         return;
     }
 
-    auto state = conn.parser.feed(buf, (std::size_t) n);
+    auto state = conn.parser.feed(buf, (int) n);
 
     if (state == RequestParser::State::Invalid)
     {

--- a/Lib/eacp/Network/IPC/Channel-Posix.cpp
+++ b/Lib/eacp/Network/IPC/Channel-Posix.cpp
@@ -222,24 +222,24 @@ NativeChannel
     }
 }
 
-std::size_t channelSend(NativeChannel channel, const char* data, std::size_t length)
+int channelSend(NativeChannel channel, const char* data, int length)
 {
-    auto sent = ::send((int) channel, data, length, sendFlags());
+    auto sent = ::send((int) channel, data, (std::size_t) length, sendFlags());
 
     if (sent < 0)
         fail("cannot send on channel");
 
-    return (std::size_t) sent;
+    return (int) sent;
 }
 
-std::size_t channelReceive(NativeChannel channel, char* buffer, std::size_t length)
+int channelReceive(NativeChannel channel, char* buffer, int length)
 {
-    auto received = ::recv((int) channel, buffer, length, 0);
+    auto received = ::recv((int) channel, buffer, (std::size_t) length, 0);
 
     if (received < 0)
         fail("cannot receive on channel");
 
-    return (std::size_t) received;
+    return (int) received;
 }
 
 void channelCancel(NativeChannel channel) noexcept

--- a/Lib/eacp/Network/IPC/Channel-Windows.cpp
+++ b/Lib/eacp/Network/IPC/Channel-Windows.cpp
@@ -5,8 +5,6 @@
 
 #include <aclapi.h>
 
-#include <algorithm>
-
 namespace eacp::IPC::detail
 {
 namespace
@@ -281,15 +279,15 @@ NativeChannel channelAccept(NativeChannel& listener,
     return connected;
 }
 
-std::size_t channelSend(NativeChannel channel, const char* data, std::size_t length)
+int channelSend(NativeChannel channel, const char* data, int length)
 {
     auto pipe = (HANDLE) channel;
-    auto toWrite = (DWORD) std::min<std::size_t>(length, MAXDWORD);
+    auto toWrite = (DWORD) length;
     auto operation = Operation {};
     auto written = DWORD {0};
 
     if (::WriteFile(pipe, data, toWrite, &written, operation.get()) != 0)
-        return written;
+        return (int) written;
 
     auto reason = ::GetLastError();
 
@@ -299,23 +297,23 @@ std::size_t channelSend(NativeChannel channel, const char* data, std::size_t len
     if (!completed(pipe, operation, written, reason))
         fail("cannot send on channel", reason);
 
-    return written;
+    return (int) written;
 }
 
-std::size_t channelReceive(NativeChannel channel, char* buffer, std::size_t length)
+int channelReceive(NativeChannel channel, char* buffer, int length)
 {
     auto pipe = (HANDLE) channel;
-    auto toRead = (DWORD) std::min<std::size_t>(length, MAXDWORD);
+    auto toRead = (DWORD) length;
     auto operation = Operation {};
     auto received = DWORD {0};
 
     if (::ReadFile(pipe, buffer, toRead, &received, operation.get()) != 0)
-        return received;
+        return (int) received;
 
     auto reason = ::GetLastError();
 
     if (reason == ERROR_IO_PENDING && completed(pipe, operation, received, reason))
-        return received;
+        return (int) received;
 
     if (endOfStream(reason))
         return 0;

--- a/Lib/eacp/Network/IPC/Channel.cpp
+++ b/Lib/eacp/Network/IPC/Channel.cpp
@@ -88,10 +88,12 @@ void Channel::send(std::string_view bytes)
     if (!isOpen())
         throw Error("send() on a closed channel");
 
-    auto sent = std::size_t {0};
-    while (sent < bytes.size())
-        sent += detail::channelSend(
-            impl->channel, bytes.data() + sent, bytes.size() - sent);
+    auto total = (int) bytes.size();
+    auto sent = 0;
+
+    while (sent < total)
+        sent +=
+            detail::channelSend(impl->channel, bytes.data() + sent, total - sent);
 }
 
 std::string Channel::receiveUntil(char delimiter)
@@ -109,12 +111,13 @@ std::string Channel::receiveUntil(char delimiter)
         }
 
         char chunk[4096];
-        auto received = detail::channelReceive(impl->channel, chunk, sizeof(chunk));
+        auto received =
+            detail::channelReceive(impl->channel, chunk, (int) sizeof(chunk));
 
         if (received == 0)
             throw Error("peer closed the channel before the delimiter arrived");
 
-        impl->buffered.append(chunk, received);
+        impl->buffered.append(chunk, (std::size_t) received);
     }
 }
 
@@ -128,23 +131,23 @@ std::string Channel::receiveLine()
     return line;
 }
 
-std::string Channel::receive(std::size_t maxBytes)
+std::string Channel::receive(int maxBytes)
 {
-    auto chunk = std::string(maxBytes, '\0');
-    chunk.resize(receive(chunk.data(), maxBytes));
+    auto chunk = std::string((std::size_t) maxBytes, '\0');
+    chunk.resize((std::size_t) receive(chunk.data(), maxBytes));
     return chunk;
 }
 
-std::size_t Channel::receive(char* buffer, std::size_t maxBytes)
+int Channel::receive(char* buffer, int maxBytes)
 {
     if (!isOpen())
         throw Error("receive() on a closed channel");
 
     if (!impl->buffered.empty())
     {
-        auto take = std::min(maxBytes, impl->buffered.size());
-        std::memcpy(buffer, impl->buffered.data(), take);
-        impl->buffered.erase(0, take);
+        auto take = std::min(maxBytes, (int) impl->buffered.size());
+        std::memcpy(buffer, impl->buffered.data(), (std::size_t) take);
+        impl->buffered.erase(0, (std::size_t) take);
         return take;
     }
 

--- a/Lib/eacp/Network/IPC/Channel.h
+++ b/Lib/eacp/Network/IPC/Channel.h
@@ -66,12 +66,12 @@ public:
     // Returns whatever a single read yields, up to maxBytes (draining any
     // bytes already buffered by receiveUntil first). An empty string means
     // the peer closed the stream cleanly.
-    std::string receive(std::size_t maxBytes = 4096);
+    std::string receive(int maxBytes = 4096);
 
     // As above, but into caller-owned storage - no per-read allocation, so
     // a large message can be assembled directly in its final buffer.
     // Returns the byte count; zero means the peer closed the stream cleanly.
-    std::size_t receive(char* buffer, std::size_t maxBytes);
+    int receive(char* buffer, int maxBytes);
 
 private:
     friend class ChannelServer;

--- a/Lib/eacp/Network/IPC/ChannelInternal.h
+++ b/Lib/eacp/Network/IPC/ChannelInternal.h
@@ -46,11 +46,11 @@ NativeChannel channelAccept(NativeChannel& listener,
 
 // Writes once, returning the number of bytes accepted (always > 0). Throws
 // IPC::Error on failure, including a peer that is gone.
-std::size_t channelSend(NativeChannel channel, const char* data, std::size_t length);
+int channelSend(NativeChannel channel, const char* data, int length);
 
 // Reads once into buffer, returning the byte count; 0 means the peer closed
 // the stream cleanly. Throws IPC::Error on failure.
-std::size_t channelReceive(NativeChannel channel, char* buffer, std::size_t length);
+int channelReceive(NativeChannel channel, char* buffer, int length);
 
 // Wakes I/O blocked on channel from another thread; a woken receive reports
 // a clean end of stream. POSIX shuts the socket down, which is permanent -

--- a/Lib/eacp/Network/IPC/Messenger.cpp
+++ b/Lib/eacp/Network/IPC/Messenger.cpp
@@ -1,6 +1,5 @@
 #include "Messenger.h"
 
-#include <array>
 #include <cstdint>
 #include <mutex>
 #include <thread>
@@ -19,38 +18,39 @@ constexpr auto interruptRetry = Time::MS {5};
 // A frame is a 32-bit little-endian byte count, then that many bytes. The
 // prefix is what frees payloads to carry anything - newlines, NULs, whole
 // files.
-constexpr auto headerSize = std::size_t {4};
+constexpr auto headerSize = 4;
 
 // Refuses lengths no honest peer would send, so a framing bug surfaces as
 // an error instead of a gigabyte allocation.
-constexpr auto maxMessageSize = std::size_t {1} << 30;
+constexpr auto maxMessageSize = 1 << 30;
 
-Array<char, headerSize> encodeHeader(std::size_t size)
+Array<char, headerSize> encodeHeader(int size)
 {
     auto header = Array<char, headerSize> {};
 
-    for (auto index = 0; index < (int) headerSize; ++index)
+    for (auto index = 0; index < headerSize; ++index)
         header[index] = (char) ((size >> (index * 8)) & 0xff);
 
     return header;
 }
 
-std::size_t decodeLength(const std::string& header)
+std::uint32_t decodeLength(const std::string& header)
 {
     auto size = std::uint32_t {0};
 
-    for (auto index = std::size_t {0}; index < headerSize; ++index)
-        size |= (std::uint32_t) (unsigned char) header[index] << (index * 8);
+    for (auto index = 0; index < headerSize; ++index)
+        size |= (std::uint32_t) (unsigned char) header[(std::size_t) index]
+                << (index * 8);
 
     return size;
 }
 
 // Fills result with exactly count bytes, sized once and written in place;
 // false means the stream ended first, leaving what did arrive in result.
-bool receiveExactly(Channel& channel, std::size_t count, std::string& result)
+bool receiveExactly(Channel& channel, int count, std::string& result)
 {
-    result.resize(count);
-    auto received = std::size_t {0};
+    result.resize((std::size_t) count);
+    auto received = 0;
 
     while (received < count)
     {
@@ -58,7 +58,7 @@ bool receiveExactly(Channel& channel, std::size_t count, std::string& result)
 
         if (chunk == 0)
         {
-            result.resize(received);
+            result.resize((std::size_t) received);
             return false;
         }
 
@@ -84,12 +84,12 @@ std::optional<std::string> receiveFrame(Channel& channel)
 
     auto length = decodeLength(header);
 
-    if (length > maxMessageSize)
+    if (length > (std::uint32_t) maxMessageSize)
         throw Error("peer sent an implausible message length");
 
     auto message = std::string {};
 
-    if (!receiveExactly(channel, length, message))
+    if (!receiveExactly(channel, (int) length, message))
         throw Error("peer closed the channel mid-message");
 
     return message;
@@ -169,7 +169,7 @@ bool Messenger::isConnected() const
 
 void Messenger::send(const std::string& message)
 {
-    if (message.size() > maxMessageSize)
+    if (message.size() > (std::size_t) maxMessageSize)
         throw Error("message is too large to frame");
 
     auto guard = std::lock_guard {impl->mutex};
@@ -181,8 +181,8 @@ void Messenger::send(const std::string& message)
     {
         // Header and payload go out as two writes so framing never copies
         // the payload - the mutex keeps them adjacent on the stream.
-        auto header = encodeHeader(message.size());
-        impl->channel->send({header.data(), headerSize});
+        auto header = encodeHeader((int) message.size());
+        impl->channel->send({header.data(), (std::size_t) headerSize});
         impl->channel->send(message);
     }
     catch (const Error&)

--- a/Lib/eacp/Network/TCP/Connection-Posix.cpp
+++ b/Lib/eacp/Network/TCP/Connection-Posix.cpp
@@ -164,28 +164,28 @@ void socketClose(NativeSocket socket) noexcept
         ::close((int) socket);
 }
 
-std::size_t socketSend(NativeSocket socket, const char* data, std::size_t length)
+int socketSend(NativeSocket socket, const char* data, int length)
 {
-    auto sent = ::send((int) socket, data, length, sendFlags());
+    auto sent = ::send((int) socket, data, (std::size_t) length, sendFlags());
     if (sent < 0)
     {
         if (timedOut())
             throw TimeoutError("send timed out");
         throwErrno("send");
     }
-    return (std::size_t) sent;
+    return (int) sent;
 }
 
-std::size_t socketReceive(NativeSocket socket, char* buffer, std::size_t length)
+int socketReceive(NativeSocket socket, char* buffer, int length)
 {
-    auto received = ::recv((int) socket, buffer, length, 0);
+    auto received = ::recv((int) socket, buffer, (std::size_t) length, 0);
     if (received < 0)
     {
         if (timedOut())
             throw TimeoutError("receive timed out");
         throwErrno("receive");
     }
-    return (std::size_t) received;
+    return (int) received;
 }
 
 NativeSocket

--- a/Lib/eacp/Network/TCP/Connection-Windows.cpp
+++ b/Lib/eacp/Network/TCP/Connection-Windows.cpp
@@ -167,28 +167,28 @@ void socketClose(NativeSocket socket) noexcept
         ::closesocket((SOCKET) socket);
 }
 
-std::size_t socketSend(NativeSocket socket, const char* data, std::size_t length)
+int socketSend(NativeSocket socket, const char* data, int length)
 {
-    auto sent = ::send((SOCKET) socket, data, (int) length, 0);
+    auto sent = ::send((SOCKET) socket, data, length, 0);
     if (sent == SOCKET_ERROR)
     {
         if (timedOut())
             throw TimeoutError("send timed out");
         throwLastError("send");
     }
-    return (std::size_t) sent;
+    return (int) sent;
 }
 
-std::size_t socketReceive(NativeSocket socket, char* buffer, std::size_t length)
+int socketReceive(NativeSocket socket, char* buffer, int length)
 {
-    auto received = ::recv((SOCKET) socket, buffer, (int) length, 0);
+    auto received = ::recv((SOCKET) socket, buffer, length, 0);
     if (received == SOCKET_ERROR)
     {
         if (timedOut())
             throw TimeoutError("receive timed out");
         throwLastError("receive");
     }
-    return (std::size_t) received;
+    return (int) received;
 }
 
 NativeSocket

--- a/Lib/eacp/Network/TCP/Connection.cpp
+++ b/Lib/eacp/Network/TCP/Connection.cpp
@@ -71,10 +71,11 @@ void Connection::send(std::string_view bytes)
     if (!isOpen())
         throw Error("send() on a closed TCP connection");
 
-    auto sent = std::size_t {0};
-    while (sent < bytes.size())
-        sent += detail::socketSend(
-            impl->socket, bytes.data() + sent, bytes.size() - sent);
+    auto total = (int) bytes.size();
+    auto sent = 0;
+
+    while (sent < total)
+        sent += detail::socketSend(impl->socket, bytes.data() + sent, total - sent);
 }
 
 std::string Connection::receiveUntil(char delimiter)
@@ -92,11 +93,12 @@ std::string Connection::receiveUntil(char delimiter)
         }
 
         char chunk[4096];
-        auto received = detail::socketReceive(impl->socket, chunk, sizeof(chunk));
+        auto received =
+            detail::socketReceive(impl->socket, chunk, (int) sizeof(chunk));
         if (received == 0)
             throw Error("peer closed the connection before the delimiter arrived");
 
-        impl->buffered.append(chunk, received);
+        impl->buffered.append(chunk, (std::size_t) received);
     }
 }
 
@@ -108,22 +110,23 @@ std::string Connection::receiveLine()
     return line;
 }
 
-std::string Connection::receive(std::size_t maxBytes)
+std::string Connection::receive(int maxBytes)
 {
     if (!isOpen())
         throw Error("receive() on a closed TCP connection");
 
     if (!impl->buffered.empty())
     {
-        auto take = std::min(maxBytes, impl->buffered.size());
-        auto out = impl->buffered.substr(0, take);
-        impl->buffered.erase(0, take);
+        auto take = std::min(maxBytes, (int) impl->buffered.size());
+        auto out = impl->buffered.substr(0, (std::size_t) take);
+        impl->buffered.erase(0, (std::size_t) take);
         return out;
     }
 
-    auto chunk = std::string(maxBytes, '\0');
-    auto received = detail::socketReceive(impl->socket, chunk.data(), chunk.size());
-    chunk.resize(received);
+    auto chunk = std::string((std::size_t) maxBytes, '\0');
+    auto received =
+        detail::socketReceive(impl->socket, chunk.data(), (int) chunk.size());
+    chunk.resize((std::size_t) received);
     return chunk;
 }
 

--- a/Lib/eacp/Network/TCP/Connection.h
+++ b/Lib/eacp/Network/TCP/Connection.h
@@ -79,7 +79,7 @@ public:
     // Returns whatever a single read yields, up to maxBytes (draining any
     // bytes already buffered by receiveUntil first). An empty string means
     // the peer closed the stream cleanly.
-    std::string receive(std::size_t maxBytes = 4096);
+    std::string receive(int maxBytes = 4096);
 
 private:
     Connection();

--- a/Lib/eacp/Network/TCP/ConnectionInternal.h
+++ b/Lib/eacp/Network/TCP/ConnectionInternal.h
@@ -26,11 +26,11 @@ void socketClose(NativeSocket socket) noexcept;
 
 // Writes once, returning the number of bytes accepted (always > 0). Throws
 // TCP::Error on timeout or failure.
-std::size_t socketSend(NativeSocket socket, const char* data, std::size_t length);
+int socketSend(NativeSocket socket, const char* data, int length);
 
 // Reads once into buffer, returning the byte count; 0 means the peer closed
 // the stream cleanly. Throws TCP::Error on timeout or failure.
-std::size_t socketReceive(NativeSocket socket, char* buffer, std::size_t length);
+int socketReceive(NativeSocket socket, char* buffer, int length);
 
 // Opens a listening socket on port (0 picks an ephemeral one), writing the
 // actually-bound port back to boundPort. Throws TCP::Error on failure.

--- a/Lib/eacp/Network/WebSocket/Protocol.cpp
+++ b/Lib/eacp/Network/WebSocket/Protocol.cpp
@@ -2,7 +2,6 @@
 
 #include <eacp/Core/Utils/Base64.h>
 
-#include <array>
 #include <random>
 
 namespace eacp::WebSocket::Protocol
@@ -17,9 +16,9 @@ std::uint32_t webSocketRotateLeft(std::uint32_t value, int bits)
     return (value << bits) | (value >> (32 - bits));
 }
 
-std::uint8_t webSocketByteAt(std::string_view bytes, std::size_t index)
+std::uint8_t webSocketByteAt(std::string_view bytes, int index)
 {
-    return (std::uint8_t) bytes[index];
+    return (std::uint8_t) bytes[(std::size_t) index];
 }
 
 void webSocketAppendBigEndian(std::string& out, std::uint64_t value, int bytes)
@@ -67,16 +66,16 @@ WebSocketSha1Round
 // eacp needs and a crypto dependency would cost more than sixty lines.
 std::string webSocketSha1(std::string_view input)
 {
-    auto hash = std::array<std::uint32_t, 5> {
+    auto hash = Array<std::uint32_t, 5> {
         0x67452301, 0xEFCDAB89, 0x98BADCFE, 0x10325476, 0xC3D2E1F0};
 
     auto message = webSocketPadForSha1(input);
 
-    for (auto chunk = std::size_t {0}; chunk < message.size(); chunk += 64)
+    for (auto chunk = 0; chunk < (int) message.size(); chunk += 64)
     {
-        auto schedule = std::array<std::uint32_t, 80> {};
+        auto schedule = Array<std::uint32_t, 80> {};
 
-        for (auto i = std::size_t {0}; i < 16; ++i)
+        for (auto i = 0; i < 16; ++i)
         {
             auto at = chunk + i * 4;
             schedule[i] = ((std::uint32_t) webSocketByteAt(message, at) << 24)
@@ -85,7 +84,7 @@ std::string webSocketSha1(std::string_view input)
                           | (std::uint32_t) webSocketByteAt(message, at + 3);
         }
 
-        for (auto i = std::size_t {16}; i < schedule.size(); ++i)
+        for (auto i = 16; i < schedule.size(); ++i)
             schedule[i] =
                 webSocketRotateLeft(schedule[i - 3] ^ schedule[i - 8]
                                         ^ schedule[i - 14] ^ schedule[i - 16],
@@ -101,7 +100,7 @@ std::string webSocketSha1(std::string_view input)
         {
             auto round = webSocketSha1Round(step, b, c, d);
             auto next = webSocketRotateLeft(a, 5) + round.mix + e + round.constant
-                        + schedule[(std::size_t) step];
+                        + schedule[step];
 
             e = d;
             d = c;
@@ -125,12 +124,12 @@ std::string webSocketSha1(std::string_view input)
     return digest;
 }
 
-std::array<std::uint8_t, 4> webSocketRandomMask()
+Array<std::uint8_t, 4> webSocketRandomMask()
 {
     static thread_local auto engine = std::mt19937(std::random_device {}());
     auto bytes = std::uniform_int_distribution<int>(0, 255);
 
-    auto key = std::array<std::uint8_t, 4> {};
+    auto key = Array<std::uint8_t, 4> {};
 
     for (auto& byte: key)
         byte = (std::uint8_t) bytes(engine);
@@ -166,19 +165,17 @@ Opcode webSocketOpcodeFrom(std::uint8_t bits)
     throw Error("Unknown WebSocket opcode");
 }
 
-std::uint64_t webSocketReadBigEndian(std::string_view buffer,
-                                     std::size_t at,
-                                     std::size_t bytes)
+std::uint64_t webSocketReadBigEndian(std::string_view buffer, int at, int bytes)
 {
     auto value = std::uint64_t {0};
 
-    for (auto i = std::size_t {0}; i < bytes; ++i)
+    for (auto i = 0; i < bytes; ++i)
         value = (value << 8) | webSocketByteAt(buffer, at + i);
 
     return value;
 }
 
-void webSocketAppendLength(std::string& out, std::size_t size, std::uint8_t maskBit)
+void webSocketAppendLength(std::string& out, int size, std::uint8_t maskBit)
 {
     if (size < 126)
     {
@@ -211,7 +208,7 @@ std::string encode(const Frame& frame, bool masked)
 
     out.push_back((char) ((frame.fin ? 0x80 : 0x00) | (std::uint8_t) frame.opcode));
 
-    webSocketAppendLength(out, frame.payload.size(), masked ? 0x80 : 0x00);
+    webSocketAppendLength(out, (int) frame.payload.size(), masked ? 0x80 : 0x00);
 
     if (!masked)
     {
@@ -224,7 +221,7 @@ std::string encode(const Frame& frame, bool masked)
     for (auto byte: key)
         out.push_back((char) byte);
 
-    for (auto i = std::size_t {0}; i < frame.payload.size(); ++i)
+    for (auto i = 0; i < (int) frame.payload.size(); ++i)
         out.push_back((char) (webSocketByteAt(frame.payload, i) ^ key[i % 4]));
 
     return out;
@@ -256,13 +253,13 @@ std::optional<Decoded> decode(std::string_view buffer)
     }
 
     auto length = (std::uint64_t) lengthCode;
-    auto header = std::size_t {2};
+    auto header = 2;
 
     if (lengthCode == 126)
     {
         header = 4;
 
-        if (buffer.size() < header)
+        if (buffer.size() < (std::size_t) header)
             return std::nullopt;
 
         length = webSocketReadBigEndian(buffer, 2, 2);
@@ -271,7 +268,7 @@ std::optional<Decoded> decode(std::string_view buffer)
     {
         header = 10;
 
-        if (buffer.size() < header)
+        if (buffer.size() < (std::size_t) header)
             return std::nullopt;
 
         length = webSocketReadBigEndian(buffer, 2, 8);
@@ -280,30 +277,31 @@ std::optional<Decoded> decode(std::string_view buffer)
             throw Error("Frame length with its high bit set");
     }
 
-    auto key = std::array<std::uint8_t, 4> {};
+    auto key = Array<std::uint8_t, 4> {};
 
     if (masked)
     {
-        if (buffer.size() < header + 4)
+        if (buffer.size() < (std::size_t) (header + 4))
             return std::nullopt;
 
-        for (auto i = std::size_t {0}; i < key.size(); ++i)
+        for (auto i = 0; i < key.size(); ++i)
             key[i] = webSocketByteAt(buffer, header + i);
 
         header += 4;
     }
 
-    if (length > buffer.size() - header)
+    if (length > buffer.size() - (std::size_t) header)
         return std::nullopt;
 
     auto decoded = Decoded();
-    decoded.consumed = header + (std::size_t) length;
+    decoded.consumed = header + (int) length;
     decoded.frame.opcode = opcode;
     decoded.frame.fin = fin;
-    decoded.frame.payload = std::string(buffer.substr(header, (std::size_t) length));
+    decoded.frame.payload =
+        std::string(buffer.substr((std::size_t) header, (std::size_t) length));
 
     if (masked)
-        for (auto i = std::size_t {0}; i < decoded.frame.payload.size(); ++i)
+        for (auto i = 0; i < (int) decoded.frame.payload.size(); ++i)
             decoded.frame.payload[i] =
                 (char) (webSocketByteAt(decoded.frame.payload, i) ^ key[i % 4]);
 

--- a/Lib/eacp/Network/WebSocket/Protocol.h
+++ b/Lib/eacp/Network/WebSocket/Protocol.h
@@ -28,7 +28,7 @@ struct Frame
 struct Decoded
 {
     Frame frame;
-    std::size_t consumed = 0;
+    int consumed = 0;
 };
 
 struct Error : std::runtime_error

--- a/Lib/eacp/Network/WebSocket/Server.cpp
+++ b/Lib/eacp/Network/WebSocket/Server.cpp
@@ -9,7 +9,6 @@
 #include <atomic>
 #include <mutex>
 #include <thread>
-#include <vector>
 
 namespace eacp::WebSocket
 {
@@ -24,15 +23,15 @@ constexpr auto webSocketServerSlice = Time::MS {200};
 // request may hold a thread of its own.
 constexpr auto webSocketServerHandshakeTimeout = Time::MS {10000};
 
-constexpr auto webSocketServerReadChunk = std::size_t {65536};
+constexpr auto webSocketServerReadChunk = 65536;
 constexpr auto webSocketServerMaxRequestLines = 100;
 
 // §5.5's cap on a control frame's payload, less the two bytes of the code.
-constexpr auto webSocketServerMaxCloseReason = std::size_t {123};
+constexpr auto webSocketServerMaxCloseReason = 123;
 
 // A frame header at its longest - two bytes, eight of length, four of mask -
 // which is the slack a limit on the message has to leave the framing itself.
-constexpr auto webSocketServerFrameHeader = std::size_t {14};
+constexpr auto webSocketServerFrameHeader = 14;
 
 TCP::Timeouts webSocketServerTimeouts()
 {
@@ -45,9 +44,9 @@ std::string webSocketServerBadRequest()
            "Connection: close\r\n\r\n";
 }
 
-std::vector<std::string> webSocketServerCommaList(std::string_view text)
+Vector<std::string> webSocketServerCommaList(std::string_view text)
 {
-    auto items = std::vector<std::string>();
+    auto items = Vector<std::string>();
 
     while (!text.empty())
     {
@@ -55,7 +54,7 @@ std::vector<std::string> webSocketServerCommaList(std::string_view text)
         auto piece = Strings::trim(text.substr(0, comma));
 
         if (!piece.empty())
-            items.push_back(std::move(piece));
+            items.add(std::move(piece));
 
         if (comma == std::string_view::npos)
             break;
@@ -95,13 +94,14 @@ std::string webSocketServerHandshakeResponse(const std::string& key,
 
 Protocol::Frame webSocketServerCloseFrame(int code, std::string_view reason)
 {
-    auto fits = reason.size() < webSocketServerMaxCloseReason
-                    ? reason.size()
+    auto length = (int) reason.size();
+    auto fits = length < webSocketServerMaxCloseReason
+                    ? length
                     : webSocketServerMaxCloseReason;
 
     return {Protocol::Opcode::close,
             true,
-            Protocol::encodeClose(code, reason.substr(0, fits))};
+            Protocol::encodeClose(code, reason.substr(0, (std::size_t) fits))};
 }
 
 // The upgrade request as the server reads it, header names lowercased the way
@@ -444,7 +444,10 @@ private:
 
             // A frame whose declared length alone is past the limit is caught
             // here, before the bytes behind it are ever waited for.
-            if (buffer.size() > options.maxMessageSize + webSocketServerFrameHeader)
+            auto declared =
+                (std::int64_t) options.maxMessageSize + webSocketServerFrameHeader;
+
+            if ((std::int64_t) buffer.size() > declared)
                 return closeWith(1009, "message too big");
 
             if (auto settled = drainFrames(buffer); settled.has_value())
@@ -472,7 +475,7 @@ private:
             if (!decoded.has_value())
                 return std::nullopt;
 
-            buffer.erase(0, decoded->consumed);
+            buffer.erase(0, (std::size_t) decoded->consumed);
 
             if (auto settled = handleFrame(decoded->frame); settled.has_value())
                 return settled;
@@ -510,7 +513,10 @@ private:
 
     std::optional<CloseStatus> collect(const Protocol::Frame& frame)
     {
-        if (assembly.size() + frame.payload.size() > options.maxMessageSize)
+        auto assembled =
+            (std::int64_t) assembly.size() + (std::int64_t) frame.payload.size();
+
+        if (assembled > options.maxMessageSize)
             return closeWith(1009, "message too big");
 
         assembly += frame.payload;
@@ -676,10 +682,10 @@ struct Server::Impl
         return listener.has_value() ? listener->port() : 0;
     }
 
-    std::size_t clientCount() const
+    int clientCount() const
     {
         auto lock = std::scoped_lock(clientsMutex);
-        auto count = std::size_t {0};
+        auto count = 0;
 
         for (const auto& [id, client]: clients)
             if (client->isConnected())
@@ -841,7 +847,7 @@ std::uint16_t Server::boundPort() const
     return impl->boundPort();
 }
 
-std::size_t Server::clientCount() const
+int Server::clientCount() const
 {
     return impl->clientCount();
 }

--- a/Lib/eacp/Network/WebSocket/Server.h
+++ b/Lib/eacp/Network/WebSocket/Server.h
@@ -24,7 +24,7 @@ struct ServerOptions
 {
     BindInterface bindTo = BindInterface::loopback;
     Vector<std::string> protocols;
-    std::size_t maxMessageSize = 64 * 1024 * 1024;
+    int maxMessageSize = 64 * 1024 * 1024;
     Time::MS closeTimeout {5000};
 };
 
@@ -37,8 +37,8 @@ struct ServerCallbacks
 {
     std::function<void(ClientId, const Handshake&)> onConnect =
         [](ClientId, const Handshake&) {};
-    std::function<void(ClientId, const Message&)> onMessage =
-        [](ClientId, const Message&) {};
+    std::function<void(ClientId, const Message&)> onMessage = [](ClientId,
+                                                                 const Message&) {};
     std::function<void(ClientId, const CloseStatus&)> onDisconnect =
         [](ClientId, const CloseStatus&) {};
     std::function<void(const std::string& error)> onError =
@@ -63,7 +63,7 @@ public:
 
     [[nodiscard]] bool isListening() const;
     [[nodiscard]] std::uint16_t boundPort() const;
-    [[nodiscard]] std::size_t clientCount() const;
+    [[nodiscard]] int clientCount() const;
 
     // Dropped for an id that is not connected
     void send(ClientId client, std::string_view text);

--- a/Lib/eacp/Network/WebSocket/WebSocket-Linux.cpp
+++ b/Lib/eacp/Network/WebSocket/WebSocket-Linux.cpp
@@ -21,7 +21,6 @@
 #endif
 
 #if EACP_WEBSOCKET_HAS_CURL_WS
-#include <array>
 #include <fcntl.h>
 #include <poll.h>
 #include <unistd.h>
@@ -72,8 +71,8 @@ bool webSocketStartsWith(std::string_view line, std::string_view lowercaseName)
     if (line.size() < lowercaseName.size())
         return false;
 
-    for (auto i = std::size_t {0}; i < lowercaseName.size(); ++i)
-        if (webSocketLower(line[i]) != lowercaseName[i])
+    for (auto i = 0; i < (int) lowercaseName.size(); ++i)
+        if (webSocketLower(line[(std::size_t) i]) != lowercaseName[(std::size_t) i])
             return false;
 
     return true;
@@ -203,7 +202,7 @@ struct WebSocketOutbound
 {
     std::string payload;
     unsigned int flags = CURLWS_TEXT;
-    std::size_t offset = 0;
+    int offset = 0;
 };
 
 // One worker thread owns the easy handle for the connection's whole life: a
@@ -451,6 +450,8 @@ private:
     {
         auto& item = *pending;
 
+        auto total = (int) item.payload.size();
+
         for (;;)
         {
             auto sent = std::size_t {0};
@@ -460,7 +461,7 @@ private:
 
             auto result = curl_ws_send(handle,
                                        item.payload.data() + item.offset,
-                                       item.payload.size() - item.offset,
+                                       (std::size_t) (total - item.offset),
                                        &sent,
                                        0,
                                        flags);
@@ -468,9 +469,9 @@ private:
             if (result != CURLE_OK)
                 return result;
 
-            item.offset += sent;
+            item.offset += (int) sent;
 
-            if (item.offset >= item.payload.size())
+            if (item.offset >= total)
                 return CURLE_OK;
         }
     }
@@ -563,9 +564,12 @@ private:
         }
 
         auto left =
-            meta.bytesleft > 0 ? (std::size_t) meta.bytesleft : std::size_t {0};
+            meta.bytesleft > 0 ? (std::int64_t) meta.bytesleft : std::int64_t {0};
 
-        if (messagePayload.size() + chunk.size() + left > maxMessageSize)
+        auto assembled = (std::int64_t) messagePayload.size()
+                         + (std::int64_t) chunk.size() + left;
+
+        if (assembled > maxMessageSize)
             return rejectOversized();
 
         messagePayload.append(chunk);
@@ -606,7 +610,8 @@ private:
         }
 
         auto deadline = Time::Deadline {Time::MS {controlSendTimeoutMs}};
-        auto offset = std::size_t {0};
+        auto total = (int) payload.size();
+        auto offset = 0;
 
         while (!stopRequested.load())
         {
@@ -616,16 +621,16 @@ private:
 
             auto result = curl_ws_send(handle,
                                        payload.data() + offset,
-                                       payload.size() - offset,
+                                       (std::size_t) (total - offset),
                                        &sent,
                                        0,
                                        frameFlags);
 
             if (result == CURLE_OK)
             {
-                offset += sent;
+                offset += (int) sent;
 
-                if (offset >= payload.size())
+                if (offset >= total)
                     return;
 
                 continue;
@@ -656,8 +661,8 @@ private:
         auto socket = CURL_SOCKET_BAD;
         curl_easy_getinfo(handle, CURLINFO_ACTIVESOCKET, &socket);
 
-        auto fds = std::array<pollfd, 2> {};
-        auto count = nfds_t {0};
+        auto fds = Array<pollfd, 2> {};
+        auto count = 0;
 
         if (socket != CURL_SOCKET_BAD)
         {
@@ -679,7 +684,7 @@ private:
             return;
         }
 
-        ::poll(fds.data(), count, timeoutMs);
+        ::poll(fds.data(), (nfds_t) count, timeoutMs);
         wake.drain();
     }
 
@@ -720,7 +725,7 @@ private:
 
     std::shared_ptr<Sink> sink;
     std::string url;
-    std::size_t maxMessageSize = 0;
+    int maxMessageSize = 0;
 
     CURL* handle = nullptr;
     CURLM* multi = nullptr;

--- a/Lib/eacp/Network/WebSocket/WebSocket-Windows.cpp
+++ b/Lib/eacp/Network/WebSocket/WebSocket-Windows.cpp
@@ -28,9 +28,9 @@ namespace
 {
 
 constexpr auto webSocketSwitchingProtocols = 101;
-constexpr auto webSocketReceiveChunkSize = std::size_t {64 * 1024};
-constexpr auto webSocketErrorTextLength = std::size_t {512};
-constexpr auto webSocketMaxCloseReasonLength = std::size_t {123};
+constexpr auto webSocketReceiveChunkSize = 64 * 1024;
+constexpr auto webSocketErrorTextLength = 512;
+constexpr auto webSocketMaxCloseReasonLength = 123;
 constexpr auto webSocketDefaultTimeoutMilliseconds = std::int64_t {30000};
 constexpr auto webSocketKeepAliveMilliseconds = DWORD {30000};
 
@@ -454,7 +454,7 @@ private:
 
     void receiveLoop()
     {
-        auto buffer = std::string(webSocketReceiveChunkSize, '\0');
+        auto buffer = std::string((std::size_t) webSocketReceiveChunkSize, '\0');
         auto payload = std::string();
 
         while (!tearingDown.load())
@@ -490,7 +490,9 @@ private:
                 return;
             }
 
-            if (payload.size() + read > options.maxMessageSize)
+            auto assembled = (std::int64_t) payload.size() + (std::int64_t) read;
+
+            if (assembled > options.maxMessageSize)
             {
                 reportOversizedMessage(socket);
                 return;
@@ -575,7 +577,7 @@ private:
 
     void shutdown(HINTERNET socket, USHORT status, const std::string& reason)
     {
-        auto text = reason.substr(0, webSocketMaxCloseReasonLength);
+        auto text = reason.substr(0, (std::size_t) webSocketMaxCloseReasonLength);
         auto length = static_cast<DWORD>(text.size());
 
         auto lock = std::scoped_lock(sendMutex);

--- a/Lib/eacp/Network/WebSocket/WebSocket.h
+++ b/Lib/eacp/Network/WebSocket/WebSocket.h
@@ -42,7 +42,7 @@ struct Options
     Vector<std::string> protocols;
     Time::MS connectTimeout {15000};
     Time::MS closeTimeout {5000};
-    std::size_t maxMessageSize = 64 * 1024 * 1024;
+    int maxMessageSize = 64 * 1024 * 1024;
 };
 
 // Every callback runs on the message thread, none inside a Connection call

--- a/Lib/eacp/Network/WebSocket/WebSocket.mm
+++ b/Lib/eacp/Network/WebSocket/WebSocket.mm
@@ -24,7 +24,7 @@ namespace eacp::WebSocket
 namespace
 {
 
-constexpr auto webSocketMaxCloseReasonLength = std::size_t {123};
+constexpr auto webSocketMaxCloseReasonLength = 123;
 
 // A close frame Network.framework has no receive pending for is not held
 // back: it ends the connection as ENOTCONN instead, and its code and reason
@@ -50,10 +50,10 @@ int webSocketEchoableCode(int code)
 // the code has taken two.
 std::string webSocketTrimReason(const std::string& reason)
 {
-    if (reason.size() <= webSocketMaxCloseReasonLength)
+    if ((int) reason.size() <= webSocketMaxCloseReasonLength)
         return reason;
 
-    return reason.substr(0, webSocketMaxCloseReasonLength);
+    return reason.substr(0, (std::size_t) webSocketMaxCloseReasonLength);
 }
 
 bool webSocketIsSecureUrl(const std::string& url)
@@ -155,7 +155,8 @@ nw_parameters_t webSocketParametersFor(const std::string& url,
     auto webSocket = nw_ws_create_options(nw_ws_version_13);
 
     nw_ws_options_set_auto_reply_ping(webSocket, true);
-    nw_ws_options_set_maximum_message_size(webSocket, options.maxMessageSize);
+    nw_ws_options_set_maximum_message_size(webSocket,
+                                           (size_t) options.maxMessageSize);
 
     for (const auto& [name, value]: options.headers)
         nw_ws_options_add_additional_header(webSocket, name.c_str(), value.c_str());

--- a/Lib/eacp/SIMD/Backend/Avx2.h
+++ b/Lib/eacp/SIMD/Backend/Avx2.h
@@ -48,7 +48,7 @@ struct Avx2
         }
 
         __m256i v;
-        static constexpr std::size_t lanes = 8;
+        static constexpr int lanes = 8;
     };
 };
 

--- a/Lib/eacp/SIMD/Backend/Neon.h
+++ b/Lib/eacp/SIMD/Backend/Neon.h
@@ -44,7 +44,7 @@ struct Neon
         }
 
         uint32x4_t v;
-        static constexpr std::size_t lanes = 4;
+        static constexpr int lanes = 4;
     };
 
     // The four channels of one RGBA pixel held as floats (128-bit).

--- a/Lib/eacp/SIMD/Backend/Scalar.h
+++ b/Lib/eacp/SIMD/Backend/Scalar.h
@@ -43,7 +43,7 @@ struct Scalar
         }
 
         std::uint32_t v;
-        static constexpr std::size_t lanes = 1;
+        static constexpr int lanes = 1;
     };
 
     // The four channels of one RGBA pixel held as floats.

--- a/Lib/eacp/SIMD/Backend/Sse2.h
+++ b/Lib/eacp/SIMD/Backend/Sse2.h
@@ -47,7 +47,7 @@ struct Sse2
         }
 
         __m128i v;
-        static constexpr std::size_t lanes = 4;
+        static constexpr int lanes = 4;
     };
 
     // The four channels of one RGBA pixel held as floats (128-bit).

--- a/Lib/eacp/SIMD/Backends.h
+++ b/Lib/eacp/SIMD/Backends.h
@@ -13,9 +13,7 @@
 namespace eacp::simd::backends
 {
 
-void swapRedBlue_scalar(const std::uint8_t* in,
-                        std::uint8_t* out,
-                        std::size_t pixelCount);
+void swapRedBlue_scalar(const std::uint8_t* in, std::uint8_t* out, int pixelCount);
 
 void resizeBilinear_scalar(const std::uint8_t* src,
                            int srcWidth,
@@ -33,9 +31,7 @@ void warpAffineInverse_scalar(const std::uint8_t* src,
                               int dstHeight);
 
 #if defined(__x86_64__) || defined(_M_X64)
-void swapRedBlue_sse2(const std::uint8_t* in,
-                      std::uint8_t* out,
-                      std::size_t pixelCount);
+void swapRedBlue_sse2(const std::uint8_t* in, std::uint8_t* out, int pixelCount);
 void resizeBilinear_sse2(const std::uint8_t* src,
                          int srcWidth,
                          int srcHeight,
@@ -50,14 +46,10 @@ void warpAffineInverse_sse2(const std::uint8_t* src,
                             int dstWidth,
                             int dstHeight);
 #if defined(EACP_SIMD_HAS_AVX2)
-void swapRedBlue_avx2(const std::uint8_t* in,
-                      std::uint8_t* out,
-                      std::size_t pixelCount);
+void swapRedBlue_avx2(const std::uint8_t* in, std::uint8_t* out, int pixelCount);
 #endif
 #elif defined(__aarch64__) || defined(_M_ARM64)
-void swapRedBlue_neon(const std::uint8_t* in,
-                      std::uint8_t* out,
-                      std::size_t pixelCount);
+void swapRedBlue_neon(const std::uint8_t* in, std::uint8_t* out, int pixelCount);
 void resizeBilinear_neon(const std::uint8_t* src,
                          int srcWidth,
                          int srcHeight,

--- a/Lib/eacp/SIMD/Dispatch/Dispatch.cpp
+++ b/Lib/eacp/SIMD/Dispatch/Dispatch.cpp
@@ -11,7 +11,7 @@ namespace eacp::simd
 namespace
 {
 
-using SwapFn = void (*)(const std::uint8_t*, std::uint8_t*, std::size_t);
+using SwapFn = void (*)(const std::uint8_t*, std::uint8_t*, int);
 
 SwapFn pickSwapRedBlue() noexcept
 {
@@ -61,14 +61,14 @@ WarpFn pickWarpAffineInverse() noexcept
 
 } // namespace
 
-void swapRedBlue(const std::uint8_t* in, std::uint8_t* out, std::size_t pixelCount)
+void swapRedBlue(const std::uint8_t* in, std::uint8_t* out, int pixelCount)
 {
     static const SwapFn fn = pickSwapRedBlue();
     fn(in, out, pixelCount);
 }
 
 void convertBgraToRgba(const std::uint8_t* src,
-                       std::size_t srcBytesPerRow,
+                       int srcBytesPerRow,
                        std::uint8_t* dst,
                        int width,
                        int height)
@@ -76,22 +76,21 @@ void convertBgraToRgba(const std::uint8_t* src,
     if (src == nullptr || dst == nullptr || width <= 0 || height <= 0)
         return;
 
-    const auto rowPixels = static_cast<std::size_t>(width);
-    const auto tightRowBytes = rowPixels * 4;
+    const auto tightRowBytes = width * 4;
 
     // Tightly-packed frames swap in a single pass; padded rows go one by one.
     // Either way the per-pixel work runs through the dispatched swapRedBlue, and
     // this whole routine is compiled at the SIMD module's forced optimization.
     if (srcBytesPerRow == tightRowBytes)
     {
-        swapRedBlue(src, dst, rowPixels * static_cast<std::size_t>(height));
+        swapRedBlue(src, dst, width * height);
     }
     else
     {
         for (auto y = 0; y < height; ++y)
-            swapRedBlue(src + static_cast<std::size_t>(y) * srcBytesPerRow,
-                        dst + static_cast<std::size_t>(y) * tightRowBytes,
-                        rowPixels);
+            swapRedBlue(src + static_cast<std::ptrdiff_t>(y) * srcBytesPerRow,
+                        dst + static_cast<std::ptrdiff_t>(y) * tightRowBytes,
+                        width);
     }
 }
 

--- a/Lib/eacp/SIMD/Kernels/SwapRedBlue.h
+++ b/Lib/eacp/SIMD/Kernels/SwapRedBlue.h
@@ -14,29 +14,30 @@ namespace eacp::simd::kernels
 // u32 R | G<<8 | B<<16 | A<<24, so the swap is: red (bits 0..7) -> bits 16..23,
 // blue (bits 16..23) -> bits 0..7, green/alpha untouched.
 template <class B>
-void swapRedBlueImpl(const std::uint8_t* in,
-                     std::uint8_t* out,
-                     std::size_t pixelCount)
+void swapRedBlueImpl(const std::uint8_t* in, std::uint8_t* out, int pixelCount)
 {
     using V = typename B::U32;
     const auto redMask = V::broadcast(0x000000FFu);
     const auto blueMask = V::broadcast(0x00FF0000u);
     const auto greenAlphaMask = V::broadcast(0xFF00FF00u);
 
-    std::size_t i = 0;
+    const auto byteOffset = [](int pixel)
+    { return static_cast<std::ptrdiff_t>(pixel) * 4; };
+
+    auto i = 0;
     for (; i + V::lanes <= pixelCount; i += V::lanes)
     {
-        const auto pixels = V::load(in + i * 4);
+        const auto pixels = V::load(in + byteOffset(i));
         const auto red = (pixels & redMask).template shl<16>();
         const auto blue = (pixels & blueMask).template shr<16>();
         const auto greenAlpha = pixels & greenAlphaMask;
-        V::store(out + i * 4, red | blue | greenAlpha);
+        V::store(out + byteOffset(i), red | blue | greenAlpha);
     }
 
     if constexpr (V::lanes > 1)
         if (i < pixelCount)
             swapRedBlueImpl<backend::Scalar>(
-                in + i * 4, out + i * 4, pixelCount - i);
+                in + byteOffset(i), out + byteOffset(i), pixelCount - i);
 }
 
 } // namespace eacp::simd::kernels

--- a/Lib/eacp/SIMD/Ops.h
+++ b/Lib/eacp/SIMD/Ops.h
@@ -7,7 +7,7 @@
 
 // Header-only, buffer-level conveniences over the raw float-array primitives in
 // SIMD.h. Anything contiguous with data()/size() qualifies (EA::Vector,
-// std::vector, std::span, std::array, ...), so call sites can write
+// EA::Array, EA::Span, std::vector, ...), so call sites can write
 // `multiply(buffer, gain)` instead of spelling out pointers and counts.
 //
 // Every helper is elementwise and in place on its first argument. When the
@@ -19,7 +19,7 @@ namespace eacp::simd
 template <typename B>
 concept FloatBuffer = requires(const B& b) {
     { b.data() } -> std::convertible_to<const float*>;
-    { b.size() } -> std::convertible_to<std::size_t>;
+    { b.size() } -> std::convertible_to<int>;
 };
 
 template <typename B>
@@ -28,9 +28,9 @@ concept MutableFloatBuffer = FloatBuffer<B> && requires(B& b) {
 };
 
 template <FloatBuffer... Buffers>
-std::size_t commonCount(const Buffers&... buffers)
+int commonCount(const Buffers&... buffers)
 {
-    return std::min({static_cast<std::size_t>(buffers.size())...});
+    return std::min({(int) buffers.size()...});
 }
 
 // dst[i] += src[i]
@@ -58,8 +58,7 @@ void multiply(Dst& dst, const Src& src)
 template <MutableFloatBuffer Dst>
 void multiply(Dst& dst, float value)
 {
-    multiplyByScalar(
-        dst.data(), value, dst.data(), static_cast<std::size_t>(dst.size()));
+    multiplyByScalar(dst.data(), value, dst.data(), (int) dst.size());
 }
 
 // dst[i] += a[i] * b[i]
@@ -87,14 +86,14 @@ void lerp(Dst& dst, const Target& target, float t)
 template <FloatBuffer Src>
 double sumOfSquares(const Src& src)
 {
-    return sumOfSquares(src.data(), static_cast<std::size_t>(src.size()));
+    return sumOfSquares(src.data(), (int) src.size());
 }
 
 // max(|src[i]|)
 template <FloatBuffer Src>
 float peakAbs(const Src& src)
 {
-    return peakAbs(src.data(), static_cast<std::size_t>(src.size()));
+    return peakAbs(src.data(), (int) src.size());
 }
 
 } // namespace eacp::simd

--- a/Lib/eacp/SIMD/SIMD.h
+++ b/Lib/eacp/SIMD/SIMD.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <cstdint>
 
 // eacp-simd: a small, self-contained portable SIMD layer.
@@ -17,7 +16,7 @@ namespace eacp::simd
 // Swap the red and blue channels of `pixelCount` tightly-packed 8-bit RGBA
 // pixels (RGBA <-> BGRA), writing to `out`. `in` and `out` may be equal
 // (in place) but must not otherwise overlap.
-void swapRedBlue(const std::uint8_t* in, std::uint8_t* out, std::size_t pixelCount);
+void swapRedBlue(const std::uint8_t* in, std::uint8_t* out, int pixelCount);
 
 // Convert a BGRA8 camera frame to tightly-packed RGBA8 in one pass: swap
 // red/blue and drop any trailing row padding. `src` rows are `srcBytesPerRow`
@@ -25,7 +24,7 @@ void swapRedBlue(const std::uint8_t* in, std::uint8_t* out, std::size_t pixelCou
 // lives in the SIMD module so its per-byte work is always built at the platform
 // optimization maximum, independent of the (possibly unoptimized) caller.
 void convertBgraToRgba(const std::uint8_t* src,
-                       std::size_t srcBytesPerRow,
+                       int srcBytesPerRow,
                        std::uint8_t* dst,
                        int width,
                        int height);
@@ -71,28 +70,27 @@ void mirroredCrop(const std::uint8_t* src,
 // at any vector width and on every build.
 
 // out[i] = a[i] + b[i]
-void add(const float* a, const float* b, float* out, std::size_t count);
+void add(const float* a, const float* b, float* out, int count);
 
 // out[i] = a[i] - b[i]
-void subtract(const float* a, const float* b, float* out, std::size_t count);
+void subtract(const float* a, const float* b, float* out, int count);
 
 // out[i] = a[i] * b[i]
-void multiply(const float* a, const float* b, float* out, std::size_t count);
+void multiply(const float* a, const float* b, float* out, int count);
 
 // out[i] = a[i] * scalar
-void multiplyByScalar(const float* a, float scalar, float* out, std::size_t count);
+void multiplyByScalar(const float* a, float scalar, float* out, int count);
 
 // out[i] = a[i] * b[i] + c[i]
 void multiplyAdd(
-    const float* a, const float* b, const float* c, float* out, std::size_t count);
+    const float* a, const float* b, const float* c, float* out, int count);
 
 // out[i] = a[i] * b + c[i] -- the axpy shape; with out == c it accumulates a
 // scaled array in place (out[i] += a[i] * b).
-void multiplyAdd(
-    const float* a, float b, const float* c, float* out, std::size_t count);
+void multiplyAdd(const float* a, float b, const float* c, float* out, int count);
 
 // out[i] = a[i] + t * (b[i] - a[i])
-void lerp(const float* a, const float* b, float t, float* out, std::size_t count);
+void lerp(const float* a, const float* b, float t, float* out, int count);
 
 // --- Float-array reductions ---
 //
@@ -103,10 +101,10 @@ void lerp(const float* a, const float* b, float t, float* out, std::size_t count
 // bit-equal to a naive sequential loop over the same data.
 
 // Returns sum(a[i]^2), accumulated in double for precision. 0.0 when count == 0.
-double sumOfSquares(const float* a, std::size_t count);
+double sumOfSquares(const float* a, int count);
 
 // Returns max(|a[i]|), 0.f when count == 0. Max is order-independent, so this
 // one matches a sequential loop exactly.
-float peakAbs(const float* a, std::size_t count);
+float peakAbs(const float* a, int count);
 
 } // namespace eacp::simd

--- a/Lib/eacp/SIMD/Tu/ArrayOps.cpp
+++ b/Lib/eacp/SIMD/Tu/ArrayOps.cpp
@@ -15,47 +15,46 @@
 namespace eacp::simd
 {
 
-void add(const float* a, const float* b, float* out, std::size_t count)
+void add(const float* a, const float* b, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] + b[i];
 }
 
-void subtract(const float* a, const float* b, float* out, std::size_t count)
+void subtract(const float* a, const float* b, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] - b[i];
 }
 
-void multiply(const float* a, const float* b, float* out, std::size_t count)
+void multiply(const float* a, const float* b, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] * b[i];
 }
 
-void multiplyByScalar(const float* a, float scalar, float* out, std::size_t count)
+void multiplyByScalar(const float* a, float scalar, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] * scalar;
 }
 
 void multiplyAdd(
-    const float* a, const float* b, const float* c, float* out, std::size_t count)
+    const float* a, const float* b, const float* c, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] * b[i] + c[i];
 }
 
-void multiplyAdd(
-    const float* a, float b, const float* c, float* out, std::size_t count)
+void multiplyAdd(const float* a, float b, const float* c, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] * b + c[i];
 }
 
-void lerp(const float* a, const float* b, float t, float* out, std::size_t count)
+void lerp(const float* a, const float* b, float t, float* out, int count)
 {
-    for (std::size_t i = 0; i < count; ++i)
+    for (int i = 0; i < count; ++i)
         out[i] = a[i] + t * (b[i] - a[i]);
 }
 
@@ -64,14 +63,14 @@ void lerp(const float* a, const float* b, float t, float* out, std::size_t count
 // onto vector lanes without fast-math, while keeping the accumulation order
 // (and therefore the result) identical on every build.
 
-double sumOfSquares(const float* a, std::size_t count)
+double sumOfSquares(const float* a, int count)
 {
     auto acc0 = 0.0;
     auto acc1 = 0.0;
     auto acc2 = 0.0;
     auto acc3 = 0.0;
 
-    auto i = std::size_t {0};
+    auto i = 0;
     for (; i + 4 <= count; i += 4)
     {
         acc0 += (double) a[i + 0] * (double) a[i + 0];
@@ -86,14 +85,14 @@ double sumOfSquares(const float* a, std::size_t count)
     return (acc0 + acc1) + (acc2 + acc3);
 }
 
-float peakAbs(const float* a, std::size_t count)
+float peakAbs(const float* a, int count)
 {
     auto max0 = 0.f;
     auto max1 = 0.f;
     auto max2 = 0.f;
     auto max3 = 0.f;
 
-    auto i = std::size_t {0};
+    auto i = 0;
     for (; i + 4 <= count; i += 4)
     {
         max0 = std::max(max0, std::abs(a[i + 0]));

--- a/Lib/eacp/SIMD/Tu/Avx2.cpp
+++ b/Lib/eacp/SIMD/Tu/Avx2.cpp
@@ -20,9 +20,7 @@ namespace eacp::simd::backends
 #if defined(__GNUC__) || defined(__clang__)
 __attribute__((target("avx2,fma")))
 #endif
-void swapRedBlue_avx2(const std::uint8_t* in,
-                      std::uint8_t* out,
-                      std::size_t pixelCount)
+void swapRedBlue_avx2(const std::uint8_t* in, std::uint8_t* out, int pixelCount)
 {
     kernels::swapRedBlueImpl<backend::Avx2>(in, out, pixelCount);
 }

--- a/Lib/eacp/SIMD/Tu/Baseline.cpp
+++ b/Lib/eacp/SIMD/Tu/Baseline.cpp
@@ -14,9 +14,7 @@
 namespace eacp::simd::backends
 {
 
-void swapRedBlue_sse2(const std::uint8_t* in,
-                      std::uint8_t* out,
-                      std::size_t pixelCount)
+void swapRedBlue_sse2(const std::uint8_t* in, std::uint8_t* out, int pixelCount)
 {
     kernels::swapRedBlueImpl<backend::Sse2>(in, out, pixelCount);
 }
@@ -53,9 +51,7 @@ void warpAffineInverse_sse2(const std::uint8_t* src,
 namespace eacp::simd::backends
 {
 
-void swapRedBlue_neon(const std::uint8_t* in,
-                      std::uint8_t* out,
-                      std::size_t pixelCount)
+void swapRedBlue_neon(const std::uint8_t* in, std::uint8_t* out, int pixelCount)
 {
     kernels::swapRedBlueImpl<backend::Neon>(in, out, pixelCount);
 }

--- a/Lib/eacp/SIMD/Tu/MirroredCrop.cpp
+++ b/Lib/eacp/SIMD/Tu/MirroredCrop.cpp
@@ -21,8 +21,8 @@ void mirroredCrop(const std::uint8_t* src,
     for (int dy = 0; dy < height; ++dy)
     {
         const std::uint8_t* srcRow =
-            src + (static_cast<std::size_t>(y + dy) * srcWidth + x) * 4;
-        std::uint8_t* dstRow = dst + static_cast<std::size_t>(dy) * width * 4;
+            src + (static_cast<std::ptrdiff_t>(y + dy) * srcWidth + x) * 4;
+        std::uint8_t* dstRow = dst + static_cast<std::ptrdiff_t>(dy) * width * 4;
         for (int dx = 0; dx < width; ++dx)
             std::memcpy(dstRow + dx * 4, srcRow + (width - 1 - dx) * 4, 4);
     }

--- a/Lib/eacp/SIMD/Tu/Scalar.cpp
+++ b/Lib/eacp/SIMD/Tu/Scalar.cpp
@@ -9,9 +9,7 @@
 namespace eacp::simd::backends
 {
 
-void swapRedBlue_scalar(const std::uint8_t* in,
-                        std::uint8_t* out,
-                        std::size_t pixelCount)
+void swapRedBlue_scalar(const std::uint8_t* in, std::uint8_t* out, int pixelCount)
 {
     kernels::swapRedBlueImpl<backend::Scalar>(in, out, pixelCount);
 }

--- a/Lib/eacp/SIMD/Vector.h
+++ b/Lib/eacp/SIMD/Vector.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <cstddef>
-
 // eacp-simd: the register-level float vector.
 //
 // This is the OTHER half of the module, and it is worth being explicit about
@@ -32,19 +30,20 @@
 // does, rather than paying an indirect call per vector.
 
 #if defined(__AVX512F__)
-    #include <immintrin.h>
-    #define EACP_SIMD_VECTOR_AVX512 1
+#include <immintrin.h>
+#define EACP_SIMD_VECTOR_AVX512 1
 #elif defined(__AVX2__)
-    #include <immintrin.h>
-    #define EACP_SIMD_VECTOR_AVX2 1
-#elif defined(__SSE2__) || defined(_M_X64) || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
-    #include <emmintrin.h>
-    #define EACP_SIMD_VECTOR_SSE2 1
+#include <immintrin.h>
+#define EACP_SIMD_VECTOR_AVX2 1
+#elif defined(__SSE2__) || defined(_M_X64)                                          \
+    || (defined(_M_IX86_FP) && _M_IX86_FP >= 2)
+#include <emmintrin.h>
+#define EACP_SIMD_VECTOR_SSE2 1
 #elif defined(__aarch64__) || defined(_M_ARM64)
-    #include <arm_neon.h>
-    #define EACP_SIMD_VECTOR_NEON 1
+#include <arm_neon.h>
+#define EACP_SIMD_VECTOR_NEON 1
 #else
-    #define EACP_SIMD_VECTOR_SCALAR 1
+#define EACP_SIMD_VECTOR_SCALAR 1
 #endif
 
 namespace eacp::simd
@@ -74,10 +73,10 @@ targets an unaligned load of an aligned address costs nothing.
 struct F32
 {
 #if defined(EACP_SIMD_VECTOR_AVX512)
-    static constexpr std::size_t lanes = 16;
+    static constexpr int lanes = 16;
     using Native = __m512;
 
-    static constexpr std::size_t registers = 32;
+    static constexpr int registers = 32;
 
     static F32 zero() { return {_mm512_setzero_ps()}; }
     static F32 broadcast(float x) { return {_mm512_set1_ps(x)}; }
@@ -98,10 +97,10 @@ struct F32
     float reduceAdd() const { return _mm512_reduce_add_ps(v); }
 
 #elif defined(EACP_SIMD_VECTOR_AVX2)
-    static constexpr std::size_t lanes = 8;
+    static constexpr int lanes = 8;
     using Native = __m256;
 
-    static constexpr std::size_t registers = 16;
+    static constexpr int registers = 16;
 
     static F32 zero() { return {_mm256_setzero_ps()}; }
     static F32 broadcast(float x) { return {_mm256_set1_ps(x)}; }
@@ -118,13 +117,13 @@ struct F32
 
     F32 fma(F32 a, F32 b) const
     {
-    #if defined(__FMA__) || defined(_MSC_VER)
+#if defined(__FMA__) || defined(_MSC_VER)
         return {_mm256_fmadd_ps(a.v, b.v, v)};
-    #else
+#else
         // -mavx2 without -mfma: the compiler still contracts this where the
         // consumer allows it, which is the point of the header being inline.
         return {_mm256_add_ps(v, _mm256_mul_ps(a.v, b.v))};
-    #endif
+#endif
     }
 
     float reduceAdd() const
@@ -138,10 +137,10 @@ struct F32
     }
 
 #elif defined(EACP_SIMD_VECTOR_SSE2)
-    static constexpr std::size_t lanes = 4;
+    static constexpr int lanes = 4;
     using Native = __m128;
 
-    static constexpr std::size_t registers = 16;
+    static constexpr int registers = 16;
 
     static F32 zero() { return {_mm_setzero_ps()}; }
     static F32 broadcast(float x) { return {_mm_set1_ps(x)}; }
@@ -166,10 +165,10 @@ struct F32
     }
 
 #elif defined(EACP_SIMD_VECTOR_NEON)
-    static constexpr std::size_t lanes = 4;
+    static constexpr int lanes = 4;
     using Native = float32x4_t;
 
-    static constexpr std::size_t registers = 32;
+    static constexpr int registers = 32;
 
     static F32 zero() { return {vdupq_n_f32(0.f)}; }
     static F32 broadcast(float x) { return {vdupq_n_f32(x)}; }
@@ -192,8 +191,8 @@ struct F32
     // No SIMD for this target. Present so a kernel written against this header
     // still COMPILES and still gives the right answer everywhere; it is not
     // expected to be fast, and no shipping target reaches it.
-    static constexpr std::size_t lanes = 4;
-    static constexpr std::size_t registers = 16;
+    static constexpr int lanes = 4;
+    static constexpr int registers = 16;
     using Native = float[lanes];
 
     static F32 zero() { return broadcast(0.f); }
@@ -201,7 +200,7 @@ struct F32
     static F32 broadcast(float x)
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = x;
         return result;
     }
@@ -209,7 +208,7 @@ struct F32
     static F32 load(const float* p)
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = p[i];
         return result;
     }
@@ -218,14 +217,14 @@ struct F32
 
     static void store(float* p, F32 a)
     {
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             p[i] = a.v[i];
     }
 
     F32 operator+(F32 o) const
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = v[i] + o.v[i];
         return result;
     }
@@ -233,7 +232,7 @@ struct F32
     F32 operator-(F32 o) const
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = v[i] - o.v[i];
         return result;
     }
@@ -241,7 +240,7 @@ struct F32
     F32 operator*(F32 o) const
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = v[i] * o.v[i];
         return result;
     }
@@ -249,7 +248,7 @@ struct F32
     static F32 min(F32 a, F32 b)
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = a.v[i] < b.v[i] ? a.v[i] : b.v[i];
         return result;
     }
@@ -257,7 +256,7 @@ struct F32
     static F32 max(F32 a, F32 b)
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = a.v[i] > b.v[i] ? a.v[i] : b.v[i];
         return result;
     }
@@ -265,7 +264,7 @@ struct F32
     F32 fma(F32 a, F32 b) const
     {
         F32 result {};
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             result.v[i] = v[i] + a.v[i] * b.v[i];
         return result;
     }
@@ -273,7 +272,7 @@ struct F32
     float reduceAdd() const
     {
         auto sum = 0.f;
-        for (std::size_t i = 0; i < lanes; ++i)
+        for (int i = 0; i < lanes; ++i)
             sum += v[i];
         return sum;
     }
@@ -287,14 +286,14 @@ struct F32
 
 // How many floats one F32 holds, for the loop bounds and the tile constants
 // that have to agree with it.
-inline constexpr std::size_t floatLanes = F32::lanes;
+inline constexpr int floatLanes = F32::lanes;
 
 // How many vector registers the target architecture has. A microkernel sizes
 // its register tile from this: the whole point of holding accumulators across a
 // reduction is lost the moment there are more of them than the register file
 // holds, and a tile that spills is slower than the smaller tile that does not.
 // 32 on NEON and AVX-512, 16 on SSE2 and AVX2.
-inline constexpr std::size_t vectorRegisters = F32::registers;
+inline constexpr int vectorRegisters = F32::registers;
 
 /*
 A partial load / store, for the ragged tail of a channel axis that is not a
@@ -306,19 +305,19 @@ per ISA, and this runs at most once per row of a tensor whose channel counts
 of eight anyway. It exists for correctness on the shapes that are not, not for
 speed on the ones that are.
 */
-inline F32 loadPartial(const float* p, std::size_t count)
+inline F32 loadPartial(const float* p, int count)
 {
     alignas(64) float staging[F32::lanes] {};
-    for (std::size_t i = 0; i < count && i < F32::lanes; ++i)
+    for (int i = 0; i < count && i < F32::lanes; ++i)
         staging[i] = p[i];
     return F32::load(staging);
 }
 
-inline void storePartial(float* p, F32 a, std::size_t count)
+inline void storePartial(float* p, F32 a, int count)
 {
     alignas(64) float staging[F32::lanes];
     F32::store(staging, a);
-    for (std::size_t i = 0; i < count && i < F32::lanes; ++i)
+    for (int i = 0; i < count && i < F32::lanes; ++i)
         p[i] = staging[i];
 }
 

--- a/Lib/eacp/SVG/NumberReader.cpp
+++ b/Lib/eacp/SVG/NumberReader.cpp
@@ -23,12 +23,12 @@ bool isNumberStart(char c)
 
 bool NumberReader::atEnd() const
 {
-    return pos >= src.size();
+    return pos >= (int) src.size();
 }
 
 char NumberReader::peek() const
 {
-    return src[pos];
+    return src[(size_t) pos];
 }
 
 void NumberReader::skipWhitespaceAndCommas()
@@ -48,7 +48,7 @@ bool NumberReader::readFlag()
     skipWhitespaceAndCommas();
 
     if (!atEnd() && (peek() == '0' || peek() == '1'))
-        return src[pos++] == '1';
+        return src[(size_t) pos++] == '1';
 
     // Not what the grammar allows, but a document that writes "0.0" where a flag
     // belongs means false by it, and refusing to read the number would put every
@@ -87,7 +87,8 @@ float NumberReader::readFloat()
     if (pos == start)
         return 0.f;
 
-    return std::stof(std::string(src.substr(start, pos - start)));
+    return std::stof(
+        std::string(src.substr((size_t) start, (size_t) (pos - start))));
 }
 
 } // namespace eacp::SVG

--- a/Lib/eacp/SVG/NumberReader.h
+++ b/Lib/eacp/SVG/NumberReader.h
@@ -23,7 +23,7 @@ struct NumberReader
     bool readFlag();
 
     std::string_view src;
-    std::size_t pos = 0;
+    int pos = 0;
 };
 
 } // namespace eacp::SVG

--- a/Lib/eacp/SVG/SVGAttributes.cpp
+++ b/Lib/eacp/SVG/SVGAttributes.cpp
@@ -100,40 +100,48 @@ ColorResult parseColor(const std::string& value)
 
 namespace
 {
-void skipWhitespace(const std::string& value, size_t& pos)
+// -1 when there is none, so a failed search reads as an index rather than npos.
+int indexOfFrom(const std::string& value, char c, int pos)
 {
-    while (pos < value.size()
-           && std::isspace(static_cast<unsigned char>(value[pos])))
+    auto found = value.find(c, (size_t) pos);
+
+    return found == std::string::npos ? -1 : (int) found;
+}
+
+void skipWhitespace(const std::string& value, int& pos)
+{
+    while (pos < (int) value.size()
+           && std::isspace(static_cast<unsigned char>(value[(size_t) pos])))
     {
         ++pos;
     }
 }
 
-bool advanceToArgumentList(const std::string& value, size_t& pos)
+bool advanceToArgumentList(const std::string& value, int& pos)
 {
-    auto open = value.find('(', pos);
-    if (open == std::string::npos)
+    auto open = indexOfFrom(value, '(', pos);
+    if (open < 0)
         return false;
     pos = open + 1;
     return true;
 }
 
-void advancePastClosingParen(const std::string& value, size_t& pos)
+void advancePastClosingParen(const std::string& value, int& pos)
 {
-    pos = value.find(')', pos);
-    if (pos != std::string::npos)
-        ++pos;
+    auto close = indexOfFrom(value, ')', pos);
+
+    pos = close < 0 ? (int) value.size() : close + 1;
 }
 
-std::string_view readFunctionName(const std::string& value, size_t& pos)
+std::string_view readFunctionName(const std::string& value, int& pos)
 {
     auto start = pos;
 
-    while (pos < value.size()
-           && std::isalpha(static_cast<unsigned char>(value[pos])))
+    while (pos < (int) value.size()
+           && std::isalpha(static_cast<unsigned char>(value[(size_t) pos])))
         ++pos;
 
-    return std::string_view {value}.substr(start, pos - start);
+    return std::string_view {value}.substr((size_t) start, (size_t) (pos - start));
 }
 
 // Hands each function of a transform list, in the order written, to `consume` as
@@ -141,12 +149,12 @@ std::string_view readFunctionName(const std::string& value, size_t& pos)
 template <typename Consumer>
 void forEachTransformFunction(const std::string& value, Consumer&& consume)
 {
-    auto pos = size_t {0};
+    auto pos = 0;
 
-    while (pos < value.size())
+    while (pos < (int) value.size())
     {
         skipWhitespace(value, pos);
-        if (pos >= value.size())
+        if (pos >= (int) value.size())
             break;
 
         auto name = readFunctionName(value, pos);
@@ -317,20 +325,20 @@ bool readAlignKeyword(const std::string& token, PreserveAspectRatio& result)
 template <typename Consumer>
 void forEachToken(const std::string& value, Consumer&& consume)
 {
-    auto pos = size_t {0};
+    auto pos = 0;
 
-    while (pos < value.size())
+    while (pos < (int) value.size())
     {
         skipWhitespace(value, pos);
 
         auto start = pos;
 
-        while (pos < value.size()
-               && !std::isspace(static_cast<unsigned char>(value[pos])))
+        while (pos < (int) value.size()
+               && !std::isspace(static_cast<unsigned char>(value[(size_t) pos])))
             ++pos;
 
         if (pos > start)
-            consume(value.substr(start, pos - start));
+            consume(value.substr((size_t) start, (size_t) (pos - start)));
     }
 }
 
@@ -464,24 +472,22 @@ std::unordered_map<std::string, std::string>
     parseStyleDeclarations(const std::string& value)
 {
     auto declarations = std::unordered_map<std::string, std::string> {};
-    auto pos = size_t {0};
+    auto pos = 0;
 
-    while (pos < value.size())
+    while (pos < (int) value.size())
     {
-        auto end = value.find(';', pos);
+        auto semicolon = indexOfFrom(value, ';', pos);
+        auto end = semicolon < 0 ? (int) value.size() : semicolon;
+        auto colon = indexOfFrom(value, ':', pos);
 
-        if (end == std::string::npos)
-            end = value.size();
-
-        auto colon = value.find(':', pos);
-
-        if (colon != std::string::npos && colon < end)
+        if (colon >= 0 && colon < end)
         {
-            auto property = Strings::trim(value.substr(pos, colon - pos));
+            auto property =
+                Strings::trim(value.substr((size_t) pos, (size_t) (colon - pos)));
 
             if (!property.empty())
-                declarations[property] =
-                    Strings::trim(value.substr(colon + 1, end - colon - 1));
+                declarations[property] = Strings::trim(
+                    value.substr((size_t) colon + 1, (size_t) (end - colon - 1)));
         }
 
         pos = end + 1;

--- a/Lib/eacp/SVG/SVGPathParser.cpp
+++ b/Lib/eacp/SVG/SVGPathParser.cpp
@@ -386,7 +386,7 @@ void handleClosePath(PathType& path, PathState& state)
 
 char readCommandChar(NumberReader& reader, char lastCommand)
 {
-    auto c = reader.src[reader.pos];
+    auto c = reader.src[(size_t) reader.pos];
     if (std::isalpha(static_cast<unsigned char>(c)))
     {
         reader.pos++;

--- a/Lib/eacp/SVG/XMLParser.cpp
+++ b/Lib/eacp/SVG/XMLParser.cpp
@@ -5,9 +5,9 @@ namespace eacp::SVG
 
 struct XMLReader
 {
-    bool atEnd() const { return pos >= src.size(); }
-    char peek() const { return src[pos]; }
-    char advance() { return src[pos++]; }
+    bool atEnd() const { return pos >= (int) src.size(); }
+    char peek() const { return src[(size_t) pos]; }
+    char advance() { return src[(size_t) pos++]; }
 
     void skipWhitespace()
     {
@@ -17,9 +17,9 @@ struct XMLReader
 
     bool match(std::string_view token)
     {
-        if (src.substr(pos, token.size()) == token)
+        if (src.substr((size_t) pos, token.size()) == token)
         {
-            pos += token.size();
+            pos += (int) token.size();
             return true;
         }
         return false;
@@ -152,12 +152,12 @@ struct XMLReader
 
             if (peek() == '<')
             {
-                if (src.substr(pos, 2) == "</")
+                if (src.substr((size_t) pos, 2) == "</")
                 {
                     skipClosingTag();
                     break;
                 }
-                if (src.substr(pos, 4) == "<!--")
+                if (src.substr((size_t) pos, 4) == "<!--")
                 {
                     pos += 4;
                     skipComment();
@@ -191,7 +191,7 @@ struct XMLReader
     }
 
     std::string_view src;
-    size_t pos = 0;
+    int pos = 0;
 };
 
 std::optional<SVGElement> parseXML(std::string_view input)

--- a/Lib/eacp/Text/GlyphAtlas.cpp
+++ b/Lib/eacp/Text/GlyphAtlas.cpp
@@ -13,7 +13,7 @@ namespace
 constexpr int glyphPadding = 1;
 
 // Shaped strings kept before the cache starts over.
-constexpr std::size_t maxShapedStrings = 16384;
+constexpr int maxShapedStrings = 16384;
 } // namespace
 
 void GlyphAtlas::Page::markDirty(int x, int y, int width, int height)
@@ -184,7 +184,7 @@ GlyphSlot GlyphAtlas::glyph(char32_t codepoint, FontStyle style, int face)
 {
     char encoded[4] = {};
     const auto length = encodeUtf8(codepoint, encoded);
-    const auto run = shape({encoded, length}, variantOf(style), face);
+    const auto run = shape({encoded, (std::size_t) length}, variantOf(style), face);
 
     if (run.glyphs.empty())
         return {};
@@ -219,7 +219,7 @@ ShapedText
 
     // A document's vocabulary is bounded; a cache that is not would hold every
     // string ever measured, so it starts over rather than grow without end.
-    if (shaped.size() >= maxShapedStrings)
+    if ((int) shaped.size() >= maxShapedStrings)
         shaped.clear();
 
     shaped.emplace(std::move(key), result);
@@ -332,8 +332,8 @@ void GlyphAtlas::dropEverything()
     slots.clear();
     shaped.clear();
 
-    std::fill(maskPage.pixels.begin(), maskPage.pixels.end(), std::uint8_t {0});
-    std::fill(colorPage.pixels.begin(), colorPage.pixels.end(), std::uint8_t {0});
+    maskPage.pixels.fill(std::uint8_t {0});
+    colorPage.pixels.fill(std::uint8_t {0});
 
     maskPage.needsFullUpload = true;
     colorPage.needsFullUpload = true;
@@ -346,20 +346,19 @@ void GlyphAtlas::dropEverything()
 void GlyphAtlas::resizePage(Page& page, int newSize, int stride)
 {
     const auto oldSize = atlasSize;
-    auto resized = std::vector<std::uint8_t>(
-        static_cast<std::size_t>(newSize) * newSize * stride, std::uint8_t {0});
+    auto resized = Vector<std::uint8_t>(newSize * newSize * stride);
 
     // Copy row by row: the old rows are shorter than the new ones, so the
     // contents keep their coordinates and every placement stays correct.
     if (!page.pixels.empty() && oldSize > 0 && oldSize <= newSize)
     {
-        const auto oldRow = static_cast<std::size_t>(oldSize) * stride;
-        const auto newRow = static_cast<std::size_t>(newSize) * stride;
+        const auto oldRow = oldSize * stride;
+        const auto newRow = newSize * stride;
 
         for (auto y = 0; y < oldSize; ++y)
-            std::memcpy(&resized[static_cast<std::size_t>(y) * newRow],
-                        &page.pixels[static_cast<std::size_t>(y) * oldRow],
-                        oldRow);
+            std::memcpy(&resized[y * newRow],
+                        &page.pixels[y * oldRow],
+                        (std::size_t) oldRow);
     }
 
     page.pixels = std::move(resized);
@@ -380,12 +379,11 @@ void GlyphAtlas::blit(Page& page,
 
     for (auto y = 0; y < bitmap.height; ++y)
     {
-        const auto destOffset =
-            (static_cast<std::size_t>(at.y + y) * atlasSize + at.x) * stride;
+        const auto destOffset = ((at.y + y) * atlasSize + at.x) * stride;
 
         std::memcpy(&page.pixels[destOffset],
-                    &bitmap.pixels[static_cast<std::size_t>(y) * sourceRow],
-                    sourceRow);
+                    &bitmap.pixels[y * sourceRow],
+                    (std::size_t) sourceRow);
     }
 
     page.markDirty(at.x, at.y, bitmap.width, bitmap.height);
@@ -427,9 +425,8 @@ void GlyphAtlas::uploadPage(Page& page, GPU::TextureFormat format, int stride)
     const auto width = page.dirtyRight - page.dirtyLeft;
     const auto height = page.dirtyBottom - page.dirtyTop;
 
-    const auto rowBytes = static_cast<std::size_t>(atlasSize) * stride;
-    const auto* start = &page.pixels[static_cast<std::size_t>(y) * rowBytes
-                                     + static_cast<std::size_t>(x) * stride];
+    const auto rowBytes = atlasSize * stride;
+    const auto* start = &page.pixels[y * rowBytes + x * stride];
 
     page.texture->update({static_cast<float>(x),
                           static_cast<float>(y),

--- a/Lib/eacp/Text/GlyphAtlas.h
+++ b/Lib/eacp/Text/GlyphAtlas.h
@@ -233,7 +233,7 @@ private:
 
     struct Page
     {
-        std::vector<std::uint8_t> pixels;
+        Vector<std::uint8_t> pixels;
         std::optional<GPU::Texture> texture;
 
         // Bounding box of everything written since the last commit. Uploading

--- a/Lib/eacp/Text/GlyphBitmap.h
+++ b/Lib/eacp/Text/GlyphBitmap.h
@@ -2,8 +2,9 @@
 
 #include "Common.h"
 
+#include <eacp/Core/Utils/Containers.h>
+
 #include <cstdint>
-#include <vector>
 
 namespace eacp::Text
 {
@@ -38,7 +39,7 @@ constexpr int bytesPerPixel(GlyphFormat format)
 // reach.
 struct GlyphBitmap
 {
-    std::vector<std::uint8_t> pixels;
+    Vector<std::uint8_t> pixels;
 
     int width = 0;
     int height = 0;
@@ -61,9 +62,6 @@ struct GlyphBitmap
 
     bool isEmpty() const { return width <= 0 || height <= 0; }
 
-    std::size_t bytesPerRow() const
-    {
-        return static_cast<std::size_t>(width) * bytesPerPixel(format);
-    }
+    int bytesPerRow() const { return width * bytesPerPixel(format); }
 };
 } // namespace eacp::Text

--- a/Lib/eacp/Text/GlyphRasterizer-Apple.mm
+++ b/Lib/eacp/Text/GlyphRasterizer-Apple.mm
@@ -10,7 +10,6 @@
 #include <cmath>
 #include <map>
 #include <optional>
-#include <vector>
 
 // CoreText rasterizer and shaper, shared by macOS and iOS — CoreText and
 // CoreGraphics are present on both, so nothing here is macOS-specific.
@@ -289,8 +288,8 @@ int weightDistance(int wanted, int have)
 // glyph's string index maps back to an offset in the text the caller gave.
 struct Utf16Text
 {
-    std::vector<UniChar> units;
-    std::vector<int> byteOf;
+    Vector<UniChar> units;
+    Vector<int> byteOf;
 };
 
 Utf16Text toUtf16(std::string_view text)
@@ -299,29 +298,29 @@ Utf16Text toUtf16(std::string_view text)
     result.units.reserve(text.size());
     result.byteOf.reserve(text.size() + 1);
 
-    auto index = std::size_t {0};
+    auto index = 0;
 
-    while (index < text.size())
+    while (index < (int) text.size())
     {
         const auto start = index;
         const auto codepoint = decodeUtf8(text, index);
 
         if (codepoint <= 0xFFFF)
         {
-            result.units.push_back((UniChar) codepoint);
-            result.byteOf.push_back((int) start);
+            result.units.add((UniChar) codepoint);
+            result.byteOf.add(start);
         }
         else
         {
             const auto value = codepoint - 0x10000;
-            result.units.push_back((UniChar) (0xD800 + (value >> 10)));
-            result.units.push_back((UniChar) (0xDC00 + (value & 0x3FF)));
-            result.byteOf.push_back((int) start);
-            result.byteOf.push_back((int) start);
+            result.units.add((UniChar) (0xD800 + (value >> 10)));
+            result.units.add((UniChar) (0xDC00 + (value & 0x3FF)));
+            result.byteOf.add(start);
+            result.byteOf.add(start);
         }
     }
 
-    result.byteOf.push_back((int) text.size());
+    result.byteOf.add((int) text.size());
 
     return result;
 }
@@ -442,7 +441,7 @@ struct GlyphRasterizer::Native
                 }
             }
 
-            familyFaces.push_back(std::move(face));
+            familyFaces.add(std::move(face));
         }
     }
 
@@ -556,16 +555,16 @@ struct GlyphRasterizer::Native
         if (runFont == nullptr || CFEqual(runFont, requested))
             return 0;
 
-        for (auto index = std::size_t {0}; index < fallbacks.size(); ++index)
+        for (auto index = 0; index < fallbacks.size(); ++index)
             if (CFEqual(fallbacks[index].get(), runFont))
-                return (int) index + 1;
+                return index + 1;
 
         if (fallbacks.size() >= 255)
             return 0;
 
-        fallbacks.emplace_back((CTFontRef) CFRetain(runFont));
+        fallbacks.create((CTFontRef) CFRetain(runFont));
 
-        return (int) fallbacks.size();
+        return fallbacks.size();
     }
 
     CTFontRef fontOf(GlyphKey key, const FontVariant& variant) const
@@ -573,9 +572,12 @@ struct GlyphRasterizer::Native
         if (key.font == 0)
             return fontFor(variant);
 
-        const auto index = (std::size_t) key.font - 1;
+        const auto index = key.font - 1;
 
-        return index < fallbacks.size() ? fallbacks[index].get() : nullptr;
+        if (index < 0 || index >= fallbacks.size())
+            return nullptr;
+
+        return fallbacks[index].get();
     }
 
     ShapedRun shape(std::string_view text, const FontVariant& variant) const
@@ -619,9 +621,9 @@ struct GlyphRasterizer::Native
             if (count <= 0)
                 continue;
 
-            auto glyphs = std::vector<CGGlyph>((std::size_t) count);
-            auto positions = std::vector<CGPoint>((std::size_t) count);
-            auto indices = std::vector<CFIndex>((std::size_t) count);
+            auto glyphs = Vector<CGGlyph>((int) count);
+            auto positions = Vector<CGPoint>((int) count);
+            auto indices = Vector<CFIndex>((int) count);
 
             CTRunGetGlyphs(run, CFRangeMake(0, 0), glyphs.data());
             CTRunGetPositions(run, CFRangeMake(0, 0), positions.data());
@@ -631,10 +633,10 @@ struct GlyphRasterizer::Native
                                                             kCTFontAttributeName);
             const auto fontIndex = fontIndexOf(runFont, font);
 
-            for (auto i = std::size_t {0}; i < glyphs.size(); ++i)
+            for (auto i = 0; i < glyphs.size(); ++i)
             {
-                const auto unit = std::clamp(
-                    (std::size_t) indices[i], std::size_t {0}, utf16.byteOf.size() - 1);
+                const auto unit =
+                    std::clamp((int) indices[i], 0, utf16.byteOf.size() - 1);
 
                 result.glyphs.add({{glyphs[i], fontIndex},
                                    (float) positions[i].x,
@@ -694,8 +696,8 @@ struct GlyphRasterizer::Native
         result.bearingX = (float) left;
         result.bearingY = (float) top;
 
-        const auto stride = (std::size_t) result.width * bytesPerPixel(result.format);
-        result.pixels.assign(stride * (std::size_t) result.height, 0);
+        const auto stride = result.width * bytesPerPixel(result.format);
+        result.pixels.assign(stride * result.height, std::uint8_t {0});
 
         CFRef<CGColorSpaceRef> space(colored ? CGColorSpaceCreateDeviceRGB() : nullptr);
 
@@ -706,7 +708,7 @@ struct GlyphRasterizer::Native
             (std::size_t) result.width,
             (std::size_t) result.height,
             8,
-            stride,
+            (std::size_t) stride,
             colored ? space.get() : nullptr,
             colored ? kCGImageAlphaPremultipliedLast : kCGImageAlphaOnly));
 
@@ -747,7 +749,7 @@ struct GlyphRasterizer::Native
         {
             // The atlas stores straight alpha so a colour glyph can be blended
             // like any other; CoreGraphics hands back premultiplied.
-            for (std::size_t i = 0; i + 3 < result.pixels.size(); i += 4)
+            for (auto i = 0; i + 3 < result.pixels.size(); i += 4)
             {
                 const auto alpha = result.pixels[i + 3];
 
@@ -765,9 +767,9 @@ struct GlyphRasterizer::Native
 
     FontRequest request;
     CFRef<CTFontRef> base;
-    std::vector<FamilyFace> familyFaces;
+    Vector<FamilyFace> familyFaces;
     mutable std::map<int, CFRef<CTFontRef>> variants;
-    mutable std::vector<CFRef<CTFontRef>> fallbacks;
+    mutable Vector<CFRef<CTFontRef>> fallbacks;
     bool valid = false;
     std::string resolved;
 };
@@ -817,7 +819,7 @@ GlyphBitmap GlyphRasterizer::rasterize(char32_t codepoint, FontStyle style) cons
     const auto length = encodeUtf8(codepoint, encoded);
 
     const auto variant = variantOf(style);
-    const auto run = impl->shape({encoded, length}, variant);
+    const auto run = impl->shape({encoded, (std::size_t) length}, variant);
 
     if (run.glyphs.empty())
         return {};
@@ -849,9 +851,9 @@ bool faceResolves(const std::string& postScriptName)
 }
 } // namespace
 
-std::optional<RegisteredFont> registerMemoryFont(const void* data, std::size_t size)
+std::optional<RegisteredFont> registerMemoryFont(const void* data, int size)
 {
-    if (data == nullptr || size == 0)
+    if (data == nullptr || size <= 0)
         return std::nullopt;
 
     CFRef<CFDataRef> copied(CFDataCreate(nullptr, (const UInt8*) data, (CFIndex) size));

--- a/Lib/eacp/Text/GlyphRasterizer-Windows.cpp
+++ b/Lib/eacp/Text/GlyphRasterizer-Windows.cpp
@@ -15,7 +15,6 @@
 #include <cstdint>
 #include <map>
 #include <string>
-#include <vector>
 
 // DirectWrite rasterizer and shaper, the Windows counterpart to
 // GlyphRasterizer-Apple.mm.
@@ -97,7 +96,7 @@ constexpr float obliqueSlant = -14.f;
 // GlyphRasterizer-Apple.mm's axisSettingsFor.
 struct AxisRequest
 {
-    std::vector<DWRITE_FONT_AXIS_VALUE> values;
+    Vector<DWRITE_FONT_AXIS_VALUE> values;
     int supplied = DWRITE_FONT_SIMULATIONS_NONE;
 };
 
@@ -115,8 +114,8 @@ AxisRequest axisRequestFor(IDWriteFontResource* resource,
     if (count == 0)
         return request;
 
-    auto defaults = std::vector<DWRITE_FONT_AXIS_VALUE>(count);
-    auto ranges = std::vector<DWRITE_FONT_AXIS_RANGE>(count);
+    auto defaults = Vector<DWRITE_FONT_AXIS_VALUE>((int) count);
+    auto ranges = Vector<DWRITE_FONT_AXIS_RANGE>((int) count);
 
     if (FAILED(resource->GetDefaultFontAxisValues(defaults.data(), count))
         || FAILED(resource->GetFontAxisRanges(ranges.data(), count)))
@@ -164,9 +163,9 @@ AxisRequest axisRequestFor(IDWriteFontResource* resource,
 // The axis values a face was built at. A layout names a family and a weight,
 // which finds a face and not a point on an axis, so a variable face has to be
 // shaped at the same values the glyphs are rasterized from.
-std::vector<DWRITE_FONT_AXIS_VALUE> axisValuesOf(IDWriteFontFace* face)
+Vector<DWRITE_FONT_AXIS_VALUE> axisValuesOf(IDWriteFontFace* face)
 {
-    auto values = std::vector<DWRITE_FONT_AXIS_VALUE> {};
+    auto values = Vector<DWRITE_FONT_AXIS_VALUE> {};
     auto varying = ComPtr<IDWriteFontFace5>();
 
     if (face == nullptr
@@ -188,7 +187,7 @@ std::vector<DWRITE_FONT_AXIS_VALUE> axisValuesOf(IDWriteFontFace* face)
 struct Utf16Text
 {
     std::wstring units;
-    std::vector<int> byteOf;
+    Vector<int> byteOf;
 };
 
 Utf16Text toUtf16(std::string_view text)
@@ -197,9 +196,9 @@ Utf16Text toUtf16(std::string_view text)
     result.units.reserve(text.size());
     result.byteOf.reserve(text.size() + 1);
 
-    auto index = std::size_t {0};
+    auto index = 0;
 
-    while (index < text.size())
+    while (index < (int) text.size())
     {
         const auto start = index;
         const auto codepoint = decodeUtf8(text, index);
@@ -207,19 +206,19 @@ Utf16Text toUtf16(std::string_view text)
         if (codepoint <= 0xFFFF)
         {
             result.units.push_back(static_cast<wchar_t>(codepoint));
-            result.byteOf.push_back(static_cast<int>(start));
+            result.byteOf.add(start);
         }
         else
         {
             const auto value = codepoint - 0x10000;
             result.units.push_back(static_cast<wchar_t>(0xD800 + (value >> 10)));
             result.units.push_back(static_cast<wchar_t>(0xDC00 + (value & 0x3FF)));
-            result.byteOf.push_back(static_cast<int>(start));
-            result.byteOf.push_back(static_cast<int>(start));
+            result.byteOf.add(start);
+            result.byteOf.add(start);
         }
     }
 
-    result.byteOf.push_back(static_cast<int>(text.size()));
+    result.byteOf.add((int) text.size());
 
     return result;
 }
@@ -231,13 +230,13 @@ struct CollectedRun
     ComPtr<IDWriteFontFace> face;
     float emSize = 0.f;
     float baselineX = 0.f;
-    std::vector<UINT16> glyphs;
-    std::vector<float> advances;
-    std::vector<DWRITE_GLYPH_OFFSET> offsets;
+    Vector<UINT16> glyphs;
+    Vector<float> advances;
+    Vector<DWRITE_GLYPH_OFFSET> offsets;
 
     // The first text position (in UTF-16 units of the whole string) each
     // glyph came from, inverted from the run's cluster map.
-    std::vector<UINT32> firstPosition;
+    Vector<UINT32> firstPosition;
 };
 
 // Whether two faces are the same font: the same files at the same index with
@@ -256,13 +255,13 @@ bool sameFontFace(IDWriteFontFace* a, IDWriteFontFace* b)
 
     const auto filesOf = [](IDWriteFontFace* face)
     {
-        auto keys = std::vector<std::string> {};
+        auto keys = Vector<std::string> {};
         auto count = UINT32 {};
 
         if (FAILED(face->GetFiles(&count, nullptr)) || count == 0)
             return keys;
 
-        auto raw = std::vector<IDWriteFontFile*>(count);
+        auto raw = Vector<IDWriteFontFile*>((int) count);
 
         if (FAILED(face->GetFiles(&count, raw.data())))
             return keys;
@@ -293,7 +292,7 @@ bool sameFontFace(IDWriteFontFace* a, IDWriteFontFace* b)
 class RunCollector final : public IDWriteTextRenderer
 {
 public:
-    std::vector<CollectedRun> runs;
+    Vector<CollectedRun> runs;
 
     HRESULT STDMETHODCALLTYPE QueryInterface(REFIID id,
                                              void** object) noexcept override
@@ -360,9 +359,9 @@ public:
             run.offsets.assign(glyphRun->glyphOffsets,
                                glyphRun->glyphOffsets + glyphRun->glyphCount);
         else
-            run.offsets.assign(glyphRun->glyphCount, DWRITE_GLYPH_OFFSET {});
+            run.offsets.assign((int) glyphRun->glyphCount, DWRITE_GLYPH_OFFSET {});
 
-        run.firstPosition.assign(glyphRun->glyphCount, UINT32_MAX);
+        run.firstPosition.assign((int) glyphRun->glyphCount, UINT32_MAX);
 
         if (description != nullptr && description->clusterMap != nullptr)
             for (auto position = UINT32 {}; position < description->stringLength;
@@ -388,7 +387,7 @@ public:
             last = position;
         }
 
-        runs.push_back(std::move(run));
+        runs.add(std::move(run));
 
         return S_OK;
     }
@@ -594,14 +593,14 @@ struct GlyphRasterizer::Native
         if (FAILED(face->GetFiles(&fileCount, nullptr)) || fileCount == 0)
             return face;
 
-        auto raw = std::vector<IDWriteFontFile*>(fileCount);
+        auto raw = Vector<IDWriteFontFile*>((int) fileCount);
 
         if (FAILED(face->GetFiles(&fileCount, raw.data())))
             return face;
 
         // GetFiles hands back references the caller owns; adopt them so they are
         // released however this returns.
-        auto owned = std::vector<ComPtr<IDWriteFontFile>>(fileCount);
+        auto owned = Vector<ComPtr<IDWriteFontFile>>((int) fileCount);
 
         for (auto index = UINT32 {}; index < fileCount; ++index)
             owned[index].Attach(raw[index]);
@@ -702,16 +701,16 @@ struct GlyphRasterizer::Native
         if (face == nullptr || sameFontFace(face, requested))
             return 0;
 
-        for (auto index = std::size_t {0}; index < fallbacks.size(); ++index)
+        for (auto index = 0; index < fallbacks.size(); ++index)
             if (sameFontFace(fallbacks[index].face.Get(), face))
-                return static_cast<int>(index) + 1;
+                return index + 1;
 
         if (fallbacks.size() >= 255)
             return 0;
 
         fallbacks.push_back({face, emSize});
 
-        return static_cast<int>(fallbacks.size());
+        return fallbacks.size();
     }
 
     struct FaceAt
@@ -725,9 +724,9 @@ struct GlyphRasterizer::Native
         if (key.font == 0)
             return {faceFor(variant), request.pixelSize()};
 
-        const auto index = static_cast<std::size_t>(key.font) - 1;
+        const auto index = key.font - 1;
 
-        if (index >= fallbacks.size())
+        if (index < 0 || index >= fallbacks.size())
             return {};
 
         return {fallbacks[index].face.Get(), fallbacks[index].emSize};
@@ -786,11 +785,10 @@ struct GlyphRasterizer::Native
                 fontIndexOf(run.face.Get(), run.emSize, requested);
             auto pen = run.baselineX;
 
-            for (auto index = std::size_t {0}; index < run.glyphs.size(); ++index)
+            for (auto index = 0; index < run.glyphs.size(); ++index)
             {
-                const auto unit =
-                    std::min(static_cast<std::size_t>(run.firstPosition[index]),
-                             utf16.byteOf.size() - 1);
+                const auto unit = std::min((int) run.firstPosition[index],
+                                           utf16.byteOf.size() - 1);
 
                 result.glyphs.add({{run.glyphs[index], fontIndex},
                                    pen + run.offsets[index].advanceOffset,
@@ -892,7 +890,7 @@ struct GlyphRasterizer::Native
 
         // One byte of coverage per pixel is already the mask format, so the
         // texture is filled straight into the bitmap with nothing in between.
-        bitmap.pixels.resize(static_cast<std::size_t>(bitmap.width) * bitmap.height);
+        bitmap.pixels.resize(bitmap.width * bitmap.height);
 
         if (FAILED(analysis->CreateAlphaTexture(
                 textureType,
@@ -949,10 +947,9 @@ struct GlyphRasterizer::Native
         return true;
     }
 
-    std::vector<ColorLayer>
-        collectLayers(IDWriteColorGlyphRunEnumerator* layers) const
+    Vector<ColorLayer> collectLayers(IDWriteColorGlyphRunEnumerator* layers) const
     {
-        auto collected = std::vector<ColorLayer> {};
+        auto collected = Vector<ColorLayer> {};
         auto hasMore = BOOL {};
 
         while (SUCCEEDED(layers->MoveNext(&hasMore)) && hasMore)
@@ -975,13 +972,13 @@ struct GlyphRasterizer::Native
                               : layer->runColor;
 
             if (entry.analysis && measure(entry.analysis.Get(), entry.bounds))
-                collected.push_back(std::move(entry));
+                collected.add(std::move(entry));
         }
 
         return collected;
     }
 
-    static void compositeLayers(const std::vector<ColorLayer>& layers,
+    static void compositeLayers(const Vector<ColorLayer>& layers,
                                 GlyphBitmap& bitmap)
     {
         auto bounds = layers.front().bounds;
@@ -996,19 +993,18 @@ struct GlyphRasterizer::Native
 
         takeBounds(bounds, bitmap);
 
-        const auto pixelCount =
-            static_cast<std::size_t>(bitmap.width) * bitmap.height;
+        const auto pixelCount = bitmap.width * bitmap.height;
 
         // Composited premultiplied, where 'over' is a plain lerp, then converted
         // to the straight alpha the atlas stores. Layers arrive bottom first.
-        auto accumulated = std::vector<float>(pixelCount * 4, 0.f);
+        auto accumulated = Vector<float>(pixelCount * 4);
 
         for (const auto& layer: layers)
             blendLayer(layer, bounds, bitmap.width, accumulated);
 
         bitmap.pixels.resize(pixelCount * 4);
 
-        for (auto index = std::size_t {}; index < pixelCount; ++index)
+        for (auto index = 0; index < pixelCount; ++index)
         {
             const auto alpha = accumulated[index * 4 + 3];
 
@@ -1024,13 +1020,12 @@ struct GlyphRasterizer::Native
     static void blendLayer(const ColorLayer& layer,
                            const RECT& bounds,
                            int width,
-                           std::vector<float>& target)
+                           Vector<float>& target)
     {
         const auto layerWidth = layer.bounds.right - layer.bounds.left;
         const auto layerHeight = layer.bounds.bottom - layer.bounds.top;
-        const auto span = static_cast<std::size_t>(layerWidth) * layerHeight;
 
-        auto texture = std::vector<std::uint8_t>(span);
+        auto texture = Vector<std::uint8_t>(layerWidth * layerHeight);
 
         if (FAILED(layer.analysis->CreateAlphaTexture(
                 textureType,
@@ -1043,7 +1038,7 @@ struct GlyphRasterizer::Native
         {
             for (auto x = 0; x < layerWidth; ++x)
             {
-                const auto source = static_cast<std::size_t>(y) * layerWidth + x;
+                const auto source = y * layerWidth + x;
                 const auto coverage = texture[source] / 255.f;
 
                 if (coverage <= 0.f)
@@ -1052,7 +1047,7 @@ struct GlyphRasterizer::Native
                 const auto alpha = coverage * layer.color.a;
                 const auto row = y + layer.bounds.top - bounds.top;
                 const auto column = x + layer.bounds.left - bounds.left;
-                const auto at = (static_cast<std::size_t>(row) * width + column) * 4;
+                const auto at = (row * width + column) * 4;
 
                 const float channels[3] = {
                     layer.color.r, layer.color.g, layer.color.b};
@@ -1070,7 +1065,7 @@ struct GlyphRasterizer::Native
     ComPtr<IDWriteFontCollection> collection;
     std::wstring family;
     mutable std::map<int, ComPtr<IDWriteFontFace>> variants;
-    mutable std::vector<FallbackFace> fallbacks;
+    mutable Vector<FallbackFace> fallbacks;
     bool valid = false;
 };
 
@@ -1119,7 +1114,7 @@ GlyphBitmap GlyphRasterizer::rasterize(char32_t codepoint, FontStyle style) cons
     char encoded[4] = {};
     const auto length = encodeUtf8(codepoint, encoded);
     const auto variant = variantOf(style);
-    const auto run = impl->shape({encoded, length}, variant);
+    const auto run = impl->shape({encoded, (std::size_t) length}, variant);
 
     if (run.glyphs.empty())
         return {};
@@ -1132,8 +1127,11 @@ const FontRequest& GlyphRasterizer::request() const
     return impl->request;
 }
 
-std::optional<RegisteredFont> registerMemoryFont(const void* data, std::size_t size)
+std::optional<RegisteredFont> registerMemoryFont(const void* data, int size)
 {
+    if (data == nullptr || size <= 0)
+        return std::nullopt;
+
     // Registration lives in eacp-graphics so its text sites (Font,
     // TextMetrics) see the face too — the same process-wide visibility
     // CTFontManagerRegisterGraphicsFont gives the Apple side.

--- a/Lib/eacp/Text/GlyphRasterizer.h
+++ b/Lib/eacp/Text/GlyphRasterizer.h
@@ -186,5 +186,5 @@ struct RegisteredFont
 // caller's buffer need not outlive the call. Nothing when the data is not a
 // usable font. Registering the same face twice reports it as it was, since a
 // page reloaded registers its fonts again.
-std::optional<RegisteredFont> registerMemoryFont(const void* data, std::size_t size);
+std::optional<RegisteredFont> registerMemoryFont(const void* data, int size);
 } // namespace eacp::Text

--- a/Lib/eacp/Text/GlyphRenderer.cpp
+++ b/Lib/eacp/Text/GlyphRenderer.cpp
@@ -134,11 +134,11 @@ void GlyphRenderer::add(const Graphics::Rect& destination,
     instance.color[2] = color.b;
     instance.color[3] = color.a;
 
-    (colored ? colors : masks).push_back(instance);
+    (colored ? colors : masks).add(instance);
 }
 
 void GlyphRenderer::drawQueue(RenderPass& pass,
-                              std::vector<GlyphInstance>& queue,
+                              Vector<GlyphInstance>& queue,
                               Texture& texture,
                               bool colored)
 {
@@ -152,9 +152,9 @@ void GlyphRenderer::drawQueue(RenderPass& pass,
                                static_cast<float>(texture.height())};
     program.atlas = texture;
 
-    program.setInstances(1, queue.data(), static_cast<int>(queue.size()));
+    program.setInstances(1, queue.data(), queue.size());
 
-    pass.drawInstanced(program, static_cast<int>(queue.size()));
+    pass.drawInstanced(program, queue.size());
 }
 
 void GlyphRenderer::flush(RenderPass& pass, GlyphAtlas& atlas)

--- a/Lib/eacp/Text/GlyphRenderer.h
+++ b/Lib/eacp/Text/GlyphRenderer.h
@@ -2,8 +2,6 @@
 
 #include "GlyphAtlas.h"
 
-#include <vector>
-
 namespace eacp::Text
 {
 // A unit-quad corner, each component 0 or 1, mapped onto each glyph's rect.
@@ -72,21 +70,21 @@ public:
     // Submits the queued glyphs: at most two draw calls, one per atlas.
     void flush(GPU::RenderPass& pass, GlyphAtlas& atlas);
 
-    std::size_t queuedGlyphs() const { return masks.size() + colors.size(); }
+    int queuedGlyphs() const { return masks.size() + colors.size(); }
 
 private:
     struct Program;
 
     void drawQueue(GPU::RenderPass& pass,
-                   std::vector<GlyphInstance>& queue,
+                   Vector<GlyphInstance>& queue,
                    GPU::Texture& texture,
                    bool colored);
 
     OwningPointer<Program> maskProgram;
     OwningPointer<Program> colorProgram;
 
-    std::vector<GlyphInstance> masks;
-    std::vector<GlyphInstance> colors;
+    Vector<GlyphInstance> masks;
+    Vector<GlyphInstance> colors;
 
     Graphics::Point viewport {1.f, 1.f};
     bool prepared = false;

--- a/Lib/eacp/Text/ShelfPacker.cpp
+++ b/Lib/eacp/Text/ShelfPacker.cpp
@@ -72,7 +72,7 @@ std::optional<PackedRect> ShelfPacker::add(int width, int height)
     nextShelfY += neededHeight;
     usedArea += static_cast<long long>(neededWidth) * neededHeight;
 
-    shelves.push_back(shelf);
+    shelves.add(shelf);
     return placed;
 }
 

--- a/Lib/eacp/Text/ShelfPacker.h
+++ b/Lib/eacp/Text/ShelfPacker.h
@@ -1,7 +1,8 @@
 #pragma once
 
+#include <eacp/Core/Utils/Containers.h>
+
 #include <optional>
-#include <vector>
 
 namespace eacp::Text
 {
@@ -73,6 +74,6 @@ private:
     int nextShelfY = 0;
     long long usedArea = 0;
 
-    std::vector<Shelf> shelves;
+    Vector<Shelf> shelves;
 };
 } // namespace eacp::Text

--- a/Lib/eacp/Text/Utf8.h
+++ b/Lib/eacp/Text/Utf8.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <cstddef>
 #include <string_view>
 
 // UTF-8 in and out, for the seams of this module that speak codepoints: the
@@ -10,7 +9,7 @@ namespace eacp::Text
 {
 // Writes `codepoint` as UTF-8 into `into`, which holds at least four bytes,
 // and returns how many it used.
-inline std::size_t encodeUtf8(char32_t codepoint, char* into)
+inline int encodeUtf8(char32_t codepoint, char* into)
 {
     if (codepoint < 0x80)
     {
@@ -43,7 +42,7 @@ inline std::size_t encodeUtf8(char32_t codepoint, char* into)
 // Decodes one UTF-8 sequence starting at `index`, advancing it past what was
 // consumed. Malformed bytes yield U+FFFD and advance by one, so a bad byte
 // costs one replacement glyph rather than desynchronising the rest of the line.
-inline char32_t decodeUtf8(std::string_view text, std::size_t& index)
+inline char32_t decodeUtf8(std::string_view text, int& index)
 {
     const auto lead = static_cast<unsigned char>(text[index]);
 
@@ -54,7 +53,7 @@ inline char32_t decodeUtf8(std::string_view text, std::size_t& index)
                                    : lead < 0xF8 ? 3
                                                  : -1;
 
-    if (continuationBytes < 0 || index + continuationBytes >= text.size())
+    if (continuationBytes < 0 || index + continuationBytes >= (int) text.size())
     {
         ++index;
         return 0xFFFD;

--- a/Lib/eacp/UI/Render/GradientRamps.cpp
+++ b/Lib/eacp/UI/Render/GradientRamps.cpp
@@ -145,7 +145,7 @@ float GradientRamps::rowFor(const Gradient& gradient)
 
 void GradientRamps::bake(const Row& source, int row)
 {
-    auto* out = pixels.data() + (std::size_t) row * rampWidth * 4;
+    auto* out = pixels.data() + row * rampWidth * 4;
 
     for (auto x = 0; x < rampWidth; ++x)
     {
@@ -175,7 +175,7 @@ void GradientRamps::commit()
     auto count = rows.size() - first;
 
     texture->update({0.f, (float) first, (float) rampWidth, (float) count},
-                    pixels.data() + (std::size_t) first * rampWidth * 4);
+                    pixels.data() + first * rampWidth * 4);
 
     uploadedRows = rows.size();
 }

--- a/Lib/eacp/Video/Decode/Decoder-Apple.mm
+++ b/Lib/eacp/Video/Decode/Decoder-Apple.mm
@@ -123,7 +123,7 @@ struct AppleDecoder final : Decoder
         auto frameInfo = FrameInfo {};
         frameInfo.width = (int) CVPixelBufferGetWidth(pixelBuffer);
         frameInfo.height = (int) CVPixelBufferGetHeight(pixelBuffer);
-        frameInfo.bytesPerRow = CVPixelBufferGetBytesPerRow(pixelBuffer);
+        frameInfo.bytesPerRow = (int) CVPixelBufferGetBytesPerRow(pixelBuffer);
         frameInfo.seconds = secondsOf(CMSampleBufferGetPresentationTimeStamp(sample));
         frameInfo.duration = secondsOf(CMSampleBufferGetOutputDuration(sample));
 
@@ -241,7 +241,7 @@ Graphics::Image nativeBufferToImage(void* buffer)
 
     auto width = (int) CVPixelBufferGetWidth(pixelBuffer);
     auto height = (int) CVPixelBufferGetHeight(pixelBuffer);
-    auto stride = CVPixelBufferGetBytesPerRow(pixelBuffer);
+    auto stride = (int) CVPixelBufferGetBytesPerRow(pixelBuffer);
     const auto* base = (const std::uint8_t*) CVPixelBufferGetBaseAddress(pixelBuffer);
 
     auto image = Graphics::Image {};
@@ -252,7 +252,7 @@ Graphics::Image nativeBufferToImage(void* buffer)
 
         for (auto y = 0; y < height; ++y)
         {
-            const auto* row = base + (std::size_t) y * stride;
+            const auto* row = base + y * stride;
 
             for (auto x = 0; x < width; ++x)
                 image.set(x,

--- a/Lib/eacp/Video/Decode/Decoder-Windows.cpp
+++ b/Lib/eacp/Video/Decode/Decoder-Windows.cpp
@@ -142,24 +142,24 @@ void copyPlanes(const std::uint8_t* source,
                 int height,
                 Vector<std::uint8_t>& out)
 {
-    auto rowBytes = static_cast<std::size_t>(width);
+    auto rowBytes = width;
     auto chromaRows = height / 2;
 
-    out.resize((int) framePixelBytes(FramePixelFormat::NV12, width, height));
+    out.resize(framePixelBytes(FramePixelFormat::NV12, width, height));
 
-    auto copyRows = [&](std::ptrdiff_t sourceRow, std::size_t destRow, int rows)
+    auto copyRows = [&](int sourceRow, int destRow, int rows)
     {
         for (auto y = 0; y < rows; ++y)
         {
             const auto* from =
                 source + (sourceRow + y) * static_cast<std::ptrdiff_t>(stride);
             std::memcpy(
-                out.data() + (destRow + (std::size_t) y) * rowBytes, from, rowBytes);
+                out.data() + (destRow + y) * rowBytes, from, (std::size_t) rowBytes);
         }
     };
 
     copyRows(0, 0, height);
-    copyRows(height, (std::size_t) height, chromaRows);
+    copyRows(height, height, chromaRows);
 }
 } // namespace
 
@@ -491,7 +491,7 @@ private:
         frameInfo.width = videoInfo.width;
         frameInfo.height = videoInfo.height;
         frameInfo.format = FramePixelFormat::NV12;
-        frameInfo.bytesPerRow = static_cast<std::size_t>(videoInfo.width);
+        frameInfo.bytesPerRow = videoInfo.width;
         frameInfo.yuvMatrix = yuvMatrix;
         frameInfo.fullRangeYuv = fullRangeYuv;
         frameInfo.seconds = seconds;

--- a/Lib/eacp/Video/Decode/FrameImage.cpp
+++ b/Lib/eacp/Video/Decode/FrameImage.cpp
@@ -41,14 +41,14 @@ Graphics::Image nv12ToImage(const VideoFrame& frame)
 
     for (auto y = 0; y < frame.height(); ++y)
     {
-        const auto* lumaRow = luma + (std::size_t) y * stride;
+        const auto* lumaRow = luma + y * stride;
 
         // One chroma row and one chroma pair per two pixels each way.
-        const auto* chromaRow = chroma + (std::size_t) (y / 2) * stride;
+        const auto* chromaRow = chroma + (y / 2) * stride;
 
         for (auto x = 0; x < frame.width(); ++x)
         {
-            const auto* pair = chromaRow + (std::size_t) (x / 2) * 2;
+            const auto* pair = chromaRow + (x / 2) * 2;
             image.set(x, y, yuvToColor(transform, lumaRow[x], pair[0], pair[1]));
         }
     }
@@ -60,12 +60,11 @@ Graphics::Image bgraToImage(const VideoFrame& frame)
 {
     const auto* pixels = frame.pixels();
     auto image = Graphics::Image {frame.width(), frame.height()};
-    auto stride = frame.bytesPerRow() != 0 ? frame.bytesPerRow()
-                                           : (std::size_t) frame.width() * 4;
+    auto stride = frame.bytesPerRow() != 0 ? frame.bytesPerRow() : frame.width() * 4;
 
     for (auto y = 0; y < frame.height(); ++y)
     {
-        const auto* row = pixels + (std::size_t) y * stride;
+        const auto* row = pixels + y * stride;
 
         for (auto x = 0; x < frame.width(); ++x)
             image.set(x,

--- a/Lib/eacp/Video/Decode/FrameStream.cpp
+++ b/Lib/eacp/Video/Decode/FrameStream.cpp
@@ -42,8 +42,8 @@ int FrameStream::depthWithinBudget(const VideoInfo& info,
                                    const StreamOptions& options)
 {
     auto requested = std::max(1, options.queueDepth);
-    auto frameBytes = (std::size_t) std::max(0, info.width)
-                      * (std::size_t) std::max(0, info.height) * 4u;
+    auto frameBytes =
+        (std::int64_t) std::max(0, info.width) * std::max(0, info.height) * 4;
 
     if (frameBytes == 0 || options.maxQueueBytes == 0)
         return requested;

--- a/Lib/eacp/Video/Decode/FrameStream.h
+++ b/Lib/eacp/Video/Decode/FrameStream.h
@@ -33,7 +33,7 @@ struct StreamOptions
     // That costs around 630 MB while an 8K file is open and proportionally
     // nothing below it: 1080p reaches the requested depth on 40 MB either way.
     // Lower it if a soft memory ceiling matters more than smoothness.
-    std::size_t maxQueueBytes = 512u * 1024u * 1024u;
+    int maxQueueBytes = 512 * 1024 * 1024;
 };
 
 // A decoded-frame stream: a Decoder, the thread that runs it ahead of the

--- a/Lib/eacp/Video/Decode/VideoFrame.h
+++ b/Lib/eacp/Video/Decode/VideoFrame.h
@@ -24,9 +24,9 @@ enum class FramePixelFormat
 };
 
 // Bytes one frame of this size and format occupies, tightly packed.
-constexpr std::size_t framePixelBytes(FramePixelFormat format, int width, int height)
+constexpr int framePixelBytes(FramePixelFormat format, int width, int height)
 {
-    auto pixels = (std::size_t) width * (std::size_t) height;
+    auto pixels = width * height;
     return format == FramePixelFormat::NV12 ? pixels + pixels / 2 : pixels * 4;
 }
 
@@ -111,7 +111,7 @@ struct FrameInfo
     // Distance between rows, which may exceed width * 4 on a padded buffer.
     // Only meaningful for the CPU path; the zero-copy path reads it from the
     // platform buffer.
-    std::size_t bytesPerRow = 0;
+    int bytesPerRow = 0;
 
     FramePixelFormat format = FramePixelFormat::BGRA8;
 
@@ -188,7 +188,7 @@ public:
     int height() const { return info().height; }
     double seconds() const { return info().seconds; }
     double duration() const { return info().duration; }
-    std::size_t bytesPerRow() const { return info().bytesPerRow; }
+    int bytesPerRow() const { return info().bytesPerRow; }
     FramePixelFormat format() const { return info().format; }
 
     YuvTransform yuvTransform() const
@@ -238,7 +238,7 @@ public:
         if (base == nullptr)
             return nullptr;
 
-        return base + bytesPerRow() * (std::size_t) height();
+        return base + bytesPerRow() * height();
     }
 
 private:

--- a/Lib/eacp/Video/Demux/BoxReader.h
+++ b/Lib/eacp/Video/Demux/BoxReader.h
@@ -1,8 +1,9 @@
 #pragma once
 
+#include <eacp/Core/Utils/Containers.h>
+
 #include <cstddef>
 #include <cstdint>
-#include <span>
 
 // Bounds-checked traversal of ISOBMFF box structures. A named namespace
 // rather than an anonymous one: this header is included from files that CI
@@ -25,16 +26,16 @@ consteval std::uint32_t fourcc(const char (&tag)[5])
 class BoxReader
 {
 public:
-    explicit BoxReader(std::span<const std::uint8_t> bytesToRead)
+    explicit BoxReader(Span<const std::uint8_t> bytesToRead)
         : bytes(bytesToRead)
     {
     }
 
     bool ok() const { return !failed; }
     std::size_t position() const { return offset; }
-    std::size_t remaining() const { return bytes.size() - offset; }
+    std::size_t remaining() const { return bytes.getSize() - offset; }
 
-    std::span<const std::uint8_t> readBytes(std::size_t count)
+    Span<const std::uint8_t> readBytes(std::size_t count)
     {
         if (count > remaining())
         {
@@ -66,7 +67,7 @@ public:
     std::int32_t readS32() { return static_cast<std::int32_t>(readU32()); }
 
 private:
-    std::uint64_t readBigEndian(std::size_t count)
+    std::uint64_t readBigEndian(int count)
     {
         auto data = readBytes(count);
         auto value = std::uint64_t {0};
@@ -77,7 +78,7 @@ private:
         return value;
     }
 
-    std::span<const std::uint8_t> bytes;
+    Span<const std::uint8_t> bytes;
     std::size_t offset = 0;
     bool failed = false;
 };
@@ -86,7 +87,7 @@ private:
 struct Box
 {
     std::uint32_t type = 0;
-    std::span<const std::uint8_t> payload;
+    Span<const std::uint8_t> payload;
 };
 
 // Reads the box starting at the reader's position. size == 0 extends to the
@@ -128,8 +129,7 @@ inline bool nextBox(BoxReader& reader, Box& out)
 
 // The first direct child of `parent` with the given type; false when absent
 // or when the parent's box structure is malformed before it is reached.
-inline bool
-    findChild(std::span<const std::uint8_t> parent, std::uint32_t type, Box& out)
+inline bool findChild(Span<const std::uint8_t> parent, std::uint32_t type, Box& out)
 {
     auto reader = BoxReader {parent};
     auto box = Box {};

--- a/Lib/eacp/Video/Demux/Mp4Demuxer.cpp
+++ b/Lib/eacp/Video/Demux/Mp4Demuxer.cpp
@@ -27,7 +27,7 @@ constexpr auto boxStss = fourcc("stss");
 
 // A SampleEntry header plus the fixed VisualSampleEntry fields; the codec
 // configuration boxes start here.
-constexpr auto visualSampleEntrySize = std::size_t {78};
+constexpr auto visualSampleEntrySize = 78;
 
 // Far beyond any real file, and keeps a hostile count from asking a table
 // for gigabytes before its bytes are ever read.
@@ -77,7 +77,7 @@ bool tableFits(const BoxReader& reader,
 
 struct Mp4TrackParser
 {
-    bool parseFile(std::span<const std::uint8_t> fileBytes)
+    bool parseFile(Span<const std::uint8_t> fileBytes)
     {
         auto reader = BoxReader {fileBytes};
         auto box = Box {};
@@ -95,7 +95,7 @@ struct Mp4TrackParser
     // Walks every trak rather than stopping at the video one: the audio
     // summary is read on the way past, and the order of the two in the file is
     // the muxer's business, not ours.
-    bool parseMoov(std::span<const std::uint8_t> payload)
+    bool parseMoov(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         auto box = Box {};
@@ -117,7 +117,7 @@ struct Mp4TrackParser
         return videoParsed;
     }
 
-    std::uint32_t trakHandler(std::span<const std::uint8_t> trak) const
+    std::uint32_t trakHandler(Span<const std::uint8_t> trak) const
     {
         auto mdia = Box {};
         auto hdlr = Box {};
@@ -133,7 +133,7 @@ struct Mp4TrackParser
         return reader.ok() ? handler : 0;
     }
 
-    void parseAudioTrak(std::span<const std::uint8_t> trak)
+    void parseAudioTrak(Span<const std::uint8_t> trak)
     {
         auto mdia = Box {};
         auto mdhd = Box {};
@@ -156,7 +156,7 @@ struct Mp4TrackParser
 
     // The AudioSampleEntry fields shared by every version of the box: channel
     // count, sample size, then the 16.16 sample rate.
-    void parseAudioSampleEntry(std::span<const std::uint8_t> stsd)
+    void parseAudioSampleEntry(Span<const std::uint8_t> stsd)
     {
         auto reader = BoxReader {stsd};
         reader.skip(4);
@@ -181,7 +181,7 @@ struct Mp4TrackParser
         audio.sampleRate = static_cast<int>(sampleRate);
     }
 
-    bool parseTrak(std::span<const std::uint8_t> trak)
+    bool parseTrak(Span<const std::uint8_t> trak)
     {
         auto mdia = Box {};
         auto mdhd = Box {};
@@ -194,12 +194,12 @@ struct Mp4TrackParser
                && findChild(minf.payload, boxStbl, stbl) && parseStbl(stbl.payload);
     }
 
-    bool parseMdhd(std::span<const std::uint8_t> payload)
+    bool parseMdhd(Span<const std::uint8_t> payload)
     {
         return parseMdhd(payload, info.timescale, info.duration);
     }
 
-    static bool parseMdhd(std::span<const std::uint8_t> payload,
+    static bool parseMdhd(Span<const std::uint8_t> payload,
                           std::uint32_t& timescaleOut,
                           std::uint64_t& durationOut)
     {
@@ -222,7 +222,7 @@ struct Mp4TrackParser
         return true;
     }
 
-    bool parseStbl(std::span<const std::uint8_t> stbl)
+    bool parseStbl(Span<const std::uint8_t> stbl)
     {
         auto reader = BoxReader {stbl};
         auto box = Box {};
@@ -270,7 +270,7 @@ struct Mp4TrackParser
                && tables.sampleCount > 0;
     }
 
-    bool parseStsd(std::span<const std::uint8_t> payload)
+    bool parseStsd(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         reader.skip(4);
@@ -308,7 +308,7 @@ struct Mp4TrackParser
         return true;
     }
 
-    bool parseStts(std::span<const std::uint8_t> payload)
+    bool parseStts(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         reader.skip(4);
@@ -329,7 +329,7 @@ struct Mp4TrackParser
         return reader.ok();
     }
 
-    bool parseCtts(std::span<const std::uint8_t> payload)
+    bool parseCtts(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         auto isSigned = reader.readU8() == 1;
@@ -353,7 +353,7 @@ struct Mp4TrackParser
         return reader.ok();
     }
 
-    bool parseStsc(std::span<const std::uint8_t> payload)
+    bool parseStsc(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         reader.skip(4);
@@ -375,7 +375,7 @@ struct Mp4TrackParser
         return reader.ok();
     }
 
-    bool parseChunkOffsets(std::span<const std::uint8_t> payload, bool is64Bit)
+    bool parseChunkOffsets(Span<const std::uint8_t> payload, bool is64Bit)
     {
         auto reader = BoxReader {payload};
         reader.skip(4);
@@ -394,7 +394,7 @@ struct Mp4TrackParser
         return reader.ok();
     }
 
-    bool parseStsz(std::span<const std::uint8_t> payload)
+    bool parseStsz(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         reader.skip(4);
@@ -418,7 +418,7 @@ struct Mp4TrackParser
         return reader.ok();
     }
 
-    bool parseStss(std::span<const std::uint8_t> payload)
+    bool parseStss(Span<const std::uint8_t> payload)
     {
         auto reader = BoxReader {payload};
         reader.skip(4);
@@ -603,7 +603,7 @@ bool Mp4Demuxer::open(const FilePath& path)
     return true;
 }
 
-bool Mp4Demuxer::parse(std::span<const std::uint8_t> fileBytes)
+bool Mp4Demuxer::parse(Span<const std::uint8_t> fileBytes)
 {
     valid = false;
     trackInfo = {};
@@ -618,7 +618,7 @@ bool Mp4Demuxer::parse(std::span<const std::uint8_t> fileBytes)
 
     auto samples = Vector<Mp4Sample> {};
 
-    if (!resolveSampleRanges(parser.tables, fileBytes.size(), samples)
+    if (!resolveSampleRanges(parser.tables, fileBytes.getSize(), samples)
         || !applyTimestamps(parser.tables, samples)
         || !markKeyframes(parser.tables, samples))
         return false;
@@ -631,18 +631,17 @@ bool Mp4Demuxer::parse(std::span<const std::uint8_t> fileBytes)
     return true;
 }
 
-std::span<const std::uint8_t> Mp4Demuxer::sampleBytes(int index) const
+Span<const std::uint8_t> Mp4Demuxer::sampleBytes(int index) const
 {
     if (index < 0 || index >= sampleList.size())
         return {};
 
     auto& range = sampleList[index].byteRange;
 
-    if (range.end() > fileData.size())
+    if (range.end() > fileData.getSize())
         return {};
 
-    return fileData.subspan(static_cast<std::size_t>(range.start),
-                            static_cast<std::size_t>(range.length));
+    return fileData.subspan(range.start, range.length);
 }
 
 double Mp4Demuxer::toSeconds(std::int64_t timeUnits) const

--- a/Lib/eacp/Video/Demux/Mp4Demuxer.h
+++ b/Lib/eacp/Video/Demux/Mp4Demuxer.h
@@ -4,7 +4,6 @@
 
 #include <cstdint>
 #include <optional>
-#include <span>
 
 namespace eacp::Video
 {
@@ -86,7 +85,7 @@ public:
 
     // Parses caller-owned bytes, which must outlive every later call to
     // sampleBytes(). For tests and in-memory sources.
-    bool parse(std::span<const std::uint8_t> fileBytes);
+    bool parse(Span<const std::uint8_t> fileBytes);
 
     bool isValid() const { return valid; }
 
@@ -98,13 +97,13 @@ public:
     const Vector<Mp4Sample>& samples() const { return sampleList; }
 
     // The mapped bytes of one sample; empty for an out-of-range index.
-    std::span<const std::uint8_t> sampleBytes(int index) const;
+    Span<const std::uint8_t> sampleBytes(int index) const;
 
     double toSeconds(std::int64_t timeUnits) const;
 
 private:
     std::optional<MemoryMappedFile> file;
-    std::span<const std::uint8_t> fileData;
+    Span<const std::uint8_t> fileData;
     Mp4TrackInfo trackInfo;
     Mp4AudioInfo audioInfo;
     Vector<Mp4Sample> sampleList;

--- a/Lib/eacp/Video/Encoder-Apple.mm
+++ b/Lib/eacp/Video/Encoder-Apple.mm
@@ -240,7 +240,7 @@ void AppleEncoder::appendImage(const Graphics::Image& image, double ptsSeconds)
     CVPixelBufferLockBaseAddress(buffer, 0);
 
     auto* dst = static_cast<std::uint8_t*>(CVPixelBufferGetBaseAddress(buffer));
-    auto dstStride = CVPixelBufferGetBytesPerRow(buffer);
+    auto dstStride = (int) CVPixelBufferGetBytesPerRow(buffer);
     compositeOverBlackBGRA(image, dst, width, height, dstStride);
 
     CVPixelBufferUnlockBaseAddress(buffer, 0);

--- a/Lib/eacp/Video/Encoder-Windows.cpp
+++ b/Lib/eacp/Video/Encoder-Windows.cpp
@@ -265,8 +265,7 @@ void WindowsEncoder::appendImage(const Graphics::Image& image, double ptsSeconds
     if (FAILED(buffer->Lock(&data, &maxLength, nullptr)))
         return;
 
-    compositeOverBlackBGRA(
-        image, data, width, height, static_cast<std::size_t>(width) * 4);
+    compositeOverBlackBGRA(image, data, width, height, width * 4);
 
     buffer->Unlock();
     buffer->SetCurrentLength(sizeInBytes);
@@ -277,7 +276,7 @@ void WindowsEncoder::appendImage(const Graphics::Image& image, double ptsSeconds
 void WindowsEncoder::appendBGRA(const std::uint8_t* rows,
                                 int sourceWidth,
                                 int sourceHeight,
-                                std::size_t stride,
+                                int stride,
                                 double ptsSeconds)
 {
     // The Screen tier's frames arrive on a thread pool thread MF has never
@@ -287,7 +286,7 @@ void WindowsEncoder::appendBGRA(const std::uint8_t* rows,
     if (!writer || rows == nullptr)
         return;
 
-    auto destinationStride = static_cast<std::size_t>(width) * 4;
+    auto destinationStride = width * 4;
     auto sizeInBytes = static_cast<DWORD>(destinationStride * height);
 
     ComPtr<IMFMediaBuffer> buffer;
@@ -308,9 +307,9 @@ void WindowsEncoder::appendBGRA(const std::uint8_t* rows,
         std::memset(data, 0, sizeInBytes);
 
     for (auto y = 0; y < copyHeight; ++y)
-        std::memcpy(data + static_cast<std::size_t>(y) * destinationStride,
-                    rows + static_cast<std::size_t>(y) * stride,
-                    static_cast<std::size_t>(copyWidth) * 4);
+        std::memcpy(data + y * destinationStride,
+                    rows + y * stride,
+                    (std::size_t) (copyWidth * 4));
 
     buffer->Unlock();
     buffer->SetCurrentLength(sizeInBytes);

--- a/Lib/eacp/Video/Encoder-Windows.h
+++ b/Lib/eacp/Video/Encoder-Windows.h
@@ -8,7 +8,6 @@
 #include <mfreadwrite.h>
 #include <wrl/client.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <mutex>
 #include <optional>
@@ -46,7 +45,7 @@ struct WindowsEncoder final : Encoder
     void appendBGRA(const std::uint8_t* rows,
                     int sourceWidth,
                     int sourceHeight,
-                    std::size_t stride,
+                    int stride,
                     double ptsSeconds);
 
     bool configureStreams(const EncoderSpec& spec);

--- a/Lib/eacp/Video/Encoder.h
+++ b/Lib/eacp/Video/Encoder.h
@@ -5,7 +5,6 @@
 #include <eacp/Core/Threads/Async.h>
 #include <eacp/Graphics/Image/Image.h>
 
-#include <cstddef>
 #include <cstdint>
 #include <optional>
 
@@ -25,15 +24,15 @@ inline void compositeOverBlackBGRA(const Graphics::Image& image,
                                    std::uint8_t* dst,
                                    int width,
                                    int height,
-                                   std::size_t dstStride)
+                                   int dstStride)
 {
     const auto* src = image.pixels().data();
-    auto srcStride = static_cast<std::size_t>(image.width()) * 4;
+    auto srcStride = image.width() * 4;
 
     for (auto y = 0; y < height; ++y)
     {
-        const auto* s = src + static_cast<std::size_t>(y) * srcStride;
-        auto* d = dst + static_cast<std::size_t>(y) * dstStride;
+        const auto* s = src + y * srcStride;
+        auto* d = dst + y * dstStride;
 
         for (auto x = 0; x < width; ++x)
         {

--- a/Lib/eacp/Video/ScreenCapture-Windows.cpp
+++ b/Lib/eacp/Video/ScreenCapture-Windows.cpp
@@ -388,7 +388,7 @@ struct WindowsScreenCapture final : ScreenCapture
                                      static_cast<std::int32_t>(description.Width)),
                             std::min(contentSize.Height,
                                      static_cast<std::int32_t>(description.Height)),
-                            mapped.RowPitch,
+                            (int) mapped.RowPitch,
                             pts);
 
         context->Unmap(staging.Get(), 0);

--- a/Lib/eacp/WebView/Codegen/HooksFormat.cpp
+++ b/Lib/eacp/WebView/Codegen/HooksFormat.cpp
@@ -43,9 +43,9 @@ std::string_view tsPrimitiveLocal(PrimitiveKind kind)
 Vector<std::string_view> splitOnDot(std::string_view name)
 {
     auto out = Vector<std::string_view> {};
-    auto start = std::size_t {0};
+    auto start = 0;
 
-    for (auto i = std::size_t {0}; i < name.size(); ++i)
+    for (auto i = 0; i < (int) name.size(); ++i)
     {
         if (name[i] == '.')
         {
@@ -113,7 +113,7 @@ std::string stripTrailing(std::string s, std::string_view suffix)
     return s;
 }
 
-const TypeNode* findRootByQualified(std::span<const TypeNode> roots,
+const TypeNode* findRootByQualified(Span<const TypeNode> roots,
                                     std::string_view qualified)
 {
     for (auto& r: roots)
@@ -167,7 +167,7 @@ std::optional<KeyedInfo> resolveKeyedInfo(const TypeNode& payload,
     return KeyedInfo {&itemNode, tsPrimitiveLocal(keyNode.primitive)};
 }
 
-bool commandExists(std::span<const CommandEntry> commands, std::string_view name)
+bool commandExists(Span<const CommandEntry> commands, std::string_view name)
 {
     for (auto& c: commands)
         if (c.name == name)
@@ -186,9 +186,9 @@ std::string initialJsonFor(const EventEntry& event)
 
 } // namespace
 
-std::string formatHooksModule(std::span<TypeNode> typeRoots,
-                              std::span<const CommandEntry> commands,
-                              std::span<const EventEntry> events,
+std::string formatHooksModule(Span<TypeNode> typeRoots,
+                              Span<const CommandEntry> commands,
+                              Span<const EventEntry> events,
                               std::string_view /*baseName*/)
 {
     auto resolved = resolveTypes(typeRoots);

--- a/Lib/eacp/WebView/Codegen/HooksFormat.h
+++ b/Lib/eacp/WebView/Codegen/HooksFormat.h
@@ -5,8 +5,6 @@
 #include <Miro/CommandExport/CommandEntry.h>
 #include <Miro/TypeTree/TypeTree.h>
 
-#include <span>
-
 namespace eacp::Graphics::Codegen
 {
 
@@ -25,10 +23,9 @@ namespace eacp::Graphics::Codegen
 // commands is consulted only to detect the existence of a get<Name>
 // twin; nothing about the command beyond the name is read. typeRoots
 // must include every event payload's reflected TypeNode.
-std::string
-    formatHooksModule(std::span<Miro::TypeTree::TypeNode> typeRoots,
-                      std::span<const Miro::CommandExport::CommandEntry> commands,
-                      std::span<const EventEntry> events,
-                      std::string_view baseName);
+std::string formatHooksModule(Span<Miro::TypeTree::TypeNode> typeRoots,
+                              Span<const Miro::CommandExport::CommandEntry> commands,
+                              Span<const EventEntry> events,
+                              std::string_view baseName);
 
 } // namespace eacp::Graphics::Codegen

--- a/Lib/eacp/WebView/Codegen/Register.cpp
+++ b/Lib/eacp/WebView/Codegen/Register.cpp
@@ -28,14 +28,13 @@ using Miro::TypeExport::registerFormat;
 // know about events, so it leaves them empty for downstream resolvers).
 // EventEntry is a Miro::EventInfo alias, so both sides feed the same
 // formatter signature.
-std::span<const eacp::Graphics::EventEntry>
+EA::Span<const eacp::Graphics::EventEntry>
     eventsFor(const Miro::TypeExport::Context& ctx)
 {
     if (!ctx.events.empty())
         return ctx.events;
 
-    auto& global = eacp::Graphics::Detail::eventRegistry();
-    return {global.data(), static_cast<std::size_t>(global.size())};
+    return eacp::Graphics::Detail::eventRegistry();
 }
 
 [[maybe_unused]] const auto hooksFormat = registerFormat(Format {

--- a/Lib/eacp/WebView/Common.h
+++ b/Lib/eacp/WebView/Common.h
@@ -7,6 +7,5 @@
 
 #include <cctype>
 #include <cstdio>
-#include <span>
 #include <stdexcept>
 #include <unordered_map>

--- a/Lib/eacp/WebView/WebView/WebView-Shared.cpp
+++ b/Lib/eacp/WebView/WebView/WebView-Shared.cpp
@@ -172,9 +172,9 @@ std::string percentDecode(std::string_view encoded)
     auto out = std::string {};
     out.reserve(encoded.size());
 
-    for (auto i = std::size_t {0}; i < encoded.size(); ++i)
+    for (auto i = 0; i < (int) encoded.size(); ++i)
     {
-        if (encoded[i] == '%' && i + 2 < encoded.size())
+        if (encoded[i] == '%' && i + 2 < (int) encoded.size())
         {
             auto hi = hexDigit(encoded[i + 1]);
             auto lo = hexDigit(encoded[i + 2]);
@@ -337,14 +337,14 @@ std::string fileURLToPath(std::string_view url)
 FileProvider fromResEmbed(std::string category)
 {
     return [category = std::move(category)](
-               std::string_view path) -> std::optional<std::span<const std::uint8_t>>
+               std::string_view path) -> std::optional<ByteView>
     {
         auto view = ResEmbed::get(std::string(path), category);
 
         if (!view)
             return std::nullopt;
 
-        return std::span<const std::uint8_t> {view.data(), view.size()};
+        return ByteView {view.data(), view.getSize()};
     };
 }
 
@@ -379,7 +379,7 @@ StreamingProvider
             mimeForFile ? mimeForFile(pathStr) : mimeForPath(pathStr);
         response.size = file->size();
         response.read = [file](RangeSize offset, ByteSpan out)
-        { return file->read(offset, out); };
+        { return (int) file->read(offset, out); };
         return response;
     };
 }

--- a/Lib/eacp/WebView/WebView/WebView-Windows.cpp
+++ b/Lib/eacp/WebView/WebView/WebView-Windows.cpp
@@ -124,10 +124,9 @@ public:
         auto got = ULONG {0};
 
         if (want > 0 && resource.read)
-            got = static_cast<ULONG>(
-                resource.read(base + position,
-                              ByteSpan {static_cast<std::uint8_t*>(out),
-                                        static_cast<std::size_t>(want)}));
+            got = static_cast<ULONG>(resource.read(
+                base + position,
+                ByteSpan {static_cast<std::uint8_t*>(out), (int) want}));
 
         position += got;
 

--- a/Lib/eacp/WebView/WebView/WebView.h
+++ b/Lib/eacp/WebView/WebView/WebView.h
@@ -8,8 +8,8 @@ namespace eacp::Graphics
 {
 // Owning byte buffer and non-owning views used across the resource API.
 using Bytes = Vector<std::uint8_t>;
-using ByteSpan = std::span<std::uint8_t>;
-using ByteView = std::span<const std::uint8_t>;
+using ByteSpan = Span<std::uint8_t>;
+using ByteView = Span<const std::uint8_t>;
 
 // Byte offsets / lengths into a resource, and a half-open byte range.
 using RangeSize = std::uint64_t;
@@ -32,7 +32,7 @@ using FileProvider = std::function<std::optional<ByteView>(std::string_view path
 // handler calls it repeatedly with monotonically advancing offsets, and may
 // call it off the main thread -- so it must be safe to run on a background
 // queue.
-using ResourceReader = std::function<std::size_t(RangeSize offset, ByteSpan out)>;
+using ResourceReader = std::function<int(RangeSize offset, ByteSpan out)>;
 
 // A resource served in chunks rather than as one in-memory blob. The provider
 // reports the MIME type and the full `size`; the handler owns Range parsing,
@@ -285,9 +285,8 @@ public:
     // environment-creation failure later.
     static bool isRuntimeAvailable();
 
-    void addScriptMessageHandler(
-        const std::string& name,
-        const MessageFunc& handler) override;
+    void addScriptMessageHandler(const std::string& name,
+                                 const MessageFunc& handler) override;
     void removeScriptMessageHandler(const std::string& name) override;
 
     void addUserScript(const std::string& source,

--- a/Lib/eacp/WebView/WebView/WebView.mm
+++ b/Lib/eacp/WebView/WebView/WebView.mm
@@ -654,8 +654,7 @@ void schemeHandlerPumpTask(id self,
 
       auto got = context->resource.read(
           context->offset,
-          eacp::Graphics::ByteSpan {context->buffer.data(),
-                                    static_cast<std::size_t>(want)});
+          eacp::Graphics::ByteSpan {context->buffer.data(), (int) want});
 
       dispatch_async(dispatch_get_main_queue(), ^{
         if (! live->load())

--- a/Tests/Codegen/InversionCodegenTests.cpp
+++ b/Tests/Codegen/InversionCodegenTests.cpp
@@ -300,7 +300,7 @@ struct SubItem
 
 struct SubItemState
 {
-    std::vector<SubItem> items;
+    EA::Vector<SubItem> items;
 
     MIRO_REFLECT(items)
 };

--- a/Tests/Core/AllocationCount.h
+++ b/Tests/Core/AllocationCount.h
@@ -23,8 +23,8 @@ struct AllocationCount
         countingAllocations.store(false, std::memory_order_relaxed);
     }
 
-    std::size_t bytes() const
+    int bytes() const
     {
-        return allocatedBytes.load(std::memory_order_relaxed);
+        return (int) allocatedBytes.load(std::memory_order_relaxed);
     }
 };

--- a/Tests/Core/EventLoopTests.cpp
+++ b/Tests/Core/EventLoopTests.cpp
@@ -2,7 +2,6 @@
 
 #include <algorithm>
 #include <thread>
-#include <vector>
 
 using namespace nano;
 using eacp::Threads::callAsync;
@@ -116,12 +115,12 @@ auto tCallAfterOrdersManyDeadlines =
     test("EventLoop/callAfter/ordersManyPendingDeadlines") = []
 {
     constexpr auto count = 64;
-    auto order = std::vector<int>();
+    auto order = EA::Vector<int>();
 
     for (auto i = count; i > 0; --i)
         callAfter(eacp::Time::MS {i}, [&, i] { order.push_back(i); });
 
-    auto ok = runEventLoopUntil([&] { return (int) order.size() == count; },
+    auto ok = runEventLoopUntil([&] { return order.size() == count; },
                                 eacp::Time::MS {5000});
 
     check(ok);

--- a/Tests/Core/FileTests.cpp
+++ b/Tests/Core/FileTests.cpp
@@ -1,8 +1,6 @@
 #include "Common.h"
-#include <array>
 #include <filesystem>
 #include <fstream>
-#include <span>
 
 using namespace nano;
 using eacp::File;
@@ -74,7 +72,7 @@ auto tSeekBackAndForth = test("File/seekBackAndForth") = []
         check(file.read(6, buffer) == 4);
         check(buffer[0] == '6' && buffer[3] == '9');
 
-        check(file.read(0, std::span<std::uint8_t> {buffer.data(), 2}) == 2);
+        check(file.read(0, eacp::Span<std::uint8_t> {buffer.data(), 2}) == 2);
         check(buffer[0] == '0' && buffer[1] == '1');
     }
 

--- a/Tests/Core/FilesTests-Posix.cpp
+++ b/Tests/Core/FilesTests-Posix.cpp
@@ -9,7 +9,6 @@
 
 #include <filesystem>
 #include <fstream>
-#include <span>
 #include <string>
 #include <thread>
 
@@ -43,8 +42,8 @@ void writeAtomically(const std::filesystem::path& path, std::string_view content
 {
     eacp::Files::writeFileAtomically(
         FilePath {path},
-        std::span {reinterpret_cast<const std::uint8_t*>(contents.data()),
-                   contents.size()});
+        eacp::Span {reinterpret_cast<const std::uint8_t*>(contents.data()),
+                    (int) contents.size()});
 }
 } // namespace
 

--- a/Tests/Core/FilesTests.cpp
+++ b/Tests/Core/FilesTests.cpp
@@ -6,7 +6,6 @@
 #include <new>
 #include <filesystem>
 #include <fstream>
-#include <span>
 #include <thread>
 
 using namespace nano;
@@ -40,13 +39,13 @@ void writeAtomically(const std::filesystem::path& path, std::string_view content
 {
     eacp::Files::writeFileAtomically(
         FilePath {path},
-        std::span {reinterpret_cast<const std::uint8_t*>(contents.data()),
-                   contents.size()});
+        eacp::Span {reinterpret_cast<const std::uint8_t*>(contents.data()),
+                    (int) contents.size()});
 }
 
-std::size_t entryCount(const std::filesystem::path& dir)
+int entryCount(const std::filesystem::path& dir)
 {
-    auto count = std::size_t {0};
+    auto count = 0;
 
     for (const auto& entry: std::filesystem::directory_iterator {dir})
     {
@@ -201,14 +200,14 @@ auto tReadAllocatesAboutTheFileSize =
 
     // Large enough that a doubling buffer reallocates many times, so the
     // difference is structural rather than a fixed overhead.
-    const auto size = std::size_t {2 * 1024 * 1024};
-    write(path, std::string(size, 'x'));
+    const auto size = 2 * 1024 * 1024;
+    write(path, std::string((std::size_t) size, 'x'));
 
     auto counter = AllocationCount {};
     const auto contents = read(path);
     const auto bytes = counter.bytes();
 
-    check(contents.size() == size);
+    check((int) contents.size() == size);
     check(bytes < size * 2);
 };
 

--- a/Tests/Core/MemoryMappedFileTests.cpp
+++ b/Tests/Core/MemoryMappedFileTests.cpp
@@ -31,11 +31,11 @@ void write(const std::filesystem::path& path, std::string_view contents)
 
 // Distinct in every byte, so a window that lands one page early or late is a
 // failed comparison rather than a run of identical filler that matches anyway.
-std::string countingPattern(std::size_t size)
+std::string countingPattern(int size)
 {
-    auto contents = std::string(size, '\0');
+    auto contents = std::string((std::size_t) size, '\0');
 
-    for (auto i = std::size_t {0}; i < size; ++i)
+    for (auto i = 0; i < size; ++i)
         contents[i] = static_cast<char>(i % 251);
 
     return contents;
@@ -170,7 +170,7 @@ auto tMapsAnUnalignedWindow = test("MemoryMappedFile/mapsAnUnalignedWindow") = [
     const auto contents = countingPattern(256 * 1024);
     write(path, contents);
 
-    const auto offset = std::size_t {65536 + 1234};
+    const auto offset = 65536 + 1234;
     const auto length = std::size_t {5000};
 
     const auto file = MemoryMappedFile {FilePath {path}, offset, length};
@@ -315,6 +315,37 @@ auto tMappingDoesNotAllocateTheFile =
     // cache, not the heap.
     check(std::accumulate(file.bytes().begin(), file.bytes().end(), std::size_t {0})
           == size * std::size_t {'x'});
+
+    std::filesystem::remove_all(dir);
+};
+
+// The case the size_t surface exists for: a file past what an int counts.
+// Only ever extended, never written, so the filesystem keeps it sparse.
+auto tMapsAFileLargerThanAnInt =
+    test("MemoryMappedFile/mapsAFileLargerThanAnInt") = []
+{
+    const auto dir = scratchDirectory("large");
+    const auto path = dir / "large.bin";
+    const auto size = (std::size_t {1} << 31) + 4096;
+
+    write(path, "");
+    std::filesystem::resize_file(path, size);
+
+    const auto file = MemoryMappedFile {FilePath {path}};
+
+    check(file.isValid());
+    check(file.size() == size);
+    check(file.bytes().getSize() == size);
+    check(file.bytes().getSizeInBytes() == size);
+    check(file.bytes()[size - 1] == 0);
+    check(file.text().size() == size);
+
+    const auto tail = MemoryMappedFile {FilePath {path}, size - 4, 4};
+
+    check(tail.isValid());
+    check(tail.size() == 4);
+    check(tail.bytes().size() == 4);
+    check(tail.bytes().data() != nullptr);
 
     std::filesystem::remove_all(dir);
 };

--- a/Tests/GPU/AtomicTests.cpp
+++ b/Tests/GPU/AtomicTests.cpp
@@ -95,7 +95,7 @@ Buffer makeZeroed(int elements)
 
     return Buffer {Device::shared(),
                    zeros.data(),
-                   sizeof(std::uint32_t) * (std::size_t) elements,
+                   (int) sizeof(std::uint32_t) * elements,
                    BufferUsage::Storage};
 }
 
@@ -103,7 +103,7 @@ Vector<float> readFloats(const Buffer& buffer, int elements)
 {
     auto values = Vector<float> {};
     values.resize(elements);
-    buffer.read(values.data(), sizeof(float) * (std::size_t) elements);
+    buffer.read(values.data(), (int) sizeof(float) * elements);
     return values;
 }
 } // namespace

--- a/Tests/GPU/CompressedTextureTests.cpp
+++ b/Tests/GPU/CompressedTextureTests.cpp
@@ -768,7 +768,7 @@ auto tCompressedSuppliedChain = test("Compressed/aSuppliedChainMinifies") = []
     constexpr auto levels = 5; // 16, 8, 4, 2, 1
 
     auto bytes = Vector<std::uint8_t> {};
-    bytes.resize((int) mipChainBytes(TextureFormat::BC1RGBA, size, size, levels));
+    bytes.resize(mipChainBytes(TextureFormat::BC1RGBA, size, size, levels));
 
     constexpr std::uint16_t green565 = 0x07E0;
 

--- a/Tests/GPU/DepthTextureTests.cpp
+++ b/Tests/GPU/DepthTextureTests.cpp
@@ -185,7 +185,7 @@ struct DepthCopyView final : GPUView
         setSampleCount(1);
 
         quad.setVertices(leftHalf, 6);
-        quad.color = std::array {1.f, 0.f, 0.f};
+        quad.color = Array {1.f, 0.f, 0.f};
         quad.prepare(1,
                      true,
                      PrimitiveTopology::Triangles,
@@ -286,7 +286,7 @@ void renderOnce(View& view)
 
 float valueAt(const Array<float, pixelCount>& values, int x, int y)
 {
-    return values[(std::size_t) (y * targetSize + x)];
+    return values[y * targetSize + x];
 }
 
 bool near(float value, float expected)
@@ -396,7 +396,7 @@ auto tFloatTargetKeepsItsPrecision =
 
     for (auto i = 0; i < pixelCount; ++i)
     {
-        check(view.values[(std::size_t) i] == nearlyFar);
-        check(view.values[(std::size_t) i] != 1.f);
+        check(view.values[i] == nearlyFar);
+        check(view.values[i] != 1.f);
     }
 };

--- a/Tests/GPU/IndirectDispatchTests.cpp
+++ b/Tests/GPU/IndirectDispatchTests.cpp
@@ -132,7 +132,7 @@ Buffer makeCandidates(int howMany)
 
     return Buffer {Device::shared(),
                    values.data(),
-                   sizeof(float) * (std::size_t) capacity,
+                   (int) sizeof(float) * capacity,
                    BufferUsage::Storage};
 }
 
@@ -157,7 +157,7 @@ Vector<float> runPipeline(const Buffer& candidates, Consumer& consume)
 
     auto output = Buffer {Device::shared(),
                           blank.data(),
-                          sizeof(float) * (std::size_t) capacity,
+                          (int) sizeof(float) * capacity,
                           BufferUsage::Storage};
 
     auto counter = CountKernel {};
@@ -195,7 +195,7 @@ Vector<float> runPipeline(const Buffer& candidates, Consumer& consume)
 
     auto values = Vector<float> {};
     values.resize(capacity);
-    output.read(values.data(), sizeof(float) * (std::size_t) capacity);
+    output.read(values.data(), (int) sizeof(float) * capacity);
     return values;
 }
 
@@ -268,7 +268,7 @@ auto tGuardedConsumerStopsAtTheCount =
 
     auto output = Buffer {Device::shared(),
                           blank.data(),
-                          sizeof(float) * (std::size_t) capacity,
+                          (int) sizeof(float) * capacity,
                           BufferUsage::Storage};
 
     auto candidates = makeCandidates(marked);
@@ -308,7 +308,7 @@ auto tGuardedConsumerStopsAtTheCount =
 
     auto values = Vector<float> {};
     values.resize(capacity);
-    output.read(values.data(), sizeof(float) * (std::size_t) capacity);
+    output.read(values.data(), (int) sizeof(float) * capacity);
 
     check(countWritten(values) == marked);
 };

--- a/Tests/GPU/MultisampledTargetTests.cpp
+++ b/Tests/GPU/MultisampledTargetTests.cpp
@@ -214,7 +214,7 @@ using Readback = Array<unsigned char, pixelBytes>;
 
 const unsigned char* pixelAt(const Readback& pixels, int x, int y)
 {
-    return pixels.data() + ((std::size_t) y * targetSize + (std::size_t) x) * 4;
+    return pixels.data() + (y * targetSize + x) * 4;
 }
 
 // One triangle into a target of the given sample count, read back inside the

--- a/Tests/GPU/PackedHalfTests.cpp
+++ b/Tests/GPU/PackedHalfTests.cpp
@@ -171,11 +171,10 @@ auto tUnpackHalf2 = test("PackedHalf/unpacksEveryFloat16Class") = []
 
     auto count = words.size();
 
-    auto input = device.makeBuffer(words.data(),
-                                   (std::size_t) count * sizeof(std::uint32_t),
-                                   BufferUsage::Storage);
+    auto input = device.makeBuffer(
+        words.data(), count * (int) sizeof(std::uint32_t), BufferUsage::Storage);
 
-    auto output = device.makeBuffer((std::size_t) count * 2 * sizeof(float));
+    auto output = device.makeBuffer(count * 2 * (int) sizeof(float));
 
     auto kernel = UnpackKernel {};
     kernel.words = input;
@@ -192,7 +191,7 @@ auto tUnpackHalf2 = test("PackedHalf/unpacksEveryFloat16Class") = []
     commands.commit();
 
     auto result = Vector<float>(count * 2);
-    output.read(result.data(), (std::size_t) result.size() * sizeof(float));
+    output.read(result.data(), result.size() * (int) sizeof(float));
 
     for (auto i = 0; i < count; ++i)
     {

--- a/Tests/GPU/RenderTargetDepthTests.cpp
+++ b/Tests/GPU/RenderTargetDepthTests.cpp
@@ -146,11 +146,11 @@ struct DepthTargetView final : GPUView
             auto into = frame.beginPass(target, {{0.f, 0.f, 0.f, 1.f}});
 
             quads.depth = nearDepth;
-            quads.color = std::array {1.f, 0.f, 0.f};
+            quads.color = Array {1.f, 0.f, 0.f};
             into.draw(quads);
 
             quads.depth = farDepth;
-            quads.color = std::array {0.f, 1.f, 0.f};
+            quads.color = Array {0.f, 1.f, 0.f};
             into.draw(quads);
         }
 

--- a/Tests/GPU/StorePlacementTests.cpp
+++ b/Tests/GPU/StorePlacementTests.cpp
@@ -81,7 +81,7 @@ Buffer makeFilled(int elements, float value)
 
     return Buffer {Device::shared(),
                    initial.data(),
-                   sizeof(float) * (std::size_t) elements,
+                   (int) sizeof(float) * elements,
                    BufferUsage::Storage};
 }
 
@@ -89,7 +89,7 @@ Vector<float> readBack(const Buffer& buffer, int elements)
 {
     auto values = Vector<float> {};
     values.resize(elements);
-    buffer.read(values.data(), sizeof(float) * (std::size_t) elements);
+    buffer.read(values.data(), (int) sizeof(float) * elements);
     return values;
 }
 

--- a/Tests/GPU/StreamingBufferTests.cpp
+++ b/Tests/GPU/StreamingBufferTests.cpp
@@ -32,12 +32,12 @@ constexpr auto alignment = StreamingBuffers::alignment;
 // The payload is never read back, so its contents do not matter - but its
 // length does: write() copies the byte count it is given, exactly as
 // Buffer::update does, so a short source and a long count reads off the end.
-BufferRange writeOnce(StreamingBuffers& buffers, std::size_t bytes = 128)
+BufferRange writeOnce(StreamingBuffers& buffers, int bytes = 128)
 {
     static auto payload = Vector<std::byte> {};
 
-    if (payload.size() < (int) bytes)
-        payload.resize((int) bytes);
+    if (payload.size() < bytes)
+        payload.resize(bytes);
 
     return buffers.write(payload.data(), bytes);
 }
@@ -129,7 +129,8 @@ auto tRecyclesWithTheRightPeriod = test("StreamingBuffers/recyclesWithPeriod") =
 // earlier flush's draw is still queued in the command buffer when the next one
 // is written. With an arena the flushes share one buffer and must not share
 // any of its bytes.
-auto tSeveralWritesInOneFrame = test("StreamingBuffers/writesInOneFrameAreDisjoint") = []
+auto tSeveralWritesInOneFrame =
+    test("StreamingBuffers/writesInOneFrameAreDisjoint") = []
 {
     auto buffers = StreamingBuffers {BufferUsage::Vertex};
 
@@ -318,13 +319,13 @@ auto tManyShuffledWritesAllocateNothing =
     // Two thousand sizes between 64 bytes and 8 KB, fixed by a small linear
     // congruential generator so the test is the same test every run.
     constexpr auto writesPerFrame = 2000;
-    auto sizes = Vector<std::size_t> {};
+    auto sizes = Vector<int> {};
     auto seed = std::uint32_t {12345};
 
     for (auto i = 0; i < writesPerFrame; ++i)
     {
         seed = seed * 1664525u + 1013904223u;
-        sizes.add(64 + (seed >> 8) % (8 * 1024 - 64));
+        sizes.add(64 + (int) ((seed >> 8) % (8 * 1024 - 64)));
     }
 
     auto streamFrame = [&](int rotation)
@@ -387,7 +388,7 @@ auto tOneLongFrameGrowsBytesNotBuffers =
     nextFrame();
 
     constexpr auto writes = 5000;
-    constexpr auto bytesPerWrite = std::size_t {300};
+    constexpr auto bytesPerWrite = 300;
 
     auto last = BufferRange {};
 

--- a/Tests/GPU/SuppliedMipChainTests.cpp
+++ b/Tests/GPU/SuppliedMipChainTests.cpp
@@ -131,7 +131,7 @@ Vector<std::uint32_t> redOverGreen(int levels)
         mipChainBytes(TextureFormat::RGBA8Unorm, textureSize, textureSize, levels);
 
     auto pixels = Vector<std::uint32_t> {};
-    pixels.resize((int) (bytes / sizeof(std::uint32_t)));
+    pixels.resize(bytes / (int) sizeof(std::uint32_t));
 
     auto index = 0;
 
@@ -185,10 +185,10 @@ auto tChainBytes = test("SuppliedMipChain/theLayoutIsTheSumOfItsLevels") = []
     check(built.isValid());
     check(built.levelCount() == 7);
 
-    auto total = std::size_t {0};
+    auto total = 0;
 
     for (auto level = 0; level < built.levelCount(); ++level)
-        total += (std::size_t) built.levels[level].size();
+        total += built.levels[level].size();
 
     check(total == mipChainBytes(TextureFormat::RGBA8Unorm, 64, 64, 7));
 };
@@ -274,9 +274,8 @@ auto tUpdateReplacesTheWholeChain =
     // Green at the top and red all the way down: the mirror of what it holds.
     auto inverted = Vector<std::uint32_t> {};
     inverted.resize(
-        (int) (mipChainBytes(
-                   TextureFormat::RGBA8Unorm, textureSize, textureSize, levels)
-               / sizeof(std::uint32_t)));
+        mipChainBytes(TextureFormat::RGBA8Unorm, textureSize, textureSize, levels)
+        / (int) sizeof(std::uint32_t));
 
     auto index = 0;
 
@@ -325,9 +324,8 @@ auto tStrideIsRefused = test("SuppliedMipChain/aStrideIsRefused") = []
     // ever regressed - which would crash instead of failing the check below.
     auto flat = Vector<std::uint32_t> {};
     flat.resize(
-        (int) (mipChainBytes(
-                   TextureFormat::RGBA8Unorm, textureSize, textureSize, levels)
-               / sizeof(std::uint32_t)));
+        mipChainBytes(TextureFormat::RGBA8Unorm, textureSize, textureSize, levels)
+        / (int) sizeof(std::uint32_t));
 
     for (auto i = 0; i < flat.size(); ++i)
         flat[i] = green;

--- a/Tests/GPU/TextureReadTests.cpp
+++ b/Tests/GPU/TextureReadTests.cpp
@@ -151,7 +151,7 @@ struct ReadBackView final : GPUView
 // The pixel at (x, y) of a read-back RGBA8 image, as four bytes.
 const unsigned char* pixelAt(const unsigned char* pixels, int x, int y)
 {
-    return pixels + ((std::size_t) y * targetSize + (std::size_t) x) * 4;
+    return pixels + (y * targetSize + x) * 4;
 }
 } // namespace
 
@@ -214,7 +214,7 @@ auto tReadHonoursRegionAndStride = test("TextureRead/honoursRegionAndStride") = 
     read.fill(0xab);
 
     // Two rows of two texels, starting one in and one down.
-    texture.read({1.f, 1.f, 2.f, 2.f}, read.data(), (std::size_t) stride);
+    texture.read({1.f, 1.f, 2.f, 2.f}, read.data(), stride);
 
     check(read[0] == (unsigned char) (targetSize + 1));
     check(read[4] == (unsigned char) (targetSize + 2));

--- a/Tests/GPUWidgets/CoverageProbe.h
+++ b/Tests/GPUWidgets/CoverageProbe.h
@@ -63,7 +63,7 @@ inline Vector<float>
     if (!GPU::Device::shared().isValid() || width <= 0 || height <= 0)
         return values;
 
-    auto bytes = sizeof(float) * (std::size_t) (width * height);
+    auto bytes = (int) sizeof(float) * width * height;
     auto readback = GPU::Buffer {
         GPU::Device::shared(), nullptr, bytes, GPU::BufferUsage::Storage};
 
@@ -109,7 +109,7 @@ inline Vector<float> rasterize(PathRasterizer& rasterizer,
 
     auto width = rasterizer.getCoverageWidth();
     auto height = rasterizer.getCoverageHeight();
-    auto bytes = sizeof(float) * (std::size_t) (width * height);
+    auto bytes = (int) sizeof(float) * width * height;
 
     auto readback = GPU::Buffer {
         GPU::Device::shared(), nullptr, bytes, GPU::BufferUsage::Storage};

--- a/Tests/GPUWidgets/PrefixSumTests.cpp
+++ b/Tests/GPUWidgets/PrefixSumTests.cpp
@@ -50,7 +50,7 @@ struct Result
 Result scanOnGpu(const Vector<std::uint32_t>& counts)
 {
     auto result = Result {};
-    auto bytes = sizeof(std::uint32_t) * (std::size_t) counts.size();
+    auto bytes = (int) sizeof(std::uint32_t) * counts.size();
 
     auto source = GPU::Buffer {
         GPU::Device::shared(), counts.data(), bytes, GPU::BufferUsage::Storage};

--- a/Tests/Network/HttpParallelDownloadTests.cpp
+++ b/Tests/Network/HttpParallelDownloadTests.cpp
@@ -37,11 +37,11 @@ std::string readFile(const std::string& path)
     return ss.str();
 }
 
-std::string makePayload(std::size_t size)
+std::string makePayload(int size)
 {
     auto out = std::string();
-    out.reserve(size);
-    for (auto i = std::size_t {0}; i < size; ++i)
+    out.reserve((std::size_t) size);
+    for (auto i = 0; i < size; ++i)
         out.push_back((char) ('A' + (i % 26)));
     return out;
 }

--- a/Tests/Network/HttpServerTests.cpp
+++ b/Tests/Network/HttpServerTests.cpp
@@ -2,11 +2,11 @@
 #include <filesystem>
 #include <fstream>
 #include <thread>
-#include <vector>
 #include <algorithm>
 #include <mutex>
 
 using namespace nano;
+using eacp::Vector;
 using eacp::HTTP::Request;
 using eacp::HTTP::Response;
 using eacp::HTTP::Server;
@@ -53,27 +53,27 @@ void performExchange(Server& server, const Request& clientRequest, Exchange& out
 
 struct ParallelExchange
 {
-    std::vector<Response> responses;
+    Vector<Response> responses;
     bool completed = false;
 };
 
 void performParallelExchange(Server& server,
-                             const std::vector<Request>& requests,
+                             const Vector<Request>& requests,
                              ParallelExchange& out,
                              eacp::Time::MS timeout = eacp::Time::MS {10000})
 {
     auto n = requests.size();
     out.responses.assign(n, Response());
 
-    auto remaining = std::make_shared<std::atomic<int>>((int) n);
-    auto workers = std::vector<std::thread>();
+    auto remaining = std::make_shared<std::atomic<int>>(n);
+    auto workers = Vector<std::thread>();
     workers.reserve(n);
 
     auto stopped = eacp::Threads::runEventLoopFor(
         timeout,
         [&]
         {
-            for (auto i = size_t {0}; i < n; ++i)
+            for (auto i = 0; i < n; ++i)
             {
                 workers.emplace_back(
                     [&, i]
@@ -422,7 +422,7 @@ auto tEventLoopModeSerializesHandlers =
     check(ok);
     port = server.boundPort();
 
-    auto requests = std::vector<Request>();
+    auto requests = Vector<Request>();
     for (auto i = 0; i < 4; ++i)
         requests.emplace_back(baseUrl(port) + "/p");
 
@@ -473,7 +473,7 @@ auto tThreadPoolModeRunsHandlersInParallel =
     check(ok);
     port = server.boundPort();
 
-    auto requests = std::vector<Request>();
+    auto requests = Vector<Request>();
     for (auto i = 0; i < 4; ++i)
         requests.emplace_back(baseUrl(port) + "/q");
 
@@ -500,7 +500,7 @@ auto tThreadPoolModeAssignsDistinctRemotePorts =
     auto port = 0;
 
     auto remotePortsMutex = std::mutex();
-    auto remotePorts = std::vector<int>();
+    auto remotePorts = Vector<int>();
 
     auto ok = server.listen(0,
                             [&](const Request& req)
@@ -517,7 +517,7 @@ auto tThreadPoolModeAssignsDistinctRemotePorts =
     check(ok);
     port = server.boundPort();
 
-    auto requests = std::vector<Request>();
+    auto requests = Vector<Request>();
     for (auto i = 0; i < 6; ++i)
         requests.emplace_back(baseUrl(port) + "/multi");
 
@@ -534,7 +534,7 @@ auto tThreadPoolModeAssignsDistinctRemotePorts =
     for (auto p: remotePorts)
         check(p > 0 && p != port);
     auto sorted = remotePorts;
-    std::sort(sorted.begin(), sorted.end());
+    sorted.sort();
     check(std::adjacent_find(sorted.begin(), sorted.end()) == sorted.end());
 };
 
@@ -799,7 +799,7 @@ auto tRouterMethodAndPathAreBothMatched =
     check(server.listen(0));
     port = server.boundPort();
 
-    auto requests = std::vector<Request>();
+    auto requests = Vector<Request>();
     requests.emplace_back(baseUrl(port) + "/x");
     requests.emplace_back(Request::post(baseUrl(port) + "/x", ""));
 
@@ -810,10 +810,10 @@ auto tRouterMethodAndPathAreBothMatched =
     check(getCalls.load() == 1);
     check(postCalls.load() == 1);
 
-    auto bodies = std::vector<std::string>();
+    auto bodies = Vector<std::string>();
     for (auto& r: out.responses)
         bodies.push_back(r.content);
-    std::sort(bodies.begin(), bodies.end());
+    bodies.sort();
     check(bodies[0] == "g");
     check(bodies[1] == "p");
 };

--- a/Tests/Network/TcpConnectionTests.cpp
+++ b/Tests/Network/TcpConnectionTests.cpp
@@ -1,8 +1,8 @@
 #include "Common.h"
 #include <thread>
-#include <vector>
 
 using namespace nano;
+using eacp::Vector;
 using eacp::TCP::Connection;
 using eacp::TCP::Error;
 using eacp::TCP::Listener;
@@ -304,10 +304,10 @@ auto tManyConnections = test("Tcp/listenerServesManyConnections") = []
             }
         });
 
-    auto connections = std::vector<Connection> {};
+    auto connections = Vector<Connection> {};
     for (auto i = 0; i < clients; ++i)
     {
-        connections.push_back(dial(listener));
+        connections.add(dial(listener));
         connections.back().send("c" + std::to_string(i) + "\n");
     }
 

--- a/Tests/Network/WebSocketProtocolTests.cpp
+++ b/Tests/Network/WebSocketProtocolTests.cpp
@@ -1,9 +1,8 @@
 #include "Common.h"
 #include <eacp/Network/WebSocket/Protocol.h>
 
-#include <vector>
-
 using namespace nano;
+using eacp::Vector;
 using eacp::WebSocket::CloseStatus;
 using eacp::WebSocket::Protocol::acceptKeyFor;
 using eacp::WebSocket::Protocol::decode;
@@ -16,22 +15,22 @@ using eacp::WebSocket::Protocol::Opcode;
 
 namespace
 {
-std::string protocolPayloadOf(std::size_t size)
+std::string protocolPayloadOf(int size)
 {
-    auto payload = std::string(size, '\0');
+    auto payload = std::string((std::size_t) size, '\0');
 
-    for (auto i = std::size_t {0}; i < size; ++i)
-        payload[i] = (char) (i % 251);
+    for (auto i = 0; i < size; ++i)
+        payload[(std::size_t) i] = (char) (i % 251);
 
     return payload;
 }
 
-std::vector<std::size_t> protocolPayloadSizes()
+Vector<int> protocolPayloadSizes()
 {
     return {0, 1, 125, 126, 127, 65535, 65536, 200000};
 }
 
-std::vector<Opcode> protocolOpcodes()
+Vector<Opcode> protocolOpcodes()
 {
     return {Opcode::continuation,
             Opcode::text,
@@ -51,7 +50,7 @@ bool protocolRoundTrips(const Frame& frame, bool masked)
     auto wire = encode(frame, masked);
     auto decoded = decode(wire);
 
-    return decoded.has_value() && decoded->consumed == wire.size()
+    return decoded.has_value() && decoded->consumed == (int) wire.size()
            && decoded->frame.opcode == frame.opcode
            && decoded->frame.fin == frame.fin
            && decoded->frame.payload == frame.payload;
@@ -147,20 +146,21 @@ auto tTruncatedNeverThrows =
 {
     auto ok = true;
 
-    for (auto size: std::vector<std::size_t> {0, 125, 126, 65536})
+    for (auto size: Vector<int> {0, 125, 126, 65536})
     {
         for (auto masked: {false, true})
         {
             auto wire =
                 encode({Opcode::binary, true, protocolPayloadOf(size)}, masked);
 
-            for (auto prefix = std::size_t {0}; prefix < wire.size(); ++prefix)
+            for (auto prefix = 0; prefix < (int) wire.size(); ++prefix)
             {
                 auto decoded = std::optional<eacp::WebSocket::Protocol::Decoded>();
 
                 try
                 {
-                    decoded = decode(std::string_view(wire).substr(0, prefix));
+                    decoded = decode(
+                        std::string_view(wire).substr(0, (std::size_t) prefix));
                 }
                 catch (const Error&)
                 {
@@ -184,10 +184,10 @@ auto tTrailingBytesAreLeft =
     auto decoded = decode(first + second);
 
     check(decoded.has_value());
-    check(decoded->consumed == first.size());
+    check(decoded->consumed == (int) first.size());
     check(decoded->frame.payload == "one");
 
-    auto next = decode((first + second).substr(decoded->consumed));
+    auto next = decode((first + second).substr((std::size_t) decoded->consumed));
 
     check(next.has_value());
     check(next->frame.payload == "two");

--- a/Tests/Network/WebSocketServerTests.cpp
+++ b/Tests/Network/WebSocketServerTests.cpp
@@ -7,9 +7,9 @@
 #include <optional>
 #include <string>
 #include <utility>
-#include <vector>
 
 using namespace nano;
+using eacp::Vector;
 using eacp::Threads::runEventLoopUntil;
 using eacp::Time::Deadline;
 using eacp::Time::MS;
@@ -132,11 +132,11 @@ struct WebSocketServerRecord
     bool reentered = false;
     bool inServerCall = false;
     bool duringAServerCall = false;
-    std::vector<ClientId> connected;
+    Vector<ClientId> connected;
     std::map<ClientId, Handshake> handshakes;
-    std::vector<std::pair<ClientId, Message>> messages;
-    std::vector<std::pair<ClientId, CloseStatus>> closes;
-    std::vector<std::string> order;
+    Vector<std::pair<ClientId, Message>> messages;
+    Vector<std::pair<ClientId, CloseStatus>> closes;
+    Vector<std::string> order;
 };
 
 // What a WebSocket::Connection said, kept apart from the server's own record
@@ -172,7 +172,7 @@ struct WebSocketServerClientRecord
     int errors = 0;
     std::string protocol;
     CloseStatus close;
-    std::vector<Message> messages;
+    Vector<Message> messages;
 };
 
 std::string webSocketServerUrl(const Server& server, const std::string& path = {})
@@ -268,7 +268,7 @@ public:
 
             if (decoded.has_value())
             {
-                buffer.erase(0, decoded->consumed);
+                buffer.erase(0, (std::size_t) decoded->consumed);
                 return decoded->frame;
             }
 
@@ -1000,9 +1000,7 @@ auto tServerEchoesForTheClient =
     auto inOrder = true;
 
     for (auto i = 0; i < burst; ++i)
-        inOrder =
-            inOrder
-            && client.messages[(std::size_t) i + 2].data == "m" + std::to_string(i);
+        inOrder = inOrder && client.messages[i + 2].data == "m" + std::to_string(i);
 
     check(inOrder);
     check(client.errors == 0);

--- a/Tests/Network/WebSocketTestServer.h
+++ b/Tests/Network/WebSocketTestServer.h
@@ -10,7 +10,6 @@
 #include <optional>
 #include <string>
 #include <thread>
-#include <vector>
 
 // What the server does once a client is on the far end. Everything here is a
 // scenario some test needs and no live server would ever do on purpose.
@@ -80,13 +79,13 @@ public:
         return found != requestHeaders.end() ? found->second : std::string();
     }
 
-    std::vector<std::string> messages() const
+    eacp::Vector<std::string> messages() const
     {
         auto lock = std::scoped_lock(mutex);
         return received;
     }
 
-    std::size_t messageCount() const
+    int messageCount() const
     {
         auto lock = std::scoped_lock(mutex);
         return received.size();
@@ -358,7 +357,7 @@ private:
             if (!decoded.has_value())
                 return true;
 
-            buffer.erase(0, decoded->consumed);
+            buffer.erase(0, (std::size_t) decoded->consumed);
 
             if (!handleFrame(peer, decoded->frame))
                 return false;
@@ -493,7 +492,7 @@ private:
 
     mutable std::mutex mutex;
     std::map<std::string, std::string> requestHeaders;
-    std::vector<std::string> received;
+    eacp::Vector<std::string> received;
     eacp::WebSocket::CloseStatus closeFromClient;
 
     std::atomic<bool> stopping {false};

--- a/Tests/Network/WebSocketTests.cpp
+++ b/Tests/Network/WebSocketTests.cpp
@@ -2,9 +2,9 @@
 #include "WebSocketTestServer.h"
 
 #include <memory>
-#include <vector>
 
 using namespace nano;
+using eacp::Vector;
 using eacp::Threads::runEventLoopUntil;
 using eacp::Time::MS;
 using eacp::WebSocket::Callbacks;
@@ -74,8 +74,8 @@ struct WebSocketRecord
     std::string protocol;
     std::string error;
     CloseStatus close;
-    std::vector<Message> messages;
-    std::vector<std::string> order;
+    Vector<Message> messages;
+    Vector<std::string> order;
     bool offMessageThread = false;
 };
 
@@ -214,9 +214,7 @@ auto tTextEcho = test("WebSocket/echoesTextAndKeepsTheOrderOfABurst") = []
     auto inOrder = true;
 
     for (auto i = 0; i < burst; ++i)
-        inOrder =
-            inOrder
-            && record.messages[(std::size_t) i + 1].data == "m" + std::to_string(i);
+        inOrder = inOrder && record.messages[i + 1].data == "m" + std::to_string(i);
 
     check(inOrder);
     check(!record.offMessageThread);

--- a/Tests/SIMD/SimdBench.cpp
+++ b/Tests/SIMD/SimdBench.cpp
@@ -28,7 +28,7 @@ namespace
 using Pixels = EA::Vector<std::uint8_t>;
 using Floats = EA::Vector<float>;
 using ResizeFn = void (*)(const std::uint8_t*, int, int, std::uint8_t*, int, int);
-using SwapFn = void (*)(const std::uint8_t*, std::uint8_t*, std::size_t);
+using SwapFn = void (*)(const std::uint8_t*, std::uint8_t*, int);
 using WarpFn =
     void (*)(const std::uint8_t*, int, int, const float*, std::uint8_t*, int, int);
 
@@ -102,39 +102,39 @@ void report(
 }
 
 // Non-vectorized scalar references for the array primitives.
-void scalarAdd(const float* a, const float* b, float* out, std::size_t n)
+void scalarAdd(const float* a, const float* b, float* out, int n)
 {
     EACP_NO_VECTORIZE
-    for (std::size_t i = 0; i < n; ++i)
+    for (int i = 0; i < n; ++i)
         out[i] = a[i] + b[i];
 }
 
-void scalarSubtract(const float* a, const float* b, float* out, std::size_t n)
+void scalarSubtract(const float* a, const float* b, float* out, int n)
 {
     EACP_NO_VECTORIZE
-    for (std::size_t i = 0; i < n; ++i)
+    for (int i = 0; i < n; ++i)
         out[i] = a[i] - b[i];
 }
 
-void scalarMultiply(const float* a, const float* b, float* out, std::size_t n)
+void scalarMultiply(const float* a, const float* b, float* out, int n)
 {
     EACP_NO_VECTORIZE
-    for (std::size_t i = 0; i < n; ++i)
+    for (int i = 0; i < n; ++i)
         out[i] = a[i] * b[i];
 }
 
-void scalarMultiplyByScalar(const float* a, float s, float* out, std::size_t n)
+void scalarMultiplyByScalar(const float* a, float s, float* out, int n)
 {
     EACP_NO_VECTORIZE
-    for (std::size_t i = 0; i < n; ++i)
+    for (int i = 0; i < n; ++i)
         out[i] = a[i] * s;
 }
 
 void scalarMultiplyAdd(
-    const float* a, const float* b, const float* c, float* out, std::size_t n)
+    const float* a, const float* b, const float* c, float* out, int n)
 {
     EACP_NO_VECTORIZE
-    for (std::size_t i = 0; i < n; ++i)
+    for (int i = 0; i < n; ++i)
         out[i] = a[i] * b[i] + c[i];
 }
 
@@ -263,7 +263,7 @@ void benchSwap(long long pixels)
 {
     auto src = makeBuffer(static_cast<int>(pixels) * 4);
     auto dst = Pixels(static_cast<int>(pixels) * 4);
-    const auto count = static_cast<std::size_t>(pixels);
+    const auto count = static_cast<int>(pixels);
     const int iters =
         static_cast<int>(std::max<long long>(20, 400'000'000LL / pixels));
 
@@ -313,7 +313,6 @@ void benchArrayOps(int count)
     auto b = makeFloats(count, 23, 1);
     auto c = makeFloats(count, 5, 1);
     auto out = Floats(count);
-    const auto n = static_cast<std::size_t>(count);
     const int iters = std::max(20, 400'000'000 / count);
 
     std::printf("  %d elements:\n", count);
@@ -334,25 +333,27 @@ void benchArrayOps(int count)
 
     row(
         "add",
-        [&] { scalarAdd(a.data(), b.data(), out.data(), n); },
-        [&] { eacp::simd::add(a.data(), b.data(), out.data(), n); });
+        [&] { scalarAdd(a.data(), b.data(), out.data(), count); },
+        [&] { eacp::simd::add(a.data(), b.data(), out.data(), count); });
     row(
         "subtract",
-        [&] { scalarSubtract(a.data(), b.data(), out.data(), n); },
-        [&] { eacp::simd::subtract(a.data(), b.data(), out.data(), n); });
+        [&] { scalarSubtract(a.data(), b.data(), out.data(), count); },
+        [&] { eacp::simd::subtract(a.data(), b.data(), out.data(), count); });
     row(
         "multiply",
-        [&] { scalarMultiply(a.data(), b.data(), out.data(), n); },
-        [&] { eacp::simd::multiply(a.data(), b.data(), out.data(), n); });
+        [&] { scalarMultiply(a.data(), b.data(), out.data(), count); },
+        [&] { eacp::simd::multiply(a.data(), b.data(), out.data(), count); });
     row(
         "multiplyByScalar",
-        [&] { scalarMultiplyByScalar(a.data(), 3.f, out.data(), n); },
-        [&] { eacp::simd::multiplyByScalar(a.data(), 3.f, out.data(), n); });
+        [&] { scalarMultiplyByScalar(a.data(), 3.f, out.data(), count); },
+        [&] { eacp::simd::multiplyByScalar(a.data(), 3.f, out.data(), count); });
     row(
         "multiplyAdd",
-        [&] { scalarMultiplyAdd(a.data(), b.data(), c.data(), out.data(), n); },
+        [&] { scalarMultiplyAdd(a.data(), b.data(), c.data(), out.data(), count); },
         [&]
-        { eacp::simd::multiplyAdd(a.data(), b.data(), c.data(), out.data(), n); });
+        {
+            eacp::simd::multiplyAdd(a.data(), b.data(), c.data(), out.data(), count);
+        });
 }
 } // namespace
 

--- a/Tests/SIMD/SimdTests.cpp
+++ b/Tests/SIMD/SimdTests.cpp
@@ -2,6 +2,8 @@
 #include <eacp/SIMD/Ops.h>
 
 #include <NanoTest/NanoTest.h>
+#include <ea_data_structures/Structures/Array.h>
+#include <ea_data_structures/Structures/Span.h>
 #include <ea_data_structures/ea_data_structures.h>
 
 using namespace nano;
@@ -9,17 +11,16 @@ using namespace nano;
 namespace
 {
 using Pixels = EA::Vector<std::uint8_t>;
-using SwapFn = void (*)(const std::uint8_t*, std::uint8_t*, std::size_t);
+using SwapFn = void (*)(const std::uint8_t*, std::uint8_t*, int);
 using ResizeFn = void (*)(const std::uint8_t*, int, int, std::uint8_t*, int, int);
 
 // Pixel counts chosen to straddle every backend's lane width (SSE2/NEON = 4,
 // AVX2 = 8): zero, sub-lane, exact multiples, and odd remainders.
-constexpr std::size_t kSwapSizes[] = {
-    0, 1, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 64, 1000};
+constexpr int kSwapSizes[] = {0, 1, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 64, 1000};
 
-Pixels makePixels(std::size_t pixelCount)
+Pixels makePixels(int pixelCount)
 {
-    auto data = Pixels(static_cast<int>(pixelCount) * 4);
+    auto data = Pixels(pixelCount * 4);
     for (int i = 0; i < data.size(); ++i)
         data[i] = static_cast<std::uint8_t>((i * 37 + 11) & 0xFF);
     return data;
@@ -346,7 +347,7 @@ auto tArraySumOfSquaresMatchesReference =
         auto partial = 0.0;
         for (int i = 0; i < count; ++i)
             partial += (double) a[i] * (double) a[i];
-        check(eacp::simd::sumOfSquares(a.data(), (std::size_t) count) == partial);
+        check(eacp::simd::sumOfSquares(a.data(), count) == partial);
     }
 };
 
@@ -423,4 +424,37 @@ auto tOpsHelpersStopAtShortestBuffer =
     eacp::simd::add(dst, shorter);
     for (int i = 0; i < kArrayCount; ++i)
         check(dst[i] == (i < kArrayCount / 2 ? a[i] + 1.f : a[i]));
+};
+
+// Ops.h's concepts are container-agnostic: EA::Array (fixed size), EA::Span
+// (a view, mutable and const) and a Span's subviews all satisfy them, and the
+// int sizes they report drive the primitives directly.
+auto tOpsHelpersAcceptArraysAndSpans =
+    test("SIMD/opsHelpersAcceptArraysAndSpans") = []
+{
+    auto gains = EA::Array<float, 4> {1.f, 2.f, 3.f, 4.f};
+    const auto factors = EA::Array<float, 4> {2.f, 2.f, 4.f, 4.f};
+    eacp::simd::multiply(gains, factors);
+    check(gains[0] == 2.f);
+    check(gains[1] == 4.f);
+    check(gains[2] == 12.f);
+    check(gains[3] == 16.f);
+    check(eacp::simd::peakAbs(gains) == 16.f);
+
+    auto storage = ramp(17, 1);
+    const auto original = storage;
+    const auto whole = EA::Span<float> {storage};
+    check(eacp::simd::peakAbs(whole) == eacp::simd::peakAbs(storage));
+    check(eacp::simd::sumOfSquares(EA::Span<const float> {storage})
+          == eacp::simd::sumOfSquares(storage));
+
+    // A subview bounds the work: only its own prefix of the buffer changes.
+    auto head = whole.first(8);
+    eacp::simd::multiply(head, 2.f);
+    for (int i = 0; i < storage.size(); ++i)
+        check(storage[i] == (i < 8 ? original[i] * 2.f : original[i]));
+
+    eacp::simd::subtract(storage, EA::Span<const float> {head});
+    for (int i = 0; i < storage.size(); ++i)
+        check(storage[i] == (i < 8 ? 0.f : original[i]));
 };

--- a/Tests/Text/FontResolution-WindowsTests.cpp
+++ b/Tests/Text/FontResolution-WindowsTests.cpp
@@ -6,7 +6,6 @@
 
 #include <fstream>
 #include <iterator>
-#include <vector>
 
 // The shared font registry (Graphics/Primitives/FontRegistry-Windows.cpp) —
 // the Windows stand-in for CoreText's process-wide font registry.
@@ -26,12 +25,15 @@ using namespace eacp::Graphics;
 
 namespace
 {
-std::vector<unsigned char> readFile(const wchar_t* path)
+EA::Vector<unsigned char> readFile(const wchar_t* path)
 {
     auto stream = std::ifstream(path, std::ios::binary);
+    auto bytes = EA::Vector<unsigned char> {};
 
-    return {std::istreambuf_iterator<char> {stream},
-            std::istreambuf_iterator<char> {}};
+    bytes.assign(std::istreambuf_iterator<char> {stream},
+                 std::istreambuf_iterator<char> {});
+
+    return bytes;
 }
 } // namespace
 

--- a/Tests/Text/GlyphAtlasTests.cpp
+++ b/Tests/Text/GlyphAtlasTests.cpp
@@ -45,15 +45,15 @@ struct StubSource final : GlyphSource
         ++shapeCalls;
 
         auto run = ShapedRun {};
-        auto index = std::size_t {0};
+        auto index = 0;
 
-        while (index < text.size())
+        while (index < (int) text.size())
         {
             const auto start = index;
             const auto codepoint = decodeUtf8(text, index);
             const auto font = codepoint >= 0x4E00 && codepoint < 0xA000 ? 1 : 0;
 
-            run.glyphs.add({{codepoint, font}, run.advance, 0.f, (int) start});
+            run.glyphs.add({{codepoint, font}, run.advance, 0.f, start});
             run.advance += 10.f;
         }
 
@@ -89,8 +89,7 @@ struct StubSource final : GlyphSource
             codepoint >= 0x1F600 ? GlyphFormat::Color : GlyphFormat::Mask;
         bitmap.width = glyphWidth;
         bitmap.height = glyphHeight;
-        bitmap.pixels.assign((std::size_t) glyphWidth * glyphHeight
-                                 * bytesPerPixel(bitmap.format),
+        bitmap.pixels.assign(glyphWidth * glyphHeight * bytesPerPixel(bitmap.format),
                              fillByte);
 
         return bitmap;

--- a/Tests/Text/GlyphRasterizerTests.cpp
+++ b/Tests/Text/GlyphRasterizerTests.cpp
@@ -41,7 +41,7 @@ int maxCoverage(const GlyphBitmap& bitmap)
 
     auto highest = 0;
 
-    for (std::size_t i = 3; i < bitmap.pixels.size(); i += 4)
+    for (auto i = 3; i < bitmap.pixels.size(); i += 4)
         highest = std::max(highest, (int) bitmap.pixels[i]);
 
     return highest;
@@ -100,7 +100,7 @@ auto tRasterizesALetter = test("GlyphRasterizer/rasterizesALetterAsAMask") = []
     check(bitmap.format == GlyphFormat::Mask);
     check(bitmap.advance > 0.f);
 
-    check(bitmap.pixels.size() == (std::size_t) bitmap.width * bitmap.height);
+    check(bitmap.pixels.size() == bitmap.width * bitmap.height);
 
     check(maxCoverage(bitmap) > 0); // it drew something
     check(bitmap.width < 200);
@@ -221,8 +221,7 @@ auto tUnassignedCodepointIsSelfConsistent =
             continue;
 
         check(bitmap.pixels.size()
-              == (std::size_t) bitmap.width * bitmap.height
-                     * bytesPerPixel(bitmap.format));
+              == bitmap.width * bitmap.height * bytesPerPixel(bitmap.format));
     }
 };
 
@@ -247,8 +246,7 @@ auto tFallsBackForMissingGlyphs =
         check(!bitmap.isEmpty());
         check(bitmap.advance > 0.f);
         check(bitmap.pixels.size()
-              == (std::size_t) bitmap.width * bitmap.height
-                     * bytesPerPixel(bitmap.format));
+              == bitmap.width * bitmap.height * bytesPerPixel(bitmap.format));
     }
 };
 
@@ -270,8 +268,7 @@ auto tColorGlyphsReportFourBytesPerPixel =
         return;
 
     check(bitmap.pixels.size()
-          == (std::size_t) bitmap.width * bitmap.height
-                 * bytesPerPixel(bitmap.format));
+          == bitmap.width * bitmap.height * bytesPerPixel(bitmap.format));
 
     if (bitmap.format != GlyphFormat::Color)
         return;
@@ -280,7 +277,7 @@ auto tColorGlyphsReportFourBytesPerPixel =
     // is the failure a premultiply/compositing mistake produces.
     auto opaque = 0;
 
-    for (std::size_t i = 3; i < bitmap.pixels.size(); i += 4)
+    for (auto i = 3; i < bitmap.pixels.size(); i += 4)
         if (bitmap.pixels[i] > 128)
             ++opaque;
 
@@ -491,8 +488,7 @@ auto tSubpixelOffsetMovesTheInk =
         for (auto y = 0; y < bitmap.height; ++y)
             for (auto x = 0; x < bitmap.width; ++x)
             {
-                const auto coverage =
-                    (double) bitmap.pixels[(std::size_t) y * bitmap.width + x];
+                const auto coverage = (double) bitmap.pixels[y * bitmap.width + x];
 
                 ink.mass += coverage;
                 moment += coverage * ((double) x + 0.5);

--- a/Tests/Text/ShelfPackerTests.cpp
+++ b/Tests/Text/ShelfPackerTests.cpp
@@ -20,7 +20,7 @@ struct Placements
         int x, y, w, h;
     };
 
-    std::vector<Box> boxes;
+    EA::Vector<Box> boxes;
 
     bool add(const PackedRect& at, int w, int h, int atlasSize)
     {
@@ -36,13 +36,14 @@ struct Placements
                 return false;
         }
 
-        boxes.push_back({at.x, at.y, w, h});
+        boxes.add({at.x, at.y, w, h});
         return true;
     }
 };
 } // namespace
 
-auto tPacksFirstRectAtPadding = test("ShelfPacker/firstRectSitsInsideThePadding") = []
+auto tPacksFirstRectAtPadding =
+    test("ShelfPacker/firstRectSitsInsideThePadding") = []
 {
     auto packer = ShelfPacker {64, 64, 1};
 
@@ -79,7 +80,8 @@ auto tLeavesPaddingBetween = test("ShelfPacker/leavesPaddingBetweenRects") = []
     check(second->x >= first->x + 10 + 1);
 };
 
-auto tOpensNewShelfWhenRowIsFull = test("ShelfPacker/opensANewShelfWhenTheRowFills") = []
+auto tOpensNewShelfWhenRowIsFull =
+    test("ShelfPacker/opensANewShelfWhenTheRowFills") = []
 {
     auto packer = ShelfPacker {64, 128, 1};
 
@@ -96,7 +98,8 @@ auto tOpensNewShelfWhenRowIsFull = test("ShelfPacker/opensANewShelfWhenTheRowFil
 
 // A short glyph must not be dropped onto a much taller shelf: the wasted height
 // applies to the whole row, so it is cheaper to open a new one.
-auto tSkipsShelvesThatWasteHeight = test("ShelfPacker/skipsShelvesThatAreTooTall") = []
+auto tSkipsShelvesThatWasteHeight =
+    test("ShelfPacker/skipsShelvesThatAreTooTall") = []
 {
     auto packer = ShelfPacker {128, 128, 1};
 

--- a/Tests/UI/TextEditorTests.cpp
+++ b/Tests/UI/TextEditorTests.cpp
@@ -3,7 +3,6 @@
 #include <NanoTest/NanoTest.h>
 
 #include <string>
-#include <vector>
 
 // What an editor does to its own string, which is the half that has nothing to
 // do with drawing.
@@ -351,7 +350,8 @@ auto tLosingFocusDropsTheSelection =
     check(harness.editor.getText() == "abc");
 };
 
-auto tPasswordMask = test("TextEditor/aPasswordFieldKeepsTheTextAndDrawsTheMask") = []
+auto tPasswordMask =
+    test("TextEditor/aPasswordFieldKeepsTheTextAndDrawsTheMask") = []
 {
     auto harness = Harness {};
 
@@ -388,8 +388,8 @@ auto tPasswordMask = test("TextEditor/aPasswordFieldKeepsTheTextAndDrawsTheMask"
     auto allTheSame = true;
 
     for (const auto& glyph: glyphs)
-        allTheSame = allTheSame && glyph.key == glyphs[0].key
-                     && glyph.face == glyphs[0].face;
+        allTheSame =
+            allTheSame && glyph.key == glyphs[0].key && glyph.face == glyphs[0].face;
 
     check(allTheSame, "and every one is the mask, not the letters typed");
 };
@@ -424,9 +424,9 @@ auto tFrameless = test("TextEditor/anEditorWithoutAFrameDrawsOnlyItsText") = []
 auto tFocusIsReported = test("TextEditor/takingAndLosingTheKeyboardIsReported") = []
 {
     auto harness = Harness {};
-    auto reported = std::vector<bool> {};
+    auto reported = Vector<int> {};
 
-    harness.editor.onFocusChange = [&](bool focused) { reported.push_back(focused); };
+    harness.editor.onFocusChange = [&](bool focused) { reported.add(focused); };
 
     harness.editor.giveAwayKeyboardFocus();
     harness.editor.grabKeyboardFocus();

--- a/Tests/Video/Common.h
+++ b/Tests/Video/Common.h
@@ -43,7 +43,7 @@ struct FakeDecoder final : Video::Decoder
         auto frameInfo = Video::FrameInfo {};
         frameInfo.width = width;
         frameInfo.height = height;
-        frameInfo.bytesPerRow = (std::size_t) width * 4;
+        frameInfo.bytesPerRow = width * 4;
         frameInfo.seconds = nextIndex / frameRate;
         frameInfo.duration = 1.0 / frameRate;
 

--- a/Tests/Video/FrameStreamTests.cpp
+++ b/Tests/Video/FrameStreamTests.cpp
@@ -108,7 +108,7 @@ auto tDepthBudget = test("FrameStream/queueDepthFitsMemoryBudget") = []
 {
     auto options = Video::StreamOptions {};
     options.queueDepth = 4;
-    options.maxQueueBytes = 192u * 1024u * 1024u;
+    options.maxQueueBytes = 192 * 1024 * 1024;
 
     auto sized = [](int width, int height)
     {
@@ -132,7 +132,7 @@ auto tDepthBudget = test("FrameStream/queueDepthFitsMemoryBudget") = []
     check(Video::FrameStream::depthWithinBudget(sized(7680, 4320), options) == 1);
 
     // A stream whose size is unknown keeps what was asked for.
-    options.maxQueueBytes = 192u * 1024u * 1024u;
+    options.maxQueueBytes = 192 * 1024 * 1024;
     check(Video::FrameStream::depthWithinBudget(sized(0, 0), options) == 4);
 };
 

--- a/Tests/Video/Mp4DemuxerTests.cpp
+++ b/Tests/Video/Mp4DemuxerTests.cpp
@@ -4,7 +4,6 @@
 #include <eacp/Video/SyntheticClip.h>
 
 #include <cmath>
-#include <span>
 #include <string>
 #include <utility>
 
@@ -36,9 +35,7 @@ using Bytes = Vector<std::uint8_t>;
 
 bool parseBytes(Video::Mp4Demuxer& demuxer, const Bytes& bytes)
 {
-    auto span = std::span<const std::uint8_t> {
-        bytes.data(), static_cast<std::size_t>(bytes.size())};
-    return demuxer.parse(span);
+    return demuxer.parse(bytes);
 }
 
 void appendBE16(Bytes& out, std::uint16_t value)
@@ -463,7 +460,7 @@ bool sampleContentMatches(const Video::Mp4Demuxer& demuxer)
     {
         auto bytes = demuxer.sampleBytes(i);
 
-        if (bytes.size() != demuxer.samples()[i].byteRange.length)
+        if ((std::uint64_t) bytes.size() != demuxer.samples()[i].byteRange.length)
             return false;
 
         for (auto byte: bytes)
@@ -553,8 +550,8 @@ auto tSampleRangesInsideFile = test("Mp4Demuxer/sampleRangesInsideFile") = []
     {
         auto& range = demuxer.samples()[i].byteRange;
         check(!range.empty());
-        check(range.end() <= fileSize);
-        check(demuxer.sampleBytes(i).size() == range.length);
+        check(range.end() <= (std::uint64_t) fileSize);
+        check((std::uint64_t) demuxer.sampleBytes(i).size() == range.length);
     }
 
     auto first = demuxer.sampleBytes(0);
@@ -563,7 +560,7 @@ auto tSampleRangesInsideFile = test("Mp4Demuxer/sampleRangesInsideFile") = []
     auto nalLength =
         std::uint64_t {first[0]} << 24 | first[1] << 16 | first[2] << 8 | first[3];
     check(nalLength > 0);
-    check(nalLength + 4 <= first.size());
+    check(nalLength + 4 <= (std::uint64_t) first.size());
 };
 
 // ---- Against hand-built structures, where every byte is pinned ----
@@ -817,8 +814,7 @@ auto tTruncationSweep = test("Mp4Demuxer/survivesTruncationEverywhere") = []
 
     for (auto length = 0; length < bytes.size(); ++length)
     {
-        auto prefix = std::span<const std::uint8_t> {
-            bytes.data(), static_cast<std::size_t>(length)};
+        auto prefix = Span<const std::uint8_t> {bytes.data(), length};
         anyPrefixParsed = demuxer.parse(prefix) || anyPrefixParsed;
     }
 

--- a/Tests/WebView/FileDragTests-Windows.cpp
+++ b/Tests/WebView/FileDragTests-Windows.cpp
@@ -7,8 +7,6 @@
 #include <eacp/WebView/WebView/FileDrag-Windows.h>
 #include <NanoTest/NanoTest.h>
 
-#include <vector>
-
 using namespace nano;
 using namespace eacp::Graphics;
 
@@ -48,7 +46,8 @@ auto tPointOutsideClientRect = test("FileDrag/pointOutsideClientRectIsOutside") 
     check(toFileDragPoint({.x = 0, .y = 0}, rect, 1.f).inside);
 };
 
-auto tZeroDpiFallsBackUnscaled = test("FileDrag/zeroDpiScaleFallsBackToUnscaled") = []
+auto tZeroDpiFallsBackUnscaled =
+    test("FileDrag/zeroDpiScaleFallsBackToUnscaled") = []
 {
     auto mapped = toFileDragPoint({.x = 40, .y = 30}, clientRect(200, 100), 0.f);
 
@@ -59,10 +58,9 @@ auto tZeroDpiFallsBackUnscaled = test("FileDrag/zeroDpiScaleFallsBackToUnscaled"
 auto tHeldButtonStreamsCursor =
     test("FileDrag/heldLeftButtonContinuesAndStreamsCursor") = []
 {
-    auto moves = std::vector<WebView::FileDragPoint> {};
+    auto moves = EA::Vector<WebView::FileDragPoint> {};
     auto source = FileDragSource {[] { return point(12, 34, true); },
-                                  [&](WebView::FileDragPoint p)
-                                  { moves.push_back(p); }};
+                                  [&](WebView::FileDragPoint p) { moves.add(p); }};
 
     check(source.QueryContinueDrag(FALSE, MK_LBUTTON) == S_OK);
     check(source.QueryContinueDrag(FALSE, MK_LBUTTON) == S_OK);
@@ -142,8 +140,7 @@ auto tComContract = test("FileDrag/comIdentityAndRefCount") = []
     check(asDropSource == static_cast<IDropSource*>(source));
 
     void* asDropTarget = nullptr;
-    check(source->QueryInterface(IID_IDropTarget, &asDropTarget)
-          == E_NOINTERFACE);
+    check(source->QueryInterface(IID_IDropTarget, &asDropTarget) == E_NOINTERFACE);
     check(asDropTarget == nullptr);
 
     // QueryInterface took a ref: 2 total. Releases count down to deletion.

--- a/Tests/WebView/FileProviderTests.cpp
+++ b/Tests/WebView/FileProviderTests.cpp
@@ -1,5 +1,4 @@
 #include "Common.h"
-#include <array>
 #include <filesystem>
 #include <fstream>
 

--- a/Tests/WebView/StreamingPumpTests.cpp
+++ b/Tests/WebView/StreamingPumpTests.cpp
@@ -47,15 +47,15 @@ StreamingProvider testProvider()
         resource.mimeType =
             isData ? "application/octet-stream" : "text/html; charset=utf-8";
         resource.size = payload->size();
-        resource.read = [payload](RangeSize offset, ByteSpan out) -> std::size_t
+        resource.read = [payload](RangeSize offset, ByteSpan out) -> int
         {
             if (offset >= payload->size())
                 return 0;
 
             auto available = payload->size() - static_cast<std::size_t>(offset);
-            auto count = std::min(out.size(), available);
+            auto count = std::min(static_cast<std::size_t>(out.size()), available);
             std::memcpy(out.data(), payload->data() + offset, count);
-            return count;
+            return (int) count;
         };
         return resource;
     };


### PR DESCRIPTION
## Summary

Moves eacp onto the EA containers and `int`-sized interfaces:

- Every `std::array`, `std::vector` and `std::span` in Lib, Apps and Tests becomes `Array`, `Vector` or `Span`, via the re-exports in `Core/Utils/Containers.h`.
- eacp-facing interfaces use `int` instead of `size_t`. `size_t` remains only where the language, the STL or an OS API forces it: `memcpy` lengths, hash functors, `operator new`, C-array extents, `std::string` indexing, and the mmap, Core Graphics, Metal, CoreText, libcurl, Winsock and D3D12 call sites. The D3D12 allocator in `GPU/Windows/D3D12Context.h` keeps `std::size_t` internally on purpose.
- Files that can outgrow an `int` use the library's new `size_t` surface: `MemoryMappedFile` reports a `size_t` size and hands out a `Span` over the whole mapping, and the MP4 `BoxReader` walks boxes with a `size_t` cursor, so files over 2 GB map and demux. A new test maps a sparse file past the `int` boundary.

Requires ea_data_structures `2cdfc28` (`getSize()` on the containers, `Span` wrapping `std::span`), which is on `main`.

## Behaviour changes

- The HTTP request parser clamps a Content-Length beyond 2^31-1 instead of believing it. Rejecting such a request outright may be the better policy; flagged for review.
- `GPU::Buffer::read` and `update` reject negative sizes, where the old unsigned parameters clamped.
- WebSocket message-size limits are compared in 64-bit so an `int` limit cannot be overflowed.
- `Text::registerMemoryFont` rejects a null pointer or non-positive size.
- `Files::writeFile` takes a `Span`, which cannot bind a temporary container; callers pass a named buffer.

## Verification

- macOS, three build trees (Debug, CLion Debug, CLion Release): clean builds with zero warnings, 1565 / 1582 / 1565 tests passing.
- Windows and Linux sources were converted by reading, without a compiler for them. This PR's CI run is their first check; MSVC at `/W4` is the most likely place for a leftover narrowing warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FCcReKxEbDAG4oKF2fTVtg
