### PR TITLE
Linux: resolve both paths before deciding standalone vs plugin

### DIFF
--- a/Lib/eacp/Core/Plugins/ModuleInfo-Linux.cpp
+++ b/Lib/eacp/Core/Plugins/ModuleInfo-Linux.cpp
@@ -1,5 +1,7 @@
 #include "ModuleInfo.h"
 
+#include "../Utils/StdPath.h"
+
 #include <filesystem>
 
 namespace eacp::Plugins
@@ -9,14 +11,30 @@ bool isDynamicLibrary()
     static const auto result = []
     {
         // A PIE executable and a shared object are both ET_DYN, so the ELF
-        // header can't tell them apart; compare images instead.
+        // header can't tell them apart; compare images instead -- resolved on
+        // both sides, because /proc/self/exe always is and the path dladdr
+        // reports is the one the program was invoked with. Launched as `./app`
+        // they differ, and a standalone app taken for a plugin returns from
+        // run<T>() without ever starting its event loop.
         auto ec = std::error_code();
-        auto exe = std::filesystem::read_symlink("/proc/self/exe", ec);
+        const auto exe = std::filesystem::read_symlink("/proc/self/exe", ec);
 
         if (ec)
             return false;
 
-        return FilePath {exe} != getCurrentModulePath();
+        const auto module = toStdPath(getCurrentModulePath());
+
+        if (module.empty())
+            return false;
+
+        const auto resolved = std::filesystem::weakly_canonical(module, ec);
+
+        // Unresolvable is answered the same way an unreadable /proc/self/exe
+        // is, above: standalone.
+        if (ec)
+            return false;
+
+        return FilePath {exe} != FilePath {resolved};
     }();
 
     return result;

--- a/Tests/Core/CMakeLists.txt
+++ b/Tests/Core/CMakeLists.txt
@@ -48,7 +48,8 @@ endif ()
 if (NOT WIN32)
     list(APPEND core_test_sources
             FilesTests-Posix.cpp
-            MemoryMappedFileTests-Posix.cpp)
+            MemoryMappedFileTests-Posix.cpp
+            ModuleInfoTests-Posix.cpp)
 endif ()
 
 if (APPLE AND NOT IOS)
@@ -84,6 +85,18 @@ add_custom_command(TARGET CoreTests POST_BUILD
 
 target_compile_definitions(CoreTests PRIVATE
         EACP_TEST_RESOURCE_MARKER="${resource_marker_name}")
+
+# The image a standalone executable reports for itself cannot be checked from
+# inside the test binary: it depends on the path the launcher used, so the
+# fixture is a second executable the cases start three different ways.
+if (NOT WIN32)
+    add_executable(ModuleInfoHarness ModuleInfoHarness.cpp)
+    target_link_libraries(ModuleInfoHarness PRIVATE eacp-core)
+
+    target_compile_definitions(CoreTests PRIVATE
+            EACP_MODULE_INFO_HARNESS="$<TARGET_FILE:ModuleInfoHarness>")
+    add_dependencies(CoreTests ModuleInfoHarness)
+endif ()
 
 # The fixture plugin's static initializer counts genuine loads in the
 # process environment, so the tests can observe real unmaps.

--- a/Tests/Core/ModuleInfoHarness.cpp
+++ b/Tests/Core/ModuleInfoHarness.cpp
@@ -1,0 +1,13 @@
+// Fixture for ModuleInfoTests: prints how this executable classifies its own
+// image. A separate process because the answer depends on the path the program
+// was launched with, and only a launcher can vary that.
+#include <eacp/Core/Plugins/ModuleInfo.h>
+
+#include <cstdio>
+
+int main()
+{
+    std::printf("%s\n", eacp::Plugins::isDynamicLibrary() ? "plugin" : "standalone");
+
+    return 0;
+}

--- a/Tests/Core/ModuleInfoTests-Posix.cpp
+++ b/Tests/Core/ModuleInfoTests-Posix.cpp
@@ -1,0 +1,64 @@
+#include "Common.h"
+
+#include <filesystem>
+#include <string>
+#include <unistd.h>
+
+using namespace nano;
+namespace Proc = eacp::Processes;
+namespace fs = std::filesystem;
+
+namespace
+{
+const auto harness = fs::path {EACP_MODULE_INFO_HARNESS};
+
+std::string classifyWhenLaunchedAs(const std::string& executable,
+                                   const std::string& workingDirectory = {})
+{
+    auto options = Proc::ProcessOptions {};
+    options.executable = executable;
+    options.workingDirectory = workingDirectory;
+
+    const auto result = Proc::run(std::move(options));
+
+    check(result.launched);
+    check(result.exited);
+    check(result.exitCode == 0);
+
+    return result.output;
+}
+} // namespace
+
+// Three spellings of one binary. A standalone executable is standalone whichever
+// was typed, and the relative one is what Linux used to answer "plugin" for:
+// /proc/self/exe is resolved and the path dladdr reports is not, so `./harness`
+// compared unequal to itself. run<T>() then handed the event loop to a host that
+// was not there and returned, so the process exited at once with status 0.
+auto tAbsolutePath = test("ModuleInfo/standaloneWhenLaunchedByAbsolutePath") = []
+{ check(classifyWhenLaunchedAs(harness.string()) == "standalone\n"); };
+
+auto tRelativePath = test("ModuleInfo/standaloneWhenLaunchedByRelativePath") = []
+{
+    check(classifyWhenLaunchedAs("./" + harness.filename().string(),
+                                 harness.parent_path().string())
+          == "standalone\n");
+};
+
+auto tSymlink = test("ModuleInfo/standaloneWhenLaunchedThroughSymlink") = []
+{
+    auto ec = std::error_code {};
+
+    // Named per process: NanoTest gives every case its own, and ctest runs them
+    // in parallel.
+    const auto link =
+        fs::temp_directory_path()
+        / ("eacp-module-info-harness-" + std::to_string((long) ::getpid()));
+
+    fs::remove(link, ec);
+    fs::create_symlink(harness, link, ec);
+    check(!ec);
+
+    check(classifyWhenLaunchedAs(link.string()) == "standalone\n");
+
+    fs::remove(link, ec);
+};


### PR DESCRIPTION
## The bug

`Plugins::isDynamicLibrary()` on Linux compares `/proc/self/exe` against the path `dladdr` reports for this image. `/proc/self/exe` is always absolute and fully resolved; `dli_fname` for the main executable is the path the program was *invoked with*.

Launch a standalone app as `./app` and the two compare unequal, so the app is taken for a plugin. `run<T>()` then takes its `Platform::isDLL()` branch, calls `runAsPlugin()` and returns; `main()` returns with it, and the process exits in milliseconds with status `0` — no window, nothing logged, nothing to grep for.

Anything launching a binary out of a build tree by relative path hits this every time. An absolute path happens to work, which is what makes it read as an environment problem rather than a bug: I lost a while to it assuming Wayland or Vulkan was at fault, when the event loop had simply never started.

Launching through a symlink was wrong the same way.

## The fix

`weakly_canonical()` the `dladdr` path before comparing. That also makes the symlink case compare equal, which it previously did not. A path that cannot be resolved is answered standalone, matching what an unreadable `/proc/self/exe` already did.

Apple and Windows are unaffected and were never wrong here: `ModuleInfo-Apple.cpp` reads the Mach-O `filetype != MH_EXECUTE` and `ModuleInfo-Windows.cpp` compares module handles. Neither can depend on the launch path — Linux was the only path-based implementation.

## The test

`ModuleInfoHarness` prints how it classifies its own image, and `ModuleInfoTests-Posix.cpp` starts it three ways: absolute, relative (via `workingDirectory`), and through a symlink. The classification is a property of how the process was started, so it can't be observed from inside the test binary — hence a second executable, following the existing `AppTerminationHarness` pattern.

It's POSIX-wide rather than Linux-only on purpose: Apple and Windows hold the invariant by construction, and stating it where they run too is the point.

Measured on the two commits in this PR, aarch64 Linux:

| launch | before | after |
| --- | --- | --- |
| absolute | pass | pass |
| relative | **fail** | pass |
| symlink | **fail** | pass |

Full suite 204/204 with the fix, built `-DEACP_UNITY_BUILD=OFF -DEACP_BUILD_GRAPHICS=OFF`.

## How I hit it

Porting a standalone eacp app (a terminal emulator) to Linux. It built and linked, then exited instantly and silently on every run. `strace` showed the app constructed, the event loop's waker pipe created and closed, and `exit_group(0)` — with zero `ppoll` calls, i.e. the loop never polled once. Launching by absolute path fixed it, which pointed at the path comparison.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GfAVZE8bGYVzWJYACxqZx