### PR TITLE
GPU: Fill the compute-layer gaps a real net surfaced

### DIFF
--- a/Lib/eacp/GPU/Codegen/ComputeProgram.h
+++ b/Lib/eacp/GPU/Codegen/ComputeProgram.h
@@ -5,6 +5,8 @@
 #include "../Pipeline/ComputePipeline.h"
 #include "ShaderProgram.h"
 
+#include <eacp/Core/Utils/Logging.h>
+
 // A compute kernel authored as a struct, the compute sibling of ShaderProgram.
 // Uniforms are named, typed members set by name; storage buffers are members
 // assigned the GPU::Buffer to bind - or a BufferRange, to bind a slice of one
@@ -174,11 +176,33 @@ public:
     // compiled on that Device rather than on the process-wide one.
     void prepare(Device& device)
     {
+        reportThreadgroupMemoryOverBudget(device);
+
         shaderLibrary.emplace(device, generated.source);
         pipelineState.emplace(device, *shaderLibrary);
+
+        reportSimdWidthMismatch();
     }
 
     void prepare() { prepare(Device::shared()); }
+
+    // How many bytes of threadgroup memory one group of this kernel takes, and
+    // whether that is inside what the device allows. The first counts the
+    // emitter's own reduction and matrix scratch beside the shared<> arrays,
+    // and takes the worst case of the three backends rather than this one's -
+    // a kernel is written once and has to fit everywhere it runs.
+    //
+    // Together with Device::maxThreadgroupMemory they are what a kernel author
+    // sizes a tile against, instead of carrying the backend's number in a
+    // comment. An invalid Device has no budget to be inside, so it fits.
+    int threadgroupMemoryBytes() const { return graph().threadgroupMemoryBytes(); }
+
+    bool fitsThreadgroupMemory(const Device& device) const
+    {
+        auto budget = device.maxThreadgroupMemory();
+
+        return budget <= 0 || threadgroupMemoryBytes() <= budget;
+    }
 
     const ComputePipeline& pipeline() const { return *pipelineState; }
 
@@ -315,6 +339,20 @@ protected:
     UInt groupSum(const UInt& value) { return builder.groupSum(value); }
     UInt groupMax(const UInt& value) { return builder.groupMax(value); }
     UInt groupMin(const UInt& value) { return builder.groupMin(value); }
+
+    // The same fold narrowed to one SIMD group: every thread is handed the
+    // fold of the simdWidth threads it shares one with, so a group of several
+    // SIMD groups comes out holding one answer per SIMD group rather than one
+    // for the group. Collective on the terms the group version sets, and on
+    // Metal a single instruction with neither scratch nor a barrier - see
+    // ShaderBuilder.
+    Float simdSum(const Float& value) { return builder.simdSum(value); }
+    Float simdMax(const Float& value) { return builder.simdMax(value); }
+    Float simdMin(const Float& value) { return builder.simdMin(value); }
+
+    UInt simdSum(const UInt& value) { return builder.simdSum(value); }
+    UInt simdMax(const UInt& value) { return builder.simdMax(value); }
+    UInt simdMin(const UInt& value) { return builder.simdMin(value); }
 
     // The SIMD-group matrix vocabulary: which SIMD group a thread is in, an
     // 8x8 float fragment filled or loaded, and the multiply-accumulate over
@@ -559,6 +597,51 @@ protected:
     virtual void define() = 0;
 
 private:
+    // The one thing a kernel using simdSum/simdMax/simdMin or a SIMD-group
+    // matrix cannot check for itself: those lower to intrinsics collective over
+    // the *hardware* SIMD group, and the EDSL's arithmetic - simdWidth, the
+    // fragment layout, simdGroupIndex - is written against a fixed 32. Every
+    // Apple GPU agrees; an Intel Mac dispatches at eight or sixteen and the two
+    // stop meaning the same thing, silently, since an intrinsic over a narrower
+    // SIMD group is a well-formed fold of the wrong set of threads.
+    //
+    // Only the compiled pipeline knows the number, which is why this is here
+    // and not in the emitter. The backends that emulate a SIMD group report
+    // nothing, and there is nothing for them to disagree with.
+    void reportSimdWidthMismatch() const
+    {
+        if (!graph().usesSimdReduction() && !graph().usesSimdGroups())
+            return;
+
+        auto width = pipelineState->threadExecutionWidth();
+
+        if (width <= 0 || width == ComputeProgram::simdWidth)
+            return;
+
+        LOG("eacp: this kernel folds or multiplies over SIMD groups of ",
+            ComputeProgram::simdWidth,
+            " threads and this device runs it at ",
+            width,
+            ". simdSum/simdMax/simdMin and SimdMatrix need the two to agree; "
+            "use the whole-group groupSum/groupMax/groupMin, which is correct "
+            "at any width.");
+    }
+
+    // Named here rather than left to the backend, which reports a threadgroup
+    // allocation it cannot make as a pipeline that would not build - on Metal
+    // after the library compiled clean, which points at the wrong thing.
+    void reportThreadgroupMemoryOverBudget(const Device& device) const
+    {
+        if (fitsThreadgroupMemory(device))
+            return;
+
+        LOG("eacp: this kernel declares ",
+            threadgroupMemoryBytes(),
+            " bytes of threadgroup memory and this device allows ",
+            device.maxThreadgroupMemory(),
+            ". Size its shared<> arrays against Device::maxThreadgroupMemory().");
+    }
+
     const void* packWithExtents(const std::uint32_t* extents, int count)
     {
         uniformBytes.clear();

--- a/Lib/eacp/GPU/Codegen/ShaderBuilder.h
+++ b/Lib/eacp/GPU/Codegen/ShaderBuilder.h
@@ -346,6 +346,56 @@ public:
     UInt groupMax(const UInt& value) { return fold(GroupReduction::Max, value); }
     UInt groupMin(const UInt& value) { return fold(GroupReduction::Min, value); }
 
+    // The same three narrowed to one SIMD group. Every thread is handed the
+    // fold of the simdWidth threads it shares a SIMD group with, so a group of
+    // several SIMD groups leaves one of these holding several answers - one per
+    // SIMD group - rather than one.
+    //
+    // On Metal that is a single instruction with no threadgroup memory and no
+    // barrier, which is what a fold inside a per-tile loop wants. It is still
+    // collective, and the backends with no wave intrinsic still reach it
+    // through a scratch array between barriers, so the group rule holds: every
+    // thread of the threadgroup reaches it or none does, and a kernel holding
+    // one loses its bounds guard and bounds its own stores.
+    //
+    // **How many threads is a promise these three cannot keep on their own.**
+    // The two emulated backends fold exactly simdWidth lanes, because that is
+    // what the emitted tree walks. Metal folds the *hardware* SIMD group, since
+    // that is what simd_sum is collective over - 32 on every Apple GPU, and
+    // eight or sixteen on an Intel one, where the same call would fold a
+    // quarter of what the arithmetic around it assumes. eacp requires the two
+    // to agree and cannot check it until there is a pipeline, so
+    // ComputeProgram::prepare compares the compiled kernel's
+    // threadExecutionWidth against simdWidth and says so when they differ. A
+    // kernel that wants to be right at any width wants groupSum/groupMax/
+    // groupMin, which combine per-SIMD-group partials however many there were.
+    //
+    // **Uniform control flow, not just a uniform arrival.** Every thread of the
+    // group must reach a fold *with the same branches taken*: loop(condition,
+    // body) takes an ordinary per-thread Bool, so a fold inside a loop whose
+    // condition some lanes leave earlier than others is divergent. The emulated
+    // backends hang at the barrier inside the fold; Metal's intrinsic tolerates
+    // it silently and folds only the lanes still running, which is worse -
+    // correct-looking on the machine it was written on and a hang on the next
+    // one. Hoist the condition to something uniform across the group, or bound
+    // the loop by a uniform and guard the body's stores instead.
+    Float simdSum(const Float& value)
+    {
+        return simdFold(GroupReduction::Sum, value);
+    }
+    Float simdMax(const Float& value)
+    {
+        return simdFold(GroupReduction::Max, value);
+    }
+    Float simdMin(const Float& value)
+    {
+        return simdFold(GroupReduction::Min, value);
+    }
+
+    UInt simdSum(const UInt& value) { return simdFold(GroupReduction::Sum, value); }
+    UInt simdMax(const UInt& value) { return simdFold(GroupReduction::Max, value); }
+    UInt simdMin(const UInt& value) { return simdFold(GroupReduction::Min, value); }
+
     // Which SIMD group of the threadgroup this thread is in, which is what
     // places the block of the output that SIMD group owns. They are numbered
     // from the flat local index, so a group of simdGroupWidth * n threads holds
@@ -877,12 +927,20 @@ private:
     }
 
     template <typename T>
-    T fold(GroupReduction operation, const T& value)
+    T fold(GroupReduction operation,
+           const T& value,
+           ReductionScope scope = ReductionScope::Group)
     {
         auto result = graphData.addGroupReduction(
-            operation, ValueTypeOf<T>::value, value.node);
+            operation, ValueTypeOf<T>::value, value.node, scope);
 
         return indexValue<T>(graphData.addVarRead(result));
+    }
+
+    template <typename T>
+    T simdFold(GroupReduction operation, const T& value)
+    {
+        return fold(operation, value, ReductionScope::Simd);
     }
 
     ShaderGraph graphData;

--- a/Lib/eacp/GPU/Codegen/ShaderEmitter.cpp
+++ b/Lib/eacp/GPU/Codegen/ShaderEmitter.cpp
@@ -356,6 +356,64 @@ constexpr auto erfcHelperGlsl =
     "eacpErfc(x.w));\n"
     "}\n\n";
 
+// tanh with its two tails answered outright.
+//
+// The native one is there in all three languages, and in none of them is what
+// it does to a large argument something a caller can rely on. Metal is the case
+// that forced this: eacp compiles its library with no MTLCompileOptions, so
+// fast math is on, and under it tanh is evaluated through exp - which overflows
+// somewhere past an argument of 44 and hands back inf/inf, a NaN, where the
+// function saturated at one long before. HLSL and GLSL leave the same freedom
+// to the driver. A tanh GELU's argument is cubic in its input, so an activation
+// of thirty is an argument of nine hundred, and one NaN in a residual stream is
+// the rest of the sequence.
+//
+// Ten is the threshold because float32 resolves nothing between tanh(9.011) and
+// one: 1 - tanh(x) falls below half an ulp of one there, so every argument this
+// answers with a constant is an argument whose correctly rounded tanh is that
+// same constant. The branch therefore changes no representable value of the
+// function - it only keeps the intrinsic inside the range where a driver's
+// version of it is worth calling.
+constexpr auto saturatingTanhHelper =
+    "float eacpSaturatingTanh(float x)\n"
+    "{\n"
+    "    return x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x));\n"
+    "}\n\n"
+    "float2 eacpSaturatingTanh(float2 x)\n"
+    "{\n"
+    "    return float2(eacpSaturatingTanh(x.x), eacpSaturatingTanh(x.y));\n"
+    "}\n\n"
+    "float3 eacpSaturatingTanh(float3 x)\n"
+    "{\n"
+    "    return float3(eacpSaturatingTanh(x.x), eacpSaturatingTanh(x.y),\n"
+    "                  eacpSaturatingTanh(x.z));\n"
+    "}\n\n"
+    "float4 eacpSaturatingTanh(float4 x)\n"
+    "{\n"
+    "    return float4(eacpSaturatingTanh(x.x), eacpSaturatingTanh(x.y),\n"
+    "                  eacpSaturatingTanh(x.z), eacpSaturatingTanh(x.w));\n"
+    "}\n\n";
+
+constexpr auto saturatingTanhHelperGlsl =
+    "float eacpSaturatingTanh(float x)\n"
+    "{\n"
+    "    return x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x));\n"
+    "}\n\n"
+    "vec2 eacpSaturatingTanh(vec2 x)\n"
+    "{\n"
+    "    return vec2(eacpSaturatingTanh(x.x), eacpSaturatingTanh(x.y));\n"
+    "}\n\n"
+    "vec3 eacpSaturatingTanh(vec3 x)\n"
+    "{\n"
+    "    return vec3(eacpSaturatingTanh(x.x), eacpSaturatingTanh(x.y),\n"
+    "                eacpSaturatingTanh(x.z));\n"
+    "}\n\n"
+    "vec4 eacpSaturatingTanh(vec4 x)\n"
+    "{\n"
+    "    return vec4(eacpSaturatingTanh(x.x), eacpSaturatingTanh(x.y),\n"
+    "                eacpSaturatingTanh(x.z), eacpSaturatingTanh(x.w));\n"
+    "}\n\n";
+
 // log2 scaled by log10(2), which is what a driver's own log10 lowers to.
 constexpr auto log10HelperGlsl = "float eacpLog10(float x)\n"
                                  "{\n"
@@ -429,7 +487,7 @@ constexpr auto packBFloat16HelperGlsl =
     "    return (low >> 16u) | (high & 0xffff0000u);\n"
     "}\n\n";
 
-const auto shaderHelpers = Array<ShaderHelper, 9> {
+const auto shaderHelpers = Array<ShaderHelper, 10> {
     ShaderHelper {"eacpUnpackHalf2",
                   "inline float2 eacpUnpackHalf2(uint bits)\n"
                   "{\n"
@@ -445,6 +503,10 @@ const auto shaderHelpers = Array<ShaderHelper, 9> {
                   "}\n\n"},
     ShaderHelper {"eacpErf", erfHelper, erfHelper, erfHelperGlsl},
     ShaderHelper {"eacpErfc", erfcHelper, erfcHelper, erfcHelperGlsl},
+    ShaderHelper {"eacpSaturatingTanh",
+                  saturatingTanhHelper,
+                  saturatingTanhHelper,
+                  saturatingTanhHelperGlsl},
     // One half chosen by a parity rather than both unpacked and one dropped:
     // shifting the wanted half down is a single instruction in every language.
     // as_type<half2>, f16tof32 and unpackHalf2x16 all read the low sixteen bits.
@@ -590,6 +652,30 @@ const char* componentSuffix(int component)
     return component == 1 ? ".y" : ".z";
 }
 
+// The MSL type a run of consecutive buffer elements is loaded through.
+//
+// The packed one and not float4, because the alignment is not ours to promise.
+// A plain float4 wants a sixteen-byte-aligned address, and eacp binds a
+// BufferRange at any four-byte offset - Device::storageBufferOffsetAlignment
+// answers four on this backend - so a range starting one float into a buffer
+// would make every such load undefined. packed_float4 is the same sixteen bytes
+// with an alignment of four, which is exactly what the binding guarantees, and
+// it converts to float4 on the way out.
+const char* metalPackedVectorType(ValueType type)
+{
+    auto integers = isUnsignedInteger(type);
+
+    switch (componentCount(type))
+    {
+        case 2:
+            return integers ? "packed_uint2" : "packed_float2";
+        case 3:
+            return integers ? "packed_uint3" : "packed_float3";
+        default:
+            return integers ? "packed_uint4" : "packed_float4";
+    }
+}
+
 // A thread index under the name both kernel scaffoldings bind it to: the whole
 // value where the node took the position as one, one lane otherwise.
 std::string indexReference(const char* name, DispatchRank rank, int component)
@@ -659,6 +745,49 @@ int reductionStride(int threads)
         stride *= 2;
 
     return stride;
+}
+
+// How many threads one fold spans: the whole group, or one SIMD group of it -
+// and a group smaller than a SIMD group is its own SIMD group, so the narrow
+// scope never reaches past what was dispatched.
+int reductionWidth(const ShaderGraph& graph, ReductionScope scope)
+{
+    auto threads = threadsPerGroup(graph);
+
+    if (scope == ReductionScope::Group)
+        return threads;
+
+    return threads < simdGroupWidth ? threads : simdGroupWidth;
+}
+
+// Whether a fold spans the whole group either because that is its scope or
+// because the group is one SIMD group and the two are the same set of threads.
+bool spansWholeGroup(const ShaderGraph& graph, ReductionScope scope)
+{
+    return reductionWidth(graph, scope) == threadsPerGroup(graph);
+}
+
+// Whether Metal answers a fold with the SIMD-group intrinsic alone, which is
+// the narrow scope and only the narrow scope.
+//
+// Not a whole-group fold in a group of simdGroupWidth threads or fewer, however
+// much it looks like the same thing: that argument holds only where the
+// hardware SIMD group is at least as wide as the group, and the hardware's
+// width is a property of the compiled pipeline (threadExecutionWidth) rather
+// than a constant. An Intel Mac dispatches a kernel at eight or sixteen lanes,
+// so a 32-thread group there is two or four SIMD groups and simd_sum alone
+// would fold a quarter of it. The wide fold keeps the combine at every width -
+// simdCount is whatever the hardware gave - which is what it was always for.
+bool metalFoldsInOneInstruction(ReductionScope scope)
+{
+    return scope == ReductionScope::Simd;
+}
+
+// So a kernel whose folds are all SIMD-scoped on Metal declares neither the
+// scratch nor the three SIMD-group builtins the combine walks.
+bool metalCombinesPartials(const ShaderGraph& graph)
+{
+    return !graph.wholeGroupReductionTypes().empty();
 }
 
 // The scratch a reduction stages its partials in, one array per element type
@@ -1113,6 +1242,39 @@ struct ExprPrinter
                 return "buffer" + std::to_string(expr.index) + "["
                        + ref(expr.args[0]) + "]";
 
+            // One load where the dialect has a spelling for one, and the
+            // componentwise construct it stands in for where it has not. See
+            // metalPackedVectorType for why the Metal form reinterprets the
+            // pointer as a packed type rather than as a plain float4.
+            case ExprKind::BufferVectorRead:
+            {
+                auto name = "buffer" + std::to_string(expr.index);
+                auto base = ref(expr.args[0]);
+
+                if (backend == Backend::Metal)
+                    return std::string(typeName(backend, expr.type))
+                           + "(*((device const " + metalPackedVectorType(expr.type)
+                           + "*) (" + name + " + " + base + ")))";
+
+                auto text = std::string(typeName(backend, expr.type)) + "(";
+
+                for (auto component = 0; component < componentCount(expr.type);
+                     ++component)
+                {
+                    if (component > 0)
+                        text += ", ";
+
+                    text += name + "[" + base;
+
+                    if (component > 0)
+                        text += " + " + std::to_string(component) + "u";
+
+                    text += "]";
+                }
+
+                return text + ")";
+            }
+
             case ExprKind::AtomicLoad:
             {
                 // HLSL has nothing to spell: a UAV element of an
@@ -1192,6 +1354,7 @@ bool wantsLocal(ExprKind kind)
         case ExprKind::Sample:
         case ExprKind::Fetch:
         case ExprKind::BufferRead:
+        case ExprKind::BufferVectorRead:
         case ExprKind::AtomicLoad:
         case ExprKind::ArrayRead:
         case ExprKind::SharedRead:
@@ -1231,8 +1394,18 @@ void countUses(const ShaderGraph& graph,
 
     seen[node] = 1;
 
-    for (auto argument: graph.expr(node).args)
-        countUses(graph, argument, uses, seen);
+    const auto& expr = graph.expr(node);
+
+    // A vector load's index is printed once per component by the backends that
+    // expand it into subscripts, so it earns a name there the way any
+    // subexpression evaluated more than once does - and Metal, which prints it
+    // once, reads the same name and is no worse for it.
+    auto perArgument =
+        expr.kind == ExprKind::BufferVectorRead ? componentCount(expr.type) : 1;
+
+    for (auto argument: expr.args)
+        for (auto i = 0; i < perArgument; ++i)
+            countUses(graph, argument, uses, seen);
 }
 
 // Which nodes a run of expressions evaluates more than once, in dependency
@@ -1510,7 +1683,8 @@ bool readsStale(const ShaderGraph& graph,
 
     // Whichever way the buffer was declared: an output a kernel reads back and
     // an atomic counter it loads are both elements a store can have changed.
-    if ((expr.kind == ExprKind::BufferRead || expr.kind == ExprKind::AtomicLoad)
+    if ((expr.kind == ExprKind::BufferRead || expr.kind == ExprKind::BufferVectorRead
+         || expr.kind == ExprKind::AtomicLoad)
         && buffersWritten[expr.index] != 0)
         return true;
 
@@ -1866,12 +2040,15 @@ struct StageEmitter
     }
 
 private:
-    // MSL folds within each SIMD group first and combines the few partials
-    // through the scratch; HLSL under FXC has no wave intrinsic and GLSL is
-    // held to what lavapipe compiles with no extension, so both take the
-    // scratch tree. Either way the result lands in the reduction's variable on
-    // every thread, and a trailing barrier leaves the scratch free for the
-    // next one.
+    // MSL has the SIMD-group intrinsics, so a fold scoped to one is a single
+    // instruction and a fold over a wider group is those partials combined
+    // through the scratch. HLSL under FXC has no wave intrinsic at cs_5_0, and
+    // GLSL's subgroup extension is both unassumable and the wrong width - a
+    // subgroup is whatever the device says it is, where eacp's simdWidth is 32
+    // everywhere by construction - so both take the scratch tree, narrowed to
+    // the folding thread's own block of lanes where the scope is the SIMD
+    // group. Either way the result lands in the reduction's variable on every
+    // thread, and a trailing barrier leaves the scratch free for the next one.
     std::string groupReduction(const Statement& statement, const std::string& indent)
     {
         auto elementType = graph().variables()[statement.slot];
@@ -1888,6 +2065,9 @@ private:
                           + metalSimdReduction(statement.reduction) + "("
                           + contributed + ");\n";
 
+            if (metalFoldsInOneInstruction(statement.scope))
+                return source;
+
             source += indent + "if (simdLane == 0u)\n" + indent + "    " + scratch
                       + "[simdIndex] = " + name + ";\n";
             source += barrier;
@@ -1903,22 +2083,43 @@ private:
         }
 
         auto lane = std::string(groupLaneName(printer.backend));
-        auto threads = threadsPerGroup(graph());
+        auto width = reductionWidth(graph(), statement.scope);
+        auto whole = spansWholeGroup(graph(), statement.scope);
+        auto widthText = std::to_string(width) + "u";
+
+        // Within the fold, a lane counts from the start of its own block; the
+        // answer is read from that block's first slot. Both collapse to the
+        // plain lane and slot zero where the block is the whole group, which is
+        // what keeps the wide fold spelled exactly as it always was.
+        auto within = whole ? lane : bracketed(lane + " % " + widthText);
+        auto first = whole ? std::string("0")
+                           : bracketed(lane + " / " + widthText) + " * " + widthText;
+
         auto element = scratch + "[" + lane + "]";
         auto partner = scratch + "[" + lane + " + " + step + "]";
 
         auto source = indent + element + " = " + contributed + ";\n";
         source += barrier;
         source += indent + "for (uint " + step + " = "
-                  + std::to_string(reductionStride(threads)) + "u; " + step
-                  + " > 0u; " + step + " >>= 1u)\n" + indent + "{\n";
-        source += indent + "    if (" + lane + " < " + step + " && " + lane + " + "
-                  + step + " < " + std::to_string(threads) + "u)\n";
+                  + std::to_string(reductionStride(width)) + "u; " + step + " > 0u; "
+                  + step + " >>= 1u)\n" + indent + "{\n";
+        // The third conjunct is the scratch's own bound, and it is not implied
+        // by the second: a narrow fold indexes with the global lane while it
+        // counts with the lane within its block, so a group that is not a whole
+        // number of SIMD groups - which the assert in emitCompute refuses, and
+        // which a release build does not - would otherwise read past the array.
+        auto bounded = whole ? std::string {}
+                             : " && " + lane + " + " + step + " < "
+                                   + std::to_string(threadsPerGroup(graph())) + "u";
+
+        source += indent + "    if (" + within + " < " + step + " && " + within
+                  + " + " + step + " < " + widthText + bounded + ")\n";
         source += indent + "        " + element + " = "
                   + foldedPair(statement.reduction, element, partner) + ";\n";
         source += barrierStatement(printer.backend, indent + "    ");
         source += indent + "}\n";
-        source += indent + type + " " + name + " = " + scratch + "[0];\n";
+        source +=
+            indent + type + " " + name + " = " + scratch + "[" + first + "];\n";
 
         return source + barrier;
     }
@@ -2464,7 +2665,9 @@ void collectBufferSlots(const ShaderGraph& graph,
 
     const auto& expr = graph.expr(node);
 
-    if (expr.kind == ExprKind::BufferRead && expr.index < used.size())
+    if ((expr.kind == ExprKind::BufferRead
+         || expr.kind == ExprKind::BufferVectorRead)
+        && expr.index < used.size())
         used[expr.index] = 1;
 
     for (auto argument: expr.args)
@@ -2722,6 +2925,18 @@ std::string emitCompute(const ShaderGraph& graph, Backend backend)
               "ComputeProgram::simdWidth threads. A group that is not leaves a "
               "partial SIMD group, whose matrix operations are undefined.");
 
+    // A SIMD-scoped fold takes the same rule with one allowance: a group
+    // narrower than a SIMD group *is* its own SIMD group, and folding it is
+    // well defined. What is not is a group that leaves a partial one at its
+    // end, where two threads a lane apart would fold over different sets.
+    assert((!graph.usesSimdReduction()
+            || graph.threadGroupShape().threadCount() <= simdGroupWidth
+            || graph.threadGroupShape().threadCount() % simdGroupWidth == 0)
+           && "eacp: a kernel using simdSum/simdMax/simdMin has to be "
+              "dispatched in a threadgroup that is a whole number of SIMD "
+              "groups - a multiple of ComputeProgram::simdWidth threads - or "
+              "in one narrower than a single SIMD group.");
+
     if (backend == Backend::Metal)
         source += "#include <metal_stdlib>\nusing namespace metal;\n\n";
 
@@ -2812,7 +3027,7 @@ std::string emitCompute(const ShaderGraph& graph, Backend backend)
         // group's index and how many of them the threadgroup was given. A
         // kernel holding SIMD-group matrices takes the same three, the index
         // being what places the block of the output each SIMD group owns.
-        if (graph.usesGroupReduction() || graph.usesSimdGroups())
+        if (metalCombinesPartials(graph) || graph.usesSimdGroups())
             source += ",\n    uint simdLane [[thread_index_in_simdgroup]],\n    "
                       "uint simdIndex [[simdgroup_index_in_threadgroup]],\n    "
                       "uint simdCount [[simdgroups_per_threadgroup]]";
@@ -2831,11 +3046,14 @@ std::string emitCompute(const ShaderGraph& graph, Backend backend)
                       + "];\n";
         }
 
-        for (auto elementType: graph.groupReductionTypes())
-            source += "    threadgroup "
-                      + std::string(typeName(backend, elementType)) + " "
-                      + groupScratchName(elementType) + "["
-                      + std::to_string(threadsPerGroup(graph)) + "];\n";
+        // Only the wide folds stage anything here, and only where the group is
+        // more than one SIMD group: everything else is the intrinsic alone.
+        if (metalCombinesPartials(graph))
+            for (auto elementType: graph.wholeGroupReductionTypes())
+                source += "    threadgroup "
+                          + std::string(typeName(backend, elementType)) + " "
+                          + groupScratchName(elementType) + "["
+                          + std::to_string(threadsPerGroup(graph)) + "];\n";
     }
     else if (backend == Backend::Vulkan)
     {

--- a/Lib/eacp/GPU/Codegen/ShaderEmitter.cpp
+++ b/Lib/eacp/GPU/Codegen/ShaderEmitter.cpp
@@ -377,7 +377,7 @@ constexpr auto erfcHelperGlsl =
 constexpr auto saturatingTanhHelper =
     "float eacpSaturatingTanh(float x)\n"
     "{\n"
-    "    return x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x));\n"
+    "    return x >= 10.0 ? 1.0 : (x <= -10.0 ? -1.0 : tanh(x));\n"
     "}\n\n"
     "float2 eacpSaturatingTanh(float2 x)\n"
     "{\n"
@@ -397,7 +397,7 @@ constexpr auto saturatingTanhHelper =
 constexpr auto saturatingTanhHelperGlsl =
     "float eacpSaturatingTanh(float x)\n"
     "{\n"
-    "    return x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x));\n"
+    "    return x >= 10.0 ? 1.0 : (x <= -10.0 ? -1.0 : tanh(x));\n"
     "}\n\n"
     "vec2 eacpSaturatingTanh(vec2 x)\n"
     "{\n"

--- a/Lib/eacp/GPU/Codegen/ShaderGraph.cpp
+++ b/Lib/eacp/GPU/Codegen/ShaderGraph.cpp
@@ -28,6 +28,7 @@ bool dependsOnMutableState(ExprKind kind)
     {
         case ExprKind::VarRead:
         case ExprKind::BufferRead:
+        case ExprKind::BufferVectorRead:
         case ExprKind::AtomicLoad:
         case ExprKind::Sample:
         case ExprKind::Fetch:
@@ -587,12 +588,18 @@ void ShaderGraph::addBarrier()
 
 int ShaderGraph::addGroupReduction(GroupReduction operation,
                                    ValueType elementType,
-                                   int value)
+                                   int value,
+                                   ReductionScope scope)
 {
     barrierUsed = true;
 
     if (!reductionTypes.contains(elementType))
         reductionTypes.add(elementType);
+
+    if (scope == ReductionScope::Simd)
+        simdReductionUsed = true;
+    else if (!wholeGroupTypes.contains(elementType))
+        wholeGroupTypes.add(elementType);
 
     auto slot = variableTypes.size();
     variableTypes.add(elementType);
@@ -601,6 +608,7 @@ int ShaderGraph::addGroupReduction(GroupReduction operation,
     fold.slot = slot;
     fold.value = value;
     fold.reduction = operation;
+    fold.scope = scope;
     addStatement(fold);
 
     return slot;
@@ -697,6 +705,45 @@ ThreadGroupShape ShaderGraph::threadGroupShape() const
             ComputePass::threadGroupSize3D};
 }
 
+// What one element of a threadgroup array really costs, which is not always
+// what the value occupies: an std430 block and a DXBC groupshared array both
+// round a vector's stride up to sixteen bytes, so an array of three-vectors is
+// a quarter larger than its components add up to. MSL packs them to twelve, so
+// this is the worst of the three - which is what a budget is asked for.
+int threadgroupElementBytes(ValueType type)
+{
+    auto bytes = byteSize(type);
+
+    return componentCount(type) > 1 && bytes < 16 ? 16 : bytes;
+}
+
+// The kernel's declarations plus the emitter's own: one scratch array per
+// element type any reduction folds, sized to the group, and one slice of a
+// SIMD-group matrix scratch per SIMD group of it - two whole fragments each,
+// which is what the product stages between its barriers.
+//
+// What it does not count is the padding *between* arrays. A backend may align
+// one array's base against the next, so a kernel sitting within a few bytes of
+// the budget may still be refused; the number is a bound on the declarations
+// and not a byte-exact prediction of the allocation.
+int ShaderGraph::threadgroupMemoryBytes() const
+{
+    auto threads = threadGroupShape().threadCount();
+    auto bytes = 0;
+
+    for (const auto& shared: sharedArrayList)
+        bytes += shared.elements * threadgroupElementBytes(shared.elementType);
+
+    for (auto elementType: reductionTypes)
+        bytes += threads * threadgroupElementBytes(elementType);
+
+    if (simdMatrices > 0)
+        bytes += threads / simdGroupWidth * 2 * simdMatrixSize * simdMatrixSize
+                 * (int) sizeof(float);
+
+    return bytes;
+}
+
 int ShaderGraph::addStorageBuffer(BufferAccess access, ValueType elementType)
 {
     storageSlots.add(access);
@@ -711,6 +758,16 @@ int ShaderGraph::addBufferRead(int slot, int index)
     node.type = storageElementType(slot);
     node.index = slot;
     node.args.add(index);
+    return add(std::move(node));
+}
+
+int ShaderGraph::addBufferVectorRead(int slot, int firstElement, ValueType type)
+{
+    auto node = Expr {};
+    node.kind = ExprKind::BufferVectorRead;
+    node.type = type;
+    node.index = slot;
+    node.args.add(firstElement);
     return add(std::move(node));
 }
 

--- a/Lib/eacp/GPU/Codegen/ShaderGraph.h
+++ b/Lib/eacp/GPU/Codegen/ShaderGraph.h
@@ -50,6 +50,13 @@ enum class ExprKind
     // a 2D or 3D one prints gid.x, gid.y or gid.z - or the whole gid again at
     // allComponents, where the node is the position as one vector.
     BufferRead, // storage-buffer element read; index = buffer slot, args = {index}
+    BufferVectorRead, // a run of 2, 3 or 4 consecutive elements of a read-only
+    // storage buffer, taken as one vector. index = buffer slot, args = {the
+    // *first element's* index}, type = the vector. Separate from a Construct
+    // over that many BufferReads because Metal reinterprets the pointer and
+    // makes one load of it, where the other two have no spelling for that and
+    // emit exactly the componentwise construct this stands in for. Read-only
+    // buffers only - see InputBuffer::read4 for why an output stays scalar.
     AtomicLoad, // one element of an atomic buffer; index = buffer slot,
     // args = {index}. An expression on both backends, unlike the add - MSL
     // spells it atomic_load_explicit and HLSL is an ordinary subscript, since
@@ -127,6 +134,19 @@ enum class GroupReduction
     Sum,
     Max,
     Min
+};
+
+// How many threads a reduction folds over: the whole threadgroup, or only the
+// SIMD group the folding thread belongs to.
+//
+// The narrow one is what a kernel wants wherever its partials are already one
+// per SIMD group - the tile loop of an attention kernel, say, where the whole
+// group has nothing to say to each other yet. On Metal the difference is one
+// instruction against a scratch array between two threadgroup barriers.
+enum class ReductionScope
+{
+    Group,
+    Simd
 };
 
 // Where a SIMD-group matrix fragment is loaded from or stored to. The two are
@@ -231,6 +251,7 @@ struct Statement
     int recordComponentsLeft = 0; // Store: how many components of that record
     // follow this one
     GroupReduction reduction = GroupReduction::Sum; // GroupReduce: which fold
+    ReductionScope scope = ReductionScope::Group; // GroupReduce: over how many
     int stride = -1; // SimdMatrixLoad / SimdMatrixStore: the patch's row stride
     int left = -1; // SimdMatrixMultiplyAdd: the left operand's fragment
     int right = -1; // SimdMatrixMultiplyAdd: the right operand's fragment
@@ -446,6 +467,12 @@ public:
     int addStorageBuffer(BufferAccess access,
                          ValueType elementType = ValueType::Float);
     int addBufferRead(int slot, int index);
+
+    // A run of consecutive elements of a read-only buffer as one vector, the
+    // index being the first element's rather than the record's. Metal makes one
+    // load of it; the other two spell the componentwise construct it stands for.
+    int addBufferVectorRead(int slot, int firstElement, ValueType type);
+
     void addStore(int slot, int index, int value);
 
     // The N element stores one record write lays down, told apart from N
@@ -487,12 +514,15 @@ public:
     void addSharedStore(int slot, int index, int value);
     void addBarrier();
 
-    // A group-wide fold. Returns the *variable* slot every thread's result
-    // lands in, which addVarRead then reads - a statement like the atomic add,
-    // and one that barriers, so it counts as a barrier for the bounds guard.
+    // A fold over the threadgroup or over one SIMD group of it. Returns the
+    // *variable* slot every thread's result lands in, which addVarRead then
+    // reads - a statement like the atomic add, and one that counts as a barrier
+    // for the bounds guard whichever scope it has, since the backends with no
+    // wave intrinsic reach even the narrow one through threadgroup memory.
     int addGroupReduction(GroupReduction operation,
                           ValueType elementType,
-                          int value);
+                          int value,
+                          ReductionScope scope = ReductionScope::Group);
 
     // The SIMD-group matrix statements. Each of the first two declares a
     // fragment and returns its slot, which is a numbering of its own: a
@@ -568,10 +598,40 @@ public:
     const Vector<TextureStore>& textureStores() const { return textureStoreList; }
     const Vector<SharedArray>& sharedArrays() const { return sharedArrayList; }
 
-    // The element types the kernel's group reductions fold, one entry each, so
-    // the emitter declares the scratch a reduction needs and no more.
+    // The element types the kernel's reductions fold, one entry each, so the
+    // emitter declares the scratch a reduction needs and no more. Both scopes
+    // are in here, because a backend with no wave intrinsic stages the narrow
+    // fold in the same array the wide one uses.
     const Vector<ValueType>& groupReductionTypes() const { return reductionTypes; }
     bool usesGroupReduction() const { return !reductionTypes.empty(); }
+
+    // The subset folded over the *whole* group, which is the only scope Metal
+    // needs an array for: there a SIMD-group fold is one instruction, and so is
+    // a whole-group fold in a group no wider than a SIMD group.
+    const Vector<ValueType>& wholeGroupReductionTypes() const
+    {
+        return wholeGroupTypes;
+    }
+
+    // Whether any reduction is collective over a SIMD group rather than over
+    // the threadgroup - which puts the kernel under the same rule a SIMD-group
+    // matrix is under, that the group has to be a whole number of SIMD groups.
+    bool usesSimdReduction() const { return simdReductionUsed; }
+
+    // How many bytes of threadgroup memory one group of this kernel takes: the
+    // shared arrays it declared, plus the scratch the emitter adds behind them
+    // for a reduction and for a SIMD-group matrix.
+    //
+    // The worst case of the three backends rather than this one's, since the
+    // number is what a kernel is written against and a kernel is written once.
+    // A vector element therefore counts as sixteen bytes, which is the stride
+    // an std430 block and a DXBC groupshared array give it where MSL packs a
+    // three-vector to twelve.
+    //
+    // Padding *between* arrays is not counted, so this is a bound on what the
+    // declarations ask for rather than a byte-exact prediction of what the
+    // backend will allocate.
+    int threadgroupMemoryBytes() const;
 
     // How many 8x8 fragments the kernel declared, and whether it asked the
     // entry point for the SIMD-group vocabulary at all - a matrix statement or
@@ -661,6 +721,8 @@ private:
     Vector<ArrayConstant> arrayConstants;
     Vector<SharedArray> sharedArrayList;
     Vector<ValueType> reductionTypes;
+    Vector<ValueType> wholeGroupTypes;
+    bool simdReductionUsed = false;
     int simdMatrices = 0;
     bool simdGroupIndexUsed = false;
     bool localIdUsed = false;

--- a/Lib/eacp/GPU/Codegen/ShaderValue.h
+++ b/Lib/eacp/GPU/Codegen/ShaderValue.h
@@ -581,17 +581,39 @@ inline UInt bufferIndex(ShaderGraph* graph, unsigned index)
     return result;
 }
 
+// The first element of record `index` in a buffer of `count`-wide records,
+// which is the one index a vector read and its matching write share.
+inline int recordBase(ShaderGraph* graph, const UInt& index, int count)
+{
+    return graph->addBinary(
+        ValueType::UInt, '*', index.node, graph->addUIntConstant((unsigned) count));
+}
+
 // count consecutive elements starting at index * count, assembled into a
-// vector. A buffer stays a run of floats on both backends - this is arithmetic
-// over the binding that already works, not a retyped one - so what it costs is
-// count scalar loads rather than one wide load. See ShaderBuilder::write for
-// the store that lays the same layout down.
+// vector, as count separate subscripts. A buffer stays a run of floats on every
+// backend - this is arithmetic over the binding that already works, not a
+// retyped one - so what it costs is count scalar loads. See
+// ShaderBuilder::write for the store that lays the same layout down.
+//
+// What a *read-only* buffer takes instead is readBufferVectorLoad below. This
+// is what an output takes, and the difference is not a missing optimisation:
+// an output may hold what this very thread stored into it a statement ago, and
+// the subscript through the pointer that was written is what orders the two.
+// A load through a second pointer of another type has nothing saying it may not
+// be hoisted above the store.
+//
+// Which is also why one GPU::Buffer must not be bound to an input slot and an
+// output slot of the same kernel, as InputBuffer's own comment says: the
+// emitter orders a read against the stores to *its slot*, not against the
+// stores to whatever resource the slot was bound, so an input's packed load is
+// unordered against a write through the output slot that happens to name the
+// same buffer. A kernel computing in place declares one OutputBuffer and reads
+// that.
 template <typename T>
 T readBufferVector(
     ShaderGraph* graph, int slot, const UInt& index, ValueType type, int count)
 {
-    auto base = graph->addBinary(
-        ValueType::UInt, '*', index.node, graph->addUIntConstant((unsigned) count));
+    auto base = recordBase(graph, index, count);
 
     auto components = Vector<int> {};
 
@@ -610,6 +632,20 @@ T readBufferVector(
     auto result = T {};
     result.graph = graph;
     result.node = graph->addConstruct(type, std::move(components));
+    return result;
+}
+
+// The same run of elements as one node, which Metal makes one load of and the
+// other two print as exactly the construct above. Read-only buffers only.
+template <typename T>
+T readBufferVectorLoad(
+    ShaderGraph* graph, int slot, const UInt& index, ValueType type, int count)
+{
+    auto result = T {};
+    result.graph = graph;
+    result.node =
+        graph->addBufferVectorRead(slot, recordBase(graph, index, count), type);
+
     return result;
 }
 } // namespace detail
@@ -647,21 +683,31 @@ struct InputBuffer
     // The index is in records, not in floats - read4(i) and the matching
     // write(output, i, Float4) address the same record - so a kernel never
     // spells the stride itself.
+    //
+    // And on Metal it is one load rather than that many: the run of elements is
+    // read through a packed vector pointer, sixteen bytes in one instruction
+    // for read4. HLSL and GLSL emit the componentwise construct, because a
+    // StructuredBuffer<float> and an std430 block of floats have no spelling
+    // for reinterpreting themselves - see ExprKind::BufferVectorRead and the
+    // emitter's metalPackedVectorType.
+    //
+    // OutputBuffer's siblings stay scalar on every backend on purpose; the
+    // comment on readBufferVector says why.
     Float2 read2(const UInt& index) const
     {
-        return detail::readBufferVector<Float2>(
+        return detail::readBufferVectorLoad<Float2>(
             graph, slot, index, ValueType::Float2, 2);
     }
 
     Float3 read3(const UInt& index) const
     {
-        return detail::readBufferVector<Float3>(
+        return detail::readBufferVectorLoad<Float3>(
             graph, slot, index, ValueType::Float3, 3);
     }
 
     Float4 read4(const UInt& index) const
     {
-        return detail::readBufferVector<Float4>(
+        return detail::readBufferVectorLoad<Float4>(
             graph, slot, index, ValueType::Float4, 4);
     }
 
@@ -681,22 +727,32 @@ struct InputBuffer
     }
 
     // The fp16 reads, for a buffer whose elements are halves: readHalf counts
-    // in halves, readHalf2 in the words that hold two of them. Declared here
+    // in halves, readHalf2 in the words that hold two of them, readHalf4 in
+    // records of four - the two words starting at word 2 * i. Declared here
     // and defined further down, since they are spelled in terms of asUInt and
     // unpackHalf2, neither of which exists yet at this point in the header.
-    // Both fetch a whole word, so the buffer needs a whole number of them.
+    // All of them fetch whole words, so the buffer needs a whole number of them.
+    //
+    // The four-wide one is the width a weight walk wants: it takes its two
+    // words through read2, so on Metal the eight bytes arrive in one load and
+    // the unpacking is register arithmetic over them.
     Float readHalf(const UInt& index) const;
     Float readHalf(unsigned index) const;
     Float2 readHalf2(const UInt& index) const;
     Float2 readHalf2(unsigned index) const;
+    Float4 readHalf4(const UInt& index) const;
+    Float4 readHalf4(unsigned index) const;
 
     // The bf16 reads, on exactly those terms: readBFloat16 counts in bfloat16s,
-    // readBFloat16x2 in the words that hold two. The two-wide name carries an
-    // x2 rather than a bare 2, which after "16" would read as one number.
+    // readBFloat16x2 in the words that hold two, readBFloat16x4 in records of
+    // four. The wide names carry an x rather than a bare digit, which after
+    // "16" would read as one number.
     Float readBFloat16(const UInt& index) const;
     Float readBFloat16(unsigned index) const;
     Float2 readBFloat16x2(const UInt& index) const;
     Float2 readBFloat16x2(unsigned index) const;
+    Float4 readBFloat16x4(const UInt& index) const;
+    Float4 readBFloat16x4(unsigned index) const;
 
     ShaderGraph* graph = nullptr;
     int slot = -1;
@@ -792,22 +848,22 @@ struct UIntInputBuffer
     // rather than single ones: read4(i) is elements 4i..4i+3 as a UInt4. The
     // index is in records, not in elements - read4(i) and the matching
     // write(output, i, UInt4) address the same record - so a kernel never
-    // spells the stride itself.
+    // spells the stride itself. One load on Metal, as InputBuffer's are.
     UInt2 read2(const UInt& index) const
     {
-        return detail::readBufferVector<UInt2>(
+        return detail::readBufferVectorLoad<UInt2>(
             graph, slot, index, ValueType::UInt2, 2);
     }
 
     UInt3 read3(const UInt& index) const
     {
-        return detail::readBufferVector<UInt3>(
+        return detail::readBufferVectorLoad<UInt3>(
             graph, slot, index, ValueType::UInt3, 3);
     }
 
     UInt4 read4(const UInt& index) const
     {
-        return detail::readBufferVector<UInt4>(
+        return detail::readBufferVectorLoad<UInt4>(
             graph, slot, index, ValueType::UInt4, 4);
     }
 
@@ -1452,6 +1508,28 @@ template <ShaderValueLike T>
 ShaderBase<T> tanh(const T& value)
 {
     return detail::componentCall(value, "tanh");
+}
+
+// tanh with its tails answered rather than computed: exactly +/-1 past an
+// argument of ten, the native builtin inside it.
+//
+// What the native one does with a large argument is the driver's business, and
+// on the backend eacp compiles with fast math - Metal, whose library is built
+// with no MTLCompileOptions - tanh(990) is a NaN rather than a one. That is not
+// a contrived argument: a tanh GELU cubes its input on the way in, so an
+// activation of thirty arrives here as nine hundred, and the NaN it comes back
+// with is the whole rest of a transformer's residual stream.
+//
+// The two spellings agree everywhere either is defined. Float32 resolves
+// nothing between tanh(9.011) and one, so every argument this answers with a
+// constant is one whose correctly rounded tanh is that same constant - which is
+// what makes this a repair of the tails and not a different function. Reach for
+// it wherever the argument is not bounded by construction, and for a saturating
+// activation that is always.
+template <ShaderValueLike T>
+ShaderBase<T> saturatingTanh(const T& value)
+{
+    return detail::componentCall(value, "eacpSaturatingTanh");
 }
 
 template <ShaderValueLike T>
@@ -3558,5 +3636,44 @@ template <typename... Args>
 Bool4 bool4(const Args&... args)
 {
     return detail::buildFrom<Bool4, ValueType::Bool>(args...);
+}
+
+// The four-wide packed reads, down here because they are the one pair spelled
+// in terms of float4(), which the vector builders below the conversions
+// declare. Both take their two words through read2 rather than through two
+// subscripts, so the eight bytes are a single load wherever the backend has
+// one and the unpacking is register arithmetic over what it brought back.
+
+// Four halves, which is two words - and read as one record of two floats rather
+// than as two subscripts, so the eight bytes are a single load wherever the
+// backend has one. The index counts records of four halves, so element k of the
+// buffer is readHalf(k) and readHalf4(k / 4) component k % 4, on the layout
+// readHalf2 already fixes: the low half of a word comes first.
+inline Float4 InputBuffer::readHalf4(const UInt& index) const
+{
+    auto words = read2(index);
+
+    return float4(unpackHalf2(asUInt(words.x())), unpackHalf2(asUInt(words.y())));
+}
+
+inline Float4 InputBuffer::readHalf4(unsigned index) const
+{
+    return readHalf4(detail::bufferIndex(graph, index));
+}
+
+// Four bfloat16s in two words, on exactly the terms readHalf4 sets: one record
+// read of two floats, so one load, and the widening is four shifts over what it
+// brought back.
+inline Float4 InputBuffer::readBFloat16x4(const UInt& index) const
+{
+    auto words = read2(index);
+
+    return float4(unpackBFloat16x2(asUInt(words.x())),
+                  unpackBFloat16x2(asUInt(words.y())));
+}
+
+inline Float4 InputBuffer::readBFloat16x4(unsigned index) const
+{
+    return readBFloat16x4(detail::bufferIndex(graph, index));
 }
 } // namespace eacp::GPU

--- a/Lib/eacp/GPU/Device/Device-Apple.mm
+++ b/Lib/eacp/GPU/Device/Device-Apple.mm
@@ -163,6 +163,16 @@ int Device::storageBufferOffsetAlignment() const
     return 4;
 }
 
+int Device::maxThreadgroupMemory() const
+{
+    auto metalDevice = (__bridge id<MTLDevice>) nativeDevice();
+
+    if (metalDevice == nil)
+        return 0;
+
+    return (int) metalDevice.maxThreadgroupMemoryLength;
+}
+
 void* Device::nativeContext() const
 {
     // Nothing to hand out: the queue, the texture cache and the samplers are

--- a/Lib/eacp/GPU/Device/Device-Linux.cpp
+++ b/Lib/eacp/GPU/Device/Device-Linux.cpp
@@ -82,6 +82,14 @@ int Device::storageBufferOffsetAlignment() const
     return alignment > 0 ? (int) alignment : 4;
 }
 
+int Device::maxThreadgroupMemory() const
+{
+    if (!isValid())
+        return 0;
+
+    return (int) getVulkanShared().getProperties().limits.maxComputeSharedMemorySize;
+}
+
 void* Device::nativeContext() const
 {
     return &impl->context;

--- a/Lib/eacp/GPU/Device/Device-Windows.cpp
+++ b/Lib/eacp/GPU/Device/Device-Windows.cpp
@@ -118,6 +118,14 @@ int Device::storageBufferOffsetAlignment() const
     return 4;
 }
 
+// A shader-model constant rather than an adapter's answer: Direct3D gives a
+// thread group 32 KB of groupshared memory at cs_5_0 on every device that runs
+// the model at all, so there is nothing to query and nothing that varies.
+int Device::maxThreadgroupMemory() const
+{
+    return isValid() ? 32 * 1024 : 0;
+}
+
 void* Device::nativeContext() const
 {
     return &impl->context;

--- a/Lib/eacp/GPU/Device/Device.h
+++ b/Lib/eacp/GPU/Device/Device.h
@@ -148,6 +148,27 @@ public:
     // ranges are four-byte everywhere, this backend included.
     int storageBufferOffsetAlignment() const;
 
+    // How many bytes of threadgroup memory one group may declare on this
+    // device - the budget every `shared<>` array in a kernel is spent out of,
+    // the emitter's own reduction and SIMD-matrix scratch included.
+    //
+    // It is a device property on two of the three backends and a shader-model
+    // constant on the third: Metal's maxThreadgroupMemoryLength is 32 KB on
+    // every Mac eacp runs on and larger on some Apple-family parts, D3D12 at
+    // cs_5_0 gives a group a flat 32 KB of groupshared, and Vulkan reports
+    // maxComputeSharedMemorySize, which the spec floors at 16 KB. So 16 KB is
+    // what a kernel may assume anywhere and 32 KB is what the two backends with
+    // a fixed number give.
+    //
+    // Worth asking rather than knowing, because the alternative is what a
+    // kernel author does today: carry the number in a comment, size the tile by
+    // hand against it, and find out from a pipeline that would not build.
+    // ComputeProgram::threadgroupMemoryBytes() is the other half - what the
+    // kernel spends - and prepare() names the overspend before the backend
+    // reports it as a pipeline it could not make. An invalid Device answers
+    // zero, and a check against zero stands down.
+    int maxThreadgroupMemory() const;
+
     // Opaque native handles for cross-translation-unit use by other GPU types.
     void* nativeDevice() const;
     void* nativeQueue() const;

--- a/Lib/eacp/GPU/Pipeline/ComputePipeline-Apple.mm
+++ b/Lib/eacp/GPU/Pipeline/ComputePipeline-Apple.mm
@@ -78,6 +78,14 @@ bool ComputePipeline::isValid() const
     return impl->state.get() != nil;
 }
 
+int ComputePipeline::threadExecutionWidth() const
+{
+    if (impl->state.get() == nil)
+        return 0;
+
+    return (int) impl->state.get().threadExecutionWidth;
+}
+
 void* ComputePipeline::nativeState() const
 {
     return (__bridge void*) impl->state.get();

--- a/Lib/eacp/GPU/Pipeline/ComputePipeline-Linux.cpp
+++ b/Lib/eacp/GPU/Pipeline/ComputePipeline-Linux.cpp
@@ -127,6 +127,13 @@ bool ComputePipeline::isValid() const
     return impl->state.pipeline != VK_NULL_HANDLE;
 }
 
+// Nothing to report: this backend emulates a SIMD group at the EDSL's own width
+// rather than lowering to a hardware one, so there is no second number here.
+int ComputePipeline::threadExecutionWidth() const
+{
+    return 0;
+}
+
 void* ComputePipeline::nativeState() const
 {
     return const_cast<VulkanComputePipeline*>(&impl->state);

--- a/Lib/eacp/GPU/Pipeline/ComputePipeline-Windows.cpp
+++ b/Lib/eacp/GPU/Pipeline/ComputePipeline-Windows.cpp
@@ -51,6 +51,13 @@ bool ComputePipeline::isValid() const
     return impl->state != nullptr;
 }
 
+// Nothing to report: this backend emulates a SIMD group at the EDSL's own width
+// rather than lowering to a hardware one, so there is no second number here.
+int ComputePipeline::threadExecutionWidth() const
+{
+    return 0;
+}
+
 void* ComputePipeline::nativeState() const
 {
     return impl->state.get();

--- a/Lib/eacp/GPU/Pipeline/ComputePipeline.h
+++ b/Lib/eacp/GPU/Pipeline/ComputePipeline.h
@@ -24,6 +24,17 @@ public:
     // dispatches it in. Unset for a hand-written source that named none.
     ThreadGroupShape threadGroupShape() const { return groupShape; }
 
+    // How many threads this pipeline's SIMD groups really hold on this device -
+    // Metal's threadExecutionWidth, which is a property of the compiled kernel
+    // and not of the EDSL: 32 on every Apple GPU and 8 or 16 on an Intel Mac.
+    //
+    // Zero where the backend reports none, which is both of the others: they
+    // emulate a SIMD group at ComputeProgram::simdWidth lanes rather than
+    // lowering to one, so there is no hardware width for them to disagree with.
+    // ComputeProgram::prepare is what reads this, for the kernels whose
+    // correctness depends on the two numbers agreeing.
+    int threadExecutionWidth() const;
+
     // Opaque native handle for cross-translation-unit use by the compute pass.
     void* nativeState() const;
 

--- a/Lib/eacp/GPU/README.md
+++ b/Lib/eacp/GPU/README.md
@@ -214,13 +214,24 @@ other. `Tests/GPU/CullModeTests.cpp` is what fails if either drifts.
   tanh approximation of it. The origin is exact, which the polynomial on its own
   is not: `erf` is odd across it bit for bit and zero at it, `erfc` is one
   there, and the two sum to one
+- `saturatingTanh`, which is `tanh` with its two tails answered rather than
+  computed: exactly ±1 past an argument of ten, the native builtin inside it.
+  What the native one does with a large argument is the driver's business, and
+  eacp compiles its Metal library with no `MTLCompileOptions` — so fast math is
+  on, `tanh` is evaluated through `exp`, and `tanh(990)` comes back NaN. A tanh
+  GELU cubes its input on the way in, so an activation of thirty arrives as
+  exactly that argument. Float32 resolves nothing between `tanh(9.011)` and one,
+  so every argument answered with a constant is one whose correctly rounded tanh
+  is that constant: it is a repair of the tails, not a different function. Reach
+  for it wherever the argument is not bounded by construction
 - Statements: `var`, `select`, `ifThen`, `loop`, `breakLoop`, `continueLoop`.
   A `var` takes any handle and any matrix. `select` runs across every family —
   a float, an index, an integer vector, a mask — and takes a literal on either
   side of a scalar one; the condition is a scalar `Bool` in all of them, which
   is the conditional operator both languages already print
 - Compute-only: `atomicAdd`, `shared<T>(count)`, `barrier`, `localId`, the
-  group-wide `groupSum` / `groupMax` / `groupMin`, and the SIMD-group matrix —
+  group-wide `groupSum` / `groupMax` / `groupMin` and their SIMD-group-scoped
+  siblings `simdSum` / `simdMax` / `simdMin`, and the SIMD-group matrix —
   `simdGroupIndex`, `simdMatrix`, `multiplyAccumulate` and the `write` that
   stores a fragment — see the compute section
 - `Array<T, N>` with a subscript, at a literal or a computed index
@@ -932,6 +943,19 @@ void define() override
 `groupShape()` is what to size the tile against rather than a literal, since it
 follows the shape the kernel asked for — 64 for one that asked for nothing.
 
+**How much there is to spend is a device question, and one the EDSL answers.**
+`Device::maxThreadgroupMemory()` is the budget in bytes — Metal's
+`maxThreadgroupMemoryLength`, a flat 32 KB at D3D's `cs_5_0`, Vulkan's
+`maxComputeSharedMemorySize`, whose spec floor of 16 KB is therefore what a
+kernel may assume anywhere. `ComputeProgram::threadgroupMemoryBytes()` is the
+other half: what this kernel takes, its `shared<>` arrays plus the scratch the
+emitter adds behind them for a reduction and for a SIMD-group matrix, counted as
+the worst of the three backends since a kernel is written once.
+`fitsThreadgroupMemory(device)` is the two compared, and `prepare()` names an
+overspend in the log — both numbers — before the backend reports it as a
+pipeline that would not build, which on Metal happens after the library compiled
+clean and points at the wrong thing.
+
 Nothing initialises it — what it holds before the group writes it is undefined,
 which is why every use starts by filling it and waiting. Reading is a subscript;
 writing goes through the same `write()` the buffers and textures use, because a
@@ -966,12 +990,34 @@ auto particle = state.read4(index);           // position.xy, velocity.xy
 write(next, index, float4(newPosition, newVelocity));
 ```
 
-Underneath it is still N scalar accesses over a run of floats, deliberately: a
-retyped `float4` binding would buy one wide store and cost the CPU-side element
-size that makes those same bytes bindable as a per-instance vertex stream. It is
-one write above them all the same — every component is stored the value the
-record held before the first of them ran — so a record read out of an output and
-rearranged back into it swaps its components rather than broadcasting one:
+Underneath, the buffer is still a run of floats and the *store* is still N
+scalar accesses over it, deliberately: a retyped `float4` binding would buy one
+wide store and cost the CPU-side element size that makes those same bytes
+bindable as a per-instance vertex stream.
+
+The *read* of a read-only buffer is one load where the dialect has a spelling
+for one. On Metal `input.read4(i)` is the sixteen bytes fetched through a
+`packed_float4` pointer — packed and not `float4`, because a ranged bind's
+offset only has to sit on `Device::storageBufferOffsetAlignment()`, which is
+four bytes there, and a `float4` load wants sixteen. HLSL and GLSL have nothing
+to reinterpret — a `StructuredBuffer<float>` and an std430 block of floats are
+runs of scalars — so they emit exactly the componentwise construct, with the
+base index named once. Giving them a real vector load would mean changing the
+binding itself: a raw `ByteAddressBuffer` SRV on D3D12, with every scalar read
+respelled as `asfloat(buffer0.Load(i * 4))`, or a second block aliasing the same
+binding in GLSL. Neither is worth what it would cost the scalar path, which is
+what almost every kernel reads through.
+
+`OutputBuffer`'s vector reads stay scalar on every backend, and that is not an
+oversight: an output may hold what this very thread stored into it a statement
+ago, and the subscript through the pointer that was written is what orders the
+two. A load through a second pointer of another type has nothing saying it may
+not be hoisted above the store.
+
+A record read is one write above its stores all the same — every component is
+stored the value the record held before the first of them ran — so a record read
+out of an output and rearranged back into it swaps its components rather than
+broadcasting one:
 
 ```cpp
 auto pair = output.read2(i);
@@ -1059,7 +1105,58 @@ partials through a scratch array; HLSL under FXC has no wave intrinsic at
 `cs_5_0` and GLSL is held to what a driver compiles with no subgroup extension,
 so both walk a `groupshared` tree with a barrier per halving step. The scratch
 is the emitter's own, declared once per kernel and only where a reduction asked
-for it.
+for it — and on Metal only where a *whole-group* fold asked, since a SIMD-scoped
+one needs none.
+
+A group of `simdWidth` threads is not a special case of that: whether it is one
+SIMD group is a property of the compiled pipeline
+(`ComputePipeline::threadExecutionWidth`) and not of the EDSL, and an Intel Mac
+runs a kernel at eight or sixteen lanes. The wide fold therefore keeps its
+combine at every group size — `simdCount` is whatever the hardware gave — which
+is what it was always for.
+
+**`simdSum`, `simdMax` and `simdMin` are the same three narrowed to one SIMD
+group.** Every thread is handed the fold of the `simdWidth` threads it shares a
+SIMD group with, so a group of several comes out holding one answer per SIMD
+group rather than one for the group. That is what a fold inside a per-tile loop
+wants — attention walking its keys a SIMD group at a time has nothing to say to
+the rest of the threadgroup yet — and on Metal it is a single instruction with
+no threadgroup memory and no barrier, against the two barriers the wide fold
+costs.
+
+They are still collective, and the rule is the wide fold's: every thread of the
+*threadgroup* reaches one or none does, and a kernel holding one loses its
+bounds guard. That is because the other two backends still reach it through the
+scratch, narrowed to the folding thread's own block of lanes — HLSL has no wave
+intrinsic at `cs_5_0`, and GLSL's `subgroupAdd` is both an extension no lane
+here is held to and the wrong fold: a subgroup is whatever width the device says
+it is (eight on Mesa's lavapipe), where `simdWidth` is thirty-two everywhere by
+construction, exactly as the SIMD-group matrix fixes it. An intrinsic that folded
+a different number of threads under the same name would be worse than no
+intrinsic. The group has to be a whole number of SIMD groups, or narrower than
+one — the same rule a fragment is under, with the one allowance that a group
+smaller than a SIMD group *is* its own SIMD group.
+
+**How many threads one folds is the one promise these three cannot keep on
+their own.** The emulated backends fold exactly `simdWidth` lanes, because that
+is what the emitted tree walks. Metal folds the *hardware* SIMD group, which is
+what `simd_sum` is collective over — thirty-two on every Apple GPU, eight or
+sixteen on an Intel one, where the same call folds a quarter of what the
+arithmetic around it assumes. eacp needs the two to agree and cannot know until
+there is a pipeline, so `ComputeProgram::prepare` compares the compiled kernel's
+`threadExecutionWidth` against `simdWidth` and says so in the log when they
+differ — for a kernel using `simdSum`/`simdMax`/`simdMin` or a `SimdMatrix`.
+A kernel that has to be right at any width wants `groupSum`/`groupMax`/
+`groupMin` instead.
+
+**Uniform control flow, not merely a uniform arrival.** Every thread must reach
+a fold with the same branches taken. `loop(condition, body)` takes an ordinary
+per-thread `Bool`, so a fold inside a loop some lanes leave earlier than others
+is divergent: the emulated backends hang at the barrier inside the fold, and
+Metal's intrinsic tolerates it silently and folds only the lanes still running —
+which is the worse of the two, being right on the machine it was written on and
+a hang on the next. Bound the loop by something uniform across the group and
+guard the body's stores instead.
 
 ### The SIMD-group matrix
 
@@ -1277,13 +1374,23 @@ These are the way in and out of that:
 | --- | --- |
 | `input.readHalf(i)` | element `i` of a buffer of halves, widened to a `Float`. `i` counts halves, so an N-weight buffer is walked `0..N-1` |
 | `input.readHalf2(i)` | both halves of word `i` as a `Float2`, `.x` the low bits |
+| `input.readHalf4(i)` | four halves as a `Float4` — the two words starting at word `2 * i`, so `i` counts records of four and element `k` is `readHalf4(k / 4)` component `k % 4` |
 | `unpackHalf2(bits)` | the same, from a `UInt` already in hand |
 | `packHalf2(pair)` | two floats narrowed and packed into a `UInt` |
 | `writeHalf2(out, i, pair)` | that word stored at `i` — `readHalf2` reads it back |
 | `asUInt(f)` / `asFloat(u)` | a value's bits rather than its value, both ways |
 
 Size the buffer in whole words: `readHalf` fetches the word at `i / 2`, so an
-odd count of halves reads past its last byte on the final element.
+odd count of halves reads past its last byte on the final element. `readHalf4`
+and `readBFloat16x4` want a whole number of *pairs* of words for the same
+reason.
+
+The four-wide pair is the width a weight walk wants, and it is not four
+subscripts: both take their two words through `read2`, so on Metal the eight
+bytes arrive in one `packed_float2` load and the unpacking is register
+arithmetic over what came back. HLSL and GLSL fetch the two words as two
+scalars, which is what their float buffers give — see the vector reads above
+for why neither can reinterpret one.
 
 `readHalf` emits a two-argument helper — the word and which half of it — rather
 than unpacking both and selecting: MSL and HLSL each reach the wanted half with
@@ -1320,6 +1427,7 @@ void define() override
 | --- | --- |
 | `input.readBFloat16(i)` | element `i` of a buffer of bfloat16s, widened to a `Float`. `i` counts bfloat16s |
 | `input.readBFloat16x2(i)` | both bfloat16s of word `i` as a `Float2`, `.x` the low bits |
+| `input.readBFloat16x4(i)` | four bfloat16s as a `Float4` — the two words starting at word `2 * i`, on the terms `readHalf4` sets |
 | `unpackBFloat16x2(bits)` | the same, from a `UInt` already in hand |
 | `packBFloat16x2(pair)` | two floats narrowed and packed into a `UInt` |
 | `writeBFloat16x2(out, i, pair)` | that word stored at `i` — `readBFloat16x2` reads it back |

--- a/Lib/eacp/GPU/README.md
+++ b/Lib/eacp/GPU/README.md
@@ -215,7 +215,8 @@ other. `Tests/GPU/CullModeTests.cpp` is what fails if either drifts.
   is not: `erf` is odd across it bit for bit and zero at it, `erfc` is one
   there, and the two sum to one
 - `saturatingTanh`, which is `tanh` with its two tails answered rather than
-  computed: exactly ±1 past an argument of ten, the native builtin inside it.
+  computed: exactly ±1 from an argument of ten outward, the native builtin
+  inside it.
   What the native one does with a large argument is the driver's business, and
   eacp compiles its Metal library with no `MTLCompileOptions` — so fast math is
   on, `tanh` is evaluated through `exp`, and `tanh(990)` comes back NaN. A tanh

--- a/Tests/GPU/ComputeBufferRangeTests.cpp
+++ b/Tests/GPU/ComputeBufferRangeTests.cpp
@@ -27,6 +27,24 @@ struct CopyKernel final : ComputeProgram
     EACP_SHADER(input, output)
 };
 
+// Four floats at a time, so the read is the one vector load rather than four
+// subscripts - the whole point of the range offset below.
+struct RecordCopyKernel final : ComputeProgram
+{
+    RecordCopyKernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, input.read4(i));
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+
 // One add per thread into a counter of its own, so an offset shows up as which
 // counters moved.
 struct BumpKernel final : ComputeProgram
@@ -142,6 +160,46 @@ auto tInputBoundAtOffset = test("GPU/computeInputBoundAtOffset") = []
         pass.setInputBuffer(elements(input, first, count), kernel.input.slot);
         pass.setOutputBuffer(output, kernel.output.slot);
         dispatchBoundByHand(pass, kernel, count);
+    }
+
+    commands.commit();
+
+    auto values = readFloats(output, count);
+
+    for (auto i = 0; i < count; ++i)
+        check(values[i] == (float) (first + i));
+};
+
+// A vector read through a range that does not start on a sixteen-byte boundary,
+// which is the case the Metal load is shaped around: a ranged bind's offset has
+// to sit on Device::storageBufferOffsetAlignment and that is four bytes here, so
+// read4 cannot ask for a float4's alignment and reads a packed vector instead.
+auto tVectorReadFromAnOffsetRange =
+    test("GPU/computeVectorReadFromAnOffsetRange") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    const auto records = 6;
+    const auto count = records * 4;
+    const auto first = rowElements(floatBytes);
+
+    auto input = makeRamp(first + count);
+    auto output = makeFilled(count, -1.0f);
+
+    auto kernel = RecordCopyKernel {};
+    kernel.prepare();
+
+    auto commands = device.makeCommandBuffer();
+
+    {
+        auto pass = commands.beginCompute();
+        pass.setPipeline(kernel.pipeline());
+        pass.setInputBuffer(elements(input, first, count), kernel.input.slot);
+        pass.setOutputBuffer(output, kernel.output.slot);
+        dispatchBoundByHand(pass, kernel, records);
     }
 
     commands.commit();

--- a/Tests/GPU/GroupReductionCodegenTests.cpp
+++ b/Tests/GPU/GroupReductionCodegenTests.cpp
@@ -78,6 +78,192 @@ auto tGroupReductionSource = test("GroupReduction/eachBackendFoldsItsOwnWay") = 
     expectGlslCompiles(graph);
 };
 
+// The SIMD-scoped fold: one instruction on Metal, and the same scratch tree
+// narrowed to a thread's own block of lanes where there is no wave intrinsic
+// to reach for.
+auto tSimdReductionSource =
+    test("GroupReduction/aSimdFoldIsOneInstructionOnMetal") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto input = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto id = builder.threadId();
+    auto value = input[id];
+
+    auto total = builder.simdSum(value);
+    auto peak = builder.simdMax(value);
+    auto least = builder.simdMin(value);
+
+    builder.write(output, id, total + peak + least);
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    auto width = std::to_string(simdGroupWidth);
+
+    // The whole of it on Metal - no scratch array, no barrier, and none of the
+    // three SIMD-group builtins the wide fold's combine walks.
+    check(has(metal, "float v0 = simd_sum("));
+    check(has(metal, "float v1 = simd_max("));
+    check(has(metal, "float v2 = simd_min("));
+    check(!has(metal, "groupScratch"));
+    check(!has(metal, "threadgroup_barrier"));
+    check(!has(metal, "simdgroups_per_threadgroup"));
+    check(!has(metal, "thread_index_in_simdgroup"));
+
+    // The tree elsewhere, over the lanes of the folding thread's own SIMD group
+    // rather than over the whole group, and read back from that block's first
+    // slot rather than from slot zero.
+    check(has(hlsl,
+              "groupshared float groupScratch[" + std::to_string(groupSize) + "];"));
+    check(has(hlsl, "for (uint gr0 = 16u; gr0 > 0u; gr0 >>= 1u)"));
+    check(has(hlsl,
+              "if ((groupLane % " + width + "u) < gr0 && (groupLane % " + width
+                  + "u) + gr0 < " + width + "u && groupLane + gr0 < "
+                  + std::to_string(groupSize) + "u)"));
+    check(has(hlsl,
+              "float v0 = groupScratch[(groupLane / " + width + "u) * " + width
+                  + "u];"));
+    check(!has(hlsl, "WaveActiveSum"));
+
+    check(has(glsl, "for (uint gr0 = 16u; gr0 > 0u; gr0 >>= 1u)"));
+    check(has(glsl,
+              "if ((gl_LocalInvocationIndex % " + width
+                  + "u) < gr0 && (gl_LocalInvocationIndex % " + width + "u) + gr0 < "
+                  + width + "u && gl_LocalInvocationIndex + gr0 < "
+                  + std::to_string(groupSize) + "u)"));
+    check(has(glsl,
+              "float v0 = groupScratch[(gl_LocalInvocationIndex / " + width + "u) * "
+                  + width + "u];"));
+
+    // No subgroup extension: a GLSL subgroup is whatever width the device says
+    // it is, where simdWidth is thirty-two by construction everywhere else in
+    // the EDSL, so the intrinsic would be a different fold under one name.
+    check(!has(glsl, "GL_KHR_shader_subgroup"));
+    check(!has(glsl, "subgroupAdd"));
+
+    expectGlslCompiles(graph);
+};
+
+// A group of simdWidth threads looks like one SIMD group and is not necessarily
+// one: threadExecutionWidth is a property of the compiled pipeline, and an
+// Intel Mac runs a kernel at eight or sixteen lanes. So the wide fold keeps its
+// combine here exactly as it does in a wider group - simdCount is whatever the
+// hardware gave - and only the narrow scope, which commits to simdWidth by
+// definition, is the intrinsic alone.
+auto tOneSimdGroupStillCombines =
+    test("GroupReduction/aGroupOfOneSimdGroupStillCombines") = []
+{
+    auto builder = ShaderBuilder {};
+
+    builder.setThreadGroupShape({simdGroupWidth});
+
+    auto input = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto id = builder.threadId();
+
+    builder.write(output, id, builder.groupSum(input[id]));
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+
+    check(has(metal, "float v0 = simd_sum("));
+    check(has(metal, "threadgroup float groupScratch[32];"));
+    check(has(metal, "if (simdLane == 0u)"));
+    check(has(metal, "for (uint gr0 = 1u; gr0 < simdCount; ++gr0)"));
+    check(has(metal, "uint simdCount [[simdgroups_per_threadgroup]]"));
+
+    // The two backends with no wave intrinsic keep the tree, which over one
+    // SIMD group's worth of threads is what it always was.
+    check(has(emitHlsl(graph), "groupshared float groupScratch[32];"));
+    check(has(emitHlsl(graph), "if (groupLane < gr0 && groupLane + gr0 < 32u)"));
+    check(has(emitGlsl(graph), "shared float groupScratch[32];"));
+
+    expectGlslCompiles(graph);
+};
+
+// The narrow tree indexes with the global lane and counts with the lane within
+// its block, so the scratch's own bound is a third conjunct rather than
+// something the second implies. A release build has no assert to stop a group
+// that is not a whole number of SIMD groups, and this is what keeps such a
+// kernel inside its array.
+auto tNarrowTreeStaysInsideTheScratch =
+    test("GroupReduction/theNarrowTreeBoundsTheScratchItself") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto input = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto id = builder.threadId();
+
+    builder.write(output, id, builder.simdSum(input[id]));
+
+    const auto& graph = builder.graph();
+    auto width = std::to_string(simdGroupWidth);
+    auto threads = std::to_string(groupSize);
+
+    check(has(emitHlsl(graph),
+              "if ((groupLane % " + width + "u) < gr0 && (groupLane % " + width
+                  + "u) + gr0 < " + width + "u && groupLane + gr0 < " + threads
+                  + "u)"));
+    check(has(emitGlsl(graph), "gl_LocalInvocationIndex + gr0 < " + threads + "u)"));
+
+    // The wide fold indexes and counts with the same lane, so it needs no such
+    // conjunct and keeps the two it always had.
+    auto wide = ShaderBuilder {};
+    auto source = wide.inputBuffer();
+    auto target = wide.outputBuffer();
+    auto index = wide.threadId();
+
+    wide.write(target, index, wide.groupSum(source[index]));
+
+    check(has(emitHlsl(wide.graph()),
+              "if (groupLane < gr0 && groupLane + gr0 < " + threads + "u)"));
+
+    expectGlslCompiles(graph);
+    expectGlslCompiles(wide.graph());
+};
+
+// Both scopes in one kernel: Metal needs the scratch for the wide fold and
+// nothing for the narrow one, so the array is there and one fold touches it.
+auto tBothScopesInOneKernel =
+    test("GroupReduction/theTwoScopesShareOneScratchArray") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto input = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto id = builder.threadId();
+    auto value = input[id];
+
+    auto whole = builder.groupSum(value);
+    auto narrow = builder.simdSum(value);
+
+    builder.write(output, id, whole + narrow);
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+
+    auto width = std::to_string(groupSize);
+
+    check(has(metal, "threadgroup float groupScratch[" + width + "];"));
+    check(has(metal, "float v0 = simd_sum("));
+    check(has(metal, "float v1 = simd_sum("));
+
+    // The wide fold combines its partials; the narrow one is the call and the
+    // semicolon, so the kernel holds exactly one combine loop.
+    check(has(metal, "for (uint gr0 = 1u; gr0 < simdCount; ++gr0)"));
+    check(!has(metal, "gr1"));
+
+    check(has(emitHlsl(graph), "groupshared float groupScratch[" + width + "];"));
+    check(has(emitGlsl(graph), "shared float groupScratch[" + width + "];"));
+
+    expectGlslCompiles(graph);
+};
+
 // The scratch belongs to the reductions, so a kernel with none declares none.
 auto tNoReductionNoScratch =
     test("GroupReduction/aKernelWithoutOneDeclaresNone") = []

--- a/Tests/GPU/GroupReductionTests.cpp
+++ b/Tests/GPU/GroupReductionTests.cpp
@@ -189,6 +189,181 @@ struct UIntFoldKernel final : ComputeProgram
     EACP_SHADER(input, output)
 };
 
+// The SIMD-scoped folds, over a group of four SIMD groups so that a fold which
+// reached the whole group instead of one of them is a different number in every
+// slot. Each SIMD group's values are offset by a hundred from the one before,
+// which puts the four sums, maxima and minima a long way apart.
+constexpr auto simdWidth = ComputeProgram::simdWidth;
+constexpr auto simdGroupsPerGroup = 4;
+constexpr auto simdGroupThreads = simdWidth * simdGroupsPerGroup;
+constexpr auto simdThreadCount = simdGroupThreads * 2;
+
+float simdLaneValue(int index)
+{
+    auto block = index / simdWidth;
+    auto lane = index % simdWidth;
+
+    return (float) ((lane * 7) % 23) - 9.f + (float) block * 100.f;
+}
+
+float simdBlockTotal(int block)
+{
+    auto total = 0.f;
+
+    for (auto lane = 0; lane < simdWidth; ++lane)
+        total += simdLaneValue(block * simdWidth + lane);
+
+    return total;
+}
+
+std::vector<float> simdLaneValues()
+{
+    auto values = std::vector<float> {};
+
+    for (auto i = 0; i < simdThreadCount; ++i)
+        values.push_back(simdLaneValue(i));
+
+    return values;
+}
+
+struct SimdFoldKernel final : ComputeProgram
+{
+    SimdFoldKernel()
+        : ComputeProgram({simdGroupThreads, 1, 1})
+    {
+        compile();
+    }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto value = input[id];
+
+        auto total = simdSum(value);
+        auto peak = simdMax(value);
+        auto least = simdMin(value);
+
+        ifThen(id < gridCount(),
+               [&]
+               {
+                   write(sums, id, total);
+                   write(maxima, id, peak);
+                   write(minima, id, least);
+               });
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> sums;
+    Uniform<OutputBuffer> maxima;
+    Uniform<OutputBuffer> minima;
+
+    EACP_SHADER(input, sums, maxima, minima)
+};
+
+// Both scopes over the same values, which is the relation between them: the
+// whole group's sum is the four SIMD groups' sums added up.
+struct BothScopesKernel final : ComputeProgram
+{
+    BothScopesKernel()
+        : ComputeProgram({simdGroupThreads, 1, 1})
+    {
+        compile();
+    }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto value = input[id];
+
+        auto whole = groupSum(value);
+        auto narrow = simdSum(value);
+
+        ifThen(id < gridCount(),
+               [&]
+               {
+                   write(wholeGroup, id, whole);
+                   write(perSimdGroup, id, narrow);
+               });
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> wholeGroup;
+    Uniform<OutputBuffer> perSimdGroup;
+
+    EACP_SHADER(input, wholeGroup, perSimdGroup)
+};
+
+// The unsigned sibling of the narrow fold, on the terms UIntFoldKernel sets.
+struct UIntSimdFoldKernel final : ComputeProgram
+{
+    UIntSimdFoldKernel()
+        : ComputeProgram({simdGroupThreads, 1, 1})
+    {
+        compile();
+    }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto value = input[id];
+
+        auto total = simdSum(value);
+        auto peak = simdMax(value);
+        auto least = simdMin(value);
+
+        ifThen(id < gridCount(),
+               [&] { write(output, id, uint3(total, peak, least)); });
+    }
+
+    Uniform<UIntInputBuffer> input;
+    Uniform<UIntOutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+
+// A group of exactly simdWidth threads, which is where the two scopes fold the
+// same set of threads on paper and where the emitter used to be tempted to
+// answer the wide one with a bare intrinsic. What makes that wrong is that the
+// hardware SIMD group is not necessarily simdWidth threads - an Intel Mac runs
+// a kernel at eight or sixteen - so both folds run here and both are checked.
+constexpr auto narrowGroupThreads = simdWidth;
+constexpr auto narrowGroupCount = 3;
+constexpr auto narrowThreadCount = narrowGroupThreads * narrowGroupCount;
+
+struct NarrowGroupKernel final : ComputeProgram
+{
+    NarrowGroupKernel()
+        : ComputeProgram({narrowGroupThreads, 1, 1})
+    {
+        compile();
+    }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto value = input[id];
+
+        auto whole = groupSum(value);
+        auto narrow = simdSum(value);
+        auto peak = groupMax(value);
+
+        ifThen(id < gridCount(),
+               [&]
+               {
+                   write(wholeGroup, id, whole);
+                   write(perSimdGroup, id, narrow);
+                   write(maxima, id, peak);
+               });
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> wholeGroup;
+    Uniform<OutputBuffer> perSimdGroup;
+    Uniform<OutputBuffer> maxima;
+
+    EACP_SHADER(input, wholeGroup, perSimdGroup, maxima)
+};
+
 Buffer makeFloatBuffer(Device& device, const std::vector<float>& values)
 {
     return device.makeBuffer(
@@ -495,4 +670,286 @@ auto tUnsignedFolds = test("GroupReduction/theUnsignedSiblingsFold") = []
             ++agreeing;
 
     check(agreeing == threadCount);
+};
+
+// The narrow fold: every thread holds the fold of the thirty-two threads it
+// shares a SIMD group with, and the four SIMD groups of a threadgroup come out
+// holding four different numbers.
+auto tSimdFoldsAreRight = test("GroupReduction/sumMaxAndMinOverOneSimdGroup") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto values = simdLaneValues();
+    auto input = makeFloatBuffer(device, values);
+
+    auto bytes = sizeof(float) * simdThreadCount;
+    auto sums = device.makeBuffer((int) bytes, BufferUsage::Storage);
+    auto maxima = device.makeBuffer((int) bytes, BufferUsage::Storage);
+    auto minima = device.makeBuffer((int) bytes, BufferUsage::Storage);
+
+    auto kernel = SimdFoldKernel {};
+    kernel.input = input;
+    kernel.sums = sums;
+    kernel.maxima = maxima;
+    kernel.minima = minima;
+    kernel.prepare();
+
+    {
+        auto commands = device.makeCommandBuffer();
+
+        {
+            auto pass = commands.beginCompute();
+            pass.dispatch(kernel, simdThreadCount);
+        }
+
+        commands.commit();
+    }
+
+    auto readBack = [&](Buffer& buffer)
+    {
+        auto out = std::vector<float>(simdThreadCount, 0.f);
+        buffer.read(out.data(), (int) bytes);
+        return out;
+    };
+
+    auto summed = readBack(sums);
+    auto peaks = readBack(maxima);
+    auto least = readBack(minima);
+
+    auto agreeing = 0;
+
+    for (auto i = 0; i < simdThreadCount; ++i)
+    {
+        auto block = i / simdWidth;
+
+        auto expectedMax = simdLaneValue(block * simdWidth);
+        auto expectedMin = expectedMax;
+
+        for (auto lane = 1; lane < simdWidth; ++lane)
+        {
+            auto value = simdLaneValue(block * simdWidth + lane);
+            expectedMax = std::max(expectedMax, value);
+            expectedMin = std::min(expectedMin, value);
+        }
+
+        if (std::abs(summed[(size_t) i] - simdBlockTotal(block)) < 1.0e-2f
+            && peaks[(size_t) i] == expectedMax && least[(size_t) i] == expectedMin)
+            ++agreeing;
+    }
+
+    check(agreeing == simdThreadCount);
+
+    // And the four SIMD groups of a threadgroup disagree with each other, which
+    // is what says the fold stopped at a SIMD group rather than running on.
+    auto distinct = 0;
+
+    for (auto block = 1; block < simdGroupsPerGroup; ++block)
+        if (summed[(size_t) block * simdWidth] != summed[0])
+            ++distinct;
+
+    check(distinct == simdGroupsPerGroup - 1);
+};
+
+// The relation between the two scopes: a group's sum is its SIMD groups' sums
+// added up, which is the same arithmetic reached two ways in one kernel.
+auto tScopesAgree = test("GroupReduction/theWideFoldIsTheNarrowOnesAddedUp") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto values = simdLaneValues();
+    auto input = makeFloatBuffer(device, values);
+
+    auto bytes = sizeof(float) * simdThreadCount;
+    auto wholeGroup = device.makeBuffer((int) bytes, BufferUsage::Storage);
+    auto perSimdGroup = device.makeBuffer((int) bytes, BufferUsage::Storage);
+
+    auto kernel = BothScopesKernel {};
+    kernel.input = input;
+    kernel.wholeGroup = wholeGroup;
+    kernel.perSimdGroup = perSimdGroup;
+    kernel.prepare();
+
+    {
+        auto commands = device.makeCommandBuffer();
+
+        {
+            auto pass = commands.beginCompute();
+            pass.dispatch(kernel, simdThreadCount);
+        }
+
+        commands.commit();
+    }
+
+    auto wide = std::vector<float>(simdThreadCount, 0.f);
+    auto narrow = std::vector<float>(simdThreadCount, 0.f);
+    wholeGroup.read(wide.data(), (int) bytes);
+    perSimdGroup.read(narrow.data(), (int) bytes);
+
+    auto agreeing = 0;
+
+    for (auto i = 0; i < simdThreadCount; ++i)
+    {
+        auto firstBlock = (i / simdGroupThreads) * simdGroupsPerGroup;
+        auto expectedWide = 0.f;
+
+        for (auto block = 0; block < simdGroupsPerGroup; ++block)
+            expectedWide += simdBlockTotal(firstBlock + block);
+
+        if (std::abs(wide[(size_t) i] - expectedWide) < 1.0e-1f
+            && std::abs(narrow[(size_t) i] - simdBlockTotal(i / simdWidth))
+                   < 1.0e-2f)
+            ++agreeing;
+    }
+
+    check(agreeing == simdThreadCount);
+};
+
+// The unsigned siblings, which take the same path with a scratch array of their
+// own where the fold goes through one.
+auto tUIntSimdFolds = test("GroupReduction/theUnsignedNarrowFold") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto values = std::vector<std::uint32_t> {};
+
+    for (auto i = 0; i < simdThreadCount; ++i)
+        values.push_back((std::uint32_t) (((i % simdWidth) * 11) % 37)
+                         + (std::uint32_t) (i / simdWidth) * 1000u);
+
+    auto input = device.makeBuffer(values.data(),
+                                   (int) (sizeof(std::uint32_t) * values.size()),
+                                   BufferUsage::Storage);
+
+    auto output = device.makeBuffer(
+        (int) (sizeof(std::uint32_t) * simdThreadCount * 3), BufferUsage::Storage);
+
+    auto kernel = UIntSimdFoldKernel {};
+    kernel.input = input;
+    kernel.output = output;
+    kernel.prepare();
+
+    {
+        auto commands = device.makeCommandBuffer();
+
+        {
+            auto pass = commands.beginCompute();
+            pass.dispatch(kernel, simdThreadCount);
+        }
+
+        commands.commit();
+    }
+
+    auto back = std::vector<std::uint32_t>((size_t) simdThreadCount * 3, 0u);
+    output.read(back.data(), (int) (sizeof(std::uint32_t) * back.size()));
+
+    auto agreeing = 0;
+
+    for (auto i = 0; i < simdThreadCount; ++i)
+    {
+        auto block = i / simdWidth;
+
+        auto expectedSum = std::uint32_t {0};
+        auto expectedMax = std::uint32_t {0};
+        auto expectedMin = std::uint32_t {~0u};
+
+        for (auto lane = 0; lane < simdWidth; ++lane)
+        {
+            auto value = values[(size_t) (block * simdWidth + lane)];
+            expectedSum += value;
+            expectedMax = std::max(expectedMax, value);
+            expectedMin = std::min(expectedMin, value);
+        }
+
+        if (back[(size_t) i * 3] == expectedSum
+            && back[(size_t) i * 3 + 1] == expectedMax
+            && back[(size_t) i * 3 + 2] == expectedMin)
+            ++agreeing;
+    }
+
+    check(agreeing == simdThreadCount);
+};
+
+// A group of exactly simdWidth threads, folded both ways against a CPU
+// reference. The wide fold has to be right whatever the hardware SIMD group
+// turns out to be, which is what the combine through the scratch is for; the
+// narrow one is the same set of threads here, so on a device whose SIMD groups
+// really are simdWidth wide the two agree to the bit.
+auto tNarrowGroupFoldsBothWays =
+    test("GroupReduction/aGroupOfOneSimdGroupFoldsBothWays") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto values = std::vector<float> {};
+
+    for (auto i = 0; i < narrowThreadCount; ++i)
+        values.push_back(simdLaneValue(i));
+
+    auto input = makeFloatBuffer(device, values);
+
+    auto bytes = sizeof(float) * narrowThreadCount;
+    auto wholeGroup = device.makeBuffer((int) bytes, BufferUsage::Storage);
+    auto perSimdGroup = device.makeBuffer((int) bytes, BufferUsage::Storage);
+    auto maxima = device.makeBuffer((int) bytes, BufferUsage::Storage);
+
+    auto kernel = NarrowGroupKernel {};
+    kernel.input = input;
+    kernel.wholeGroup = wholeGroup;
+    kernel.perSimdGroup = perSimdGroup;
+    kernel.maxima = maxima;
+    kernel.prepare();
+
+    {
+        auto commands = device.makeCommandBuffer();
+
+        {
+            auto pass = commands.beginCompute();
+            pass.dispatch(kernel, narrowThreadCount);
+        }
+
+        commands.commit();
+    }
+
+    auto readBack = [&](Buffer& buffer)
+    {
+        auto out = std::vector<float>(narrowThreadCount, 0.f);
+        buffer.read(out.data(), (int) bytes);
+        return out;
+    };
+
+    auto wide = readBack(wholeGroup);
+    auto narrow = readBack(perSimdGroup);
+    auto peaks = readBack(maxima);
+
+    auto agreeing = 0;
+
+    for (auto i = 0; i < narrowThreadCount; ++i)
+    {
+        auto block = i / narrowGroupThreads;
+        auto expected = simdBlockTotal(block);
+
+        auto expectedMax = simdLaneValue(block * narrowGroupThreads);
+
+        for (auto lane = 1; lane < narrowGroupThreads; ++lane)
+            expectedMax = std::max(expectedMax,
+                                   simdLaneValue(block * narrowGroupThreads + lane));
+
+        if (std::abs(wide[(size_t) i] - expected) < 1.0e-2f
+            && std::abs(narrow[(size_t) i] - expected) < 1.0e-2f
+            && peaks[(size_t) i] == expectedMax)
+            ++agreeing;
+    }
+
+    check(agreeing == narrowThreadCount);
 };

--- a/Tests/GPU/IntrinsicTests.cpp
+++ b/Tests/GPU/IntrinsicTests.cpp
@@ -113,6 +113,26 @@ struct HyperbolicKernel final : ComputeProgram
     EACP_SHADER(input, output)
 };
 
+// The repaired tanh, one value per thread. What the sweep it runs over is for
+// is the two tails: a driver is free to evaluate tanh through exp, and the one
+// eacp compiles its library with - fast math, no MTLCompileOptions - does, so
+// the native builtin hands back a NaN out where this has to hand back a one.
+struct SaturatingTanhKernel final : ComputeProgram
+{
+    SaturatingTanhKernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, saturatingTanh(input[i]));
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+
 struct Log10Kernel final : ComputeProgram
 {
     Log10Kernel() { compile(); }
@@ -275,6 +295,46 @@ auto tErrorFunctionGoesThroughAHelper =
     }
 };
 
+// The saturating tanh is a helper on all three backends rather than a rename:
+// what it adds is the two constant tails, which no dialect spells for us.
+auto tSaturatingTanhGoesThroughAHelper =
+    test("Intrinsics/saturatingTanhIsEmittedAsAHelper") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto input = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    builder.write(
+        output, i, saturatingTanh(input[i]) + saturatingTanh(input.read4(i)).w());
+
+    const auto& graph = builder.graph();
+
+    for (const auto& source: {emitMetal(graph), emitHlsl(graph)})
+    {
+        check(contains(source, "float eacpSaturatingTanh(float x)"));
+        check(contains(source, "x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x))"));
+
+        for (const auto& width:
+             {std::string("float2"), std::string("float3"), std::string("float4")})
+            check(contains(
+                source, (width + " eacpSaturatingTanh(" + width + " x)").c_str()));
+
+        check(source.find("eacpSaturatingTanh(")
+              < source.rfind("eacpSaturatingTanh("));
+    }
+
+    auto glsl = emitGlsl(graph);
+
+    check(contains(glsl, "float eacpSaturatingTanh(float x)"));
+    check(contains(glsl, "vec4 eacpSaturatingTanh(vec4 x)"));
+    check(contains(glsl, "x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x))"));
+    check(!contains(glsl, "float4"));
+
+    expectGlslCompiles(graph);
+};
+
 // The helpers are emitted only into shaders that call them.
 auto tHelpersAreNotAlwaysEmitted =
     test("Intrinsics/emitsTheErrorFunctionHelperOnlyWhenUsed") = []
@@ -282,6 +342,7 @@ auto tHelpersAreNotAlwaysEmitted =
     auto plain = PlainIntrinsicKernel {};
     const auto& source = plain.source().source;
 
+    check(!contains(source, "eacpSaturatingTanh"));
     check(!contains(source, "eacpErf"));
     check(!contains(source, "eacpErfc"));
 };
@@ -323,6 +384,65 @@ auto tHyperbolics = test("Intrinsics/computesTheHyperbolics") = []
         check(near(result[i * 3], std::tanh(x), tolerance(std::tanh(x))));
         check(near(result[i * 3 + 1], std::sinh(x), tolerance(std::sinh(x))));
         check(near(result[i * 3 + 2], std::cosh(x), tolerance(std::cosh(x))));
+    }
+};
+
+// The saturating tanh, swept from the origin out past where a fast-math tanh
+// stops being a number at all. std::tanh is the reference over the whole sweep,
+// which is the claim: the two agree everywhere, and where the native builtin
+// on this backend does not agree with either, this one still does.
+auto tSaturatingTanh = test("Intrinsics/saturatingTanhAnswersTheTails") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto values = Vector<float> {};
+
+    // The small end first, the origin and its negative zero included, then the
+    // body of the curve, then the tails - 990 being what a tanh GELU's cubic
+    // argument reaches for an activation of thirty, which is the value that
+    // came back NaN and started this.
+    for (auto small: {0.0f, -0.0f, 1.0e-20f, -1.0e-20f, 1.0e-7f, -1.0e-7f})
+        values.add(small);
+
+    for (auto i = -120; i <= 120; ++i)
+        values.add((float) i / 20.0f);
+
+    for (auto far: {9.0f, 9.5f, 10.0f, 10.5f, 30.0f, 120.0f, 990.0f, 1.0e20f})
+    {
+        values.add(far);
+        values.add(-far);
+    }
+
+    auto count = values.size();
+
+    auto input = device.makeBuffer(
+        values.data(), count * (int) sizeof(float), BufferUsage::Storage);
+    auto output = device.makeBuffer(count * (int) sizeof(float));
+
+    auto kernel = SaturatingTanhKernel {};
+    kernel.input = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    auto result = runKernel(kernel, output, count, 1);
+
+    for (auto i = 0; i < count; ++i)
+    {
+        auto x = values[i];
+
+        check(std::isfinite(result[i]));
+        check(near(result[i], std::tanh((double) x), 1.0e-6));
+
+        // And exactly, not nearly, past the threshold the helper answers at.
+        // Between 9.011 and ten the function has already rounded to one in
+        // float32 and the native builtin is what returns it, which is a claim
+        // about the driver's tanh rather than about this - so the tolerance
+        // above covers that stretch and this covers the constant.
+        if (std::fabs(x) >= 10.0f)
+            check(result[i] == (x > 0.0f ? 1.0f : -1.0f));
     }
 };
 

--- a/Tests/GPU/IntrinsicTests.cpp
+++ b/Tests/GPU/IntrinsicTests.cpp
@@ -314,7 +314,7 @@ auto tSaturatingTanhGoesThroughAHelper =
     for (const auto& source: {emitMetal(graph), emitHlsl(graph)})
     {
         check(contains(source, "float eacpSaturatingTanh(float x)"));
-        check(contains(source, "x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x))"));
+        check(contains(source, "x >= 10.0 ? 1.0 : (x <= -10.0 ? -1.0 : tanh(x))"));
 
         for (const auto& width:
              {std::string("float2"), std::string("float3"), std::string("float4")})
@@ -329,7 +329,7 @@ auto tSaturatingTanhGoesThroughAHelper =
 
     check(contains(glsl, "float eacpSaturatingTanh(float x)"));
     check(contains(glsl, "vec4 eacpSaturatingTanh(vec4 x)"));
-    check(contains(glsl, "x > 10.0 ? 1.0 : (x < -10.0 ? -1.0 : tanh(x))"));
+    check(contains(glsl, "x >= 10.0 ? 1.0 : (x <= -10.0 ? -1.0 : tanh(x))"));
     check(!contains(glsl, "float4"));
 
     expectGlslCompiles(graph);
@@ -436,11 +436,13 @@ auto tSaturatingTanh = test("Intrinsics/saturatingTanhAnswersTheTails") = []
         check(std::isfinite(result[i]));
         check(near(result[i], std::tanh((double) x), 1.0e-6));
 
-        // And exactly, not nearly, past the threshold the helper answers at.
-        // Between 9.011 and ten the function has already rounded to one in
-        // float32 and the native builtin is what returns it, which is a claim
-        // about the driver's tanh rather than about this - so the tolerance
-        // above covers that stretch and this covers the constant.
+        // And exactly, not nearly, from the threshold outward - ten itself
+        // included, since the helper compares inclusively so that the value it
+        // documents as the threshold is one it answers. Between 9.011 and ten
+        // the function has already rounded to one in float32 and the native
+        // builtin is what returns it, which is a claim about the driver's tanh
+        // rather than about this - so the tolerance above covers that stretch
+        // and this covers the constant.
         if (std::fabs(x) >= 10.0f)
             check(result[i] == (x > 0.0f ? 1.0f : -1.0f));
     }

--- a/Tests/GPU/PackedBFloat16Tests.cpp
+++ b/Tests/GPU/PackedBFloat16Tests.cpp
@@ -191,6 +191,24 @@ struct ReadBFloat16x2Kernel final : ComputeProgram
     EACP_SHADER(weights, output)
 };
 
+// Four bfloat16s at a time, which is two words: the width a weight walk wants,
+// and the one the record read underneath turns into a single eight-byte load.
+struct ReadBFloat16x4Kernel final : ComputeProgram
+{
+    ReadBFloat16x4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.readBFloat16x4(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
 // Widen a word and narrow it straight back, storing the packed result in the
 // float slot it came out of - the whole bf16-storage round trip in one line.
 struct RoundTripKernel final : ComputeProgram
@@ -349,6 +367,17 @@ bool contains(const std::string& text, const char* needle)
 {
     return text.find(needle) != std::string::npos;
 }
+
+int countOccurrences(const std::string& haystack, const std::string& needle)
+{
+    auto count = 0;
+
+    for (auto found = haystack.find(needle); found != std::string::npos;
+         found = haystack.find(needle, found + needle.size()))
+        ++count;
+
+    return count;
+}
 } // namespace
 
 // What the encoding *is*, pinned against values rather than against the shift
@@ -505,6 +534,52 @@ auto tReadPair = test("PackedBFloat16/readBFloat16x2ReadsBothHalvesOfAWord") = [
     {
         check(matches(result[i * 2], widened((std::uint16_t) (words[i] & 0xffffu))));
         check(matches(result[i * 2 + 1], widened((std::uint16_t) (words[i] >> 16))));
+    }
+};
+
+// Four elements across two words, in the order readBFloat16 walks them: the low
+// half of the first word, its high half, then the second word's two.
+auto tReadQuad = test("PackedBFloat16/readBFloat16x4ReadsFourAcrossTwoWords") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto words = everyPackedPair();
+    auto records = words.size() / 2;
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(records * 4 * (int) sizeof(float));
+
+    auto kernel = ReadBFloat16x4Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, records);
+    auto result = floatsOf(output);
+
+    for (auto i = 0; i < records; ++i)
+    {
+        auto low = words[i * 2];
+        auto high = words[i * 2 + 1];
+
+        check(matches(result[i * 4], widened((std::uint16_t) (low & 0xffffu))));
+        check(matches(result[i * 4 + 1], widened((std::uint16_t) (low >> 16))));
+        check(matches(result[i * 4 + 2], widened((std::uint16_t) (high & 0xffffu))));
+        check(matches(result[i * 4 + 3], widened((std::uint16_t) (high >> 16))));
+    }
+
+    // And element by element it is the same walk readBFloat16 makes, which is
+    // what says the two spellings address one layout.
+    for (auto element = 0; element < records * 4; ++element)
+    {
+        auto word = words[element / 2];
+        auto half = (element % 2) == 0 ? (std::uint16_t) (word & 0xffffu)
+                                       : (std::uint16_t) (word >> 16);
+
+        check(matches(result[element], widened(half)));
     }
 };
 
@@ -686,6 +761,62 @@ auto tSourceIsRight = test("PackedBFloat16/bothBackendsSpellTheHelpers") = []
     check(!contains(hlsl, "f16tof32"));
     check(!contains(hlsl, "f32tof16"));
     check(!contains(hlsl, "as_type"));
+};
+
+// The four-wide read, per backend: two words fetched as one record - which is a
+// single packed load on Metal and two subscripts where there is no such
+// spelling - then the same two unpack helpers over what came back.
+auto tQuadSourceIsRight = test("PackedBFloat16/theFourWideReadIsOneRecordRead") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    builder.write(output, i, weights.readBFloat16x4(i));
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    // The index counts records of four bfloat16s, which is two words - so the
+    // record read underneath strides by two, and the widening is the same
+    // helper the two-wide read calls, once per word.
+    for (const auto& source: {metal, hlsl, glsl})
+    {
+        check(contains(source, "uint t1 = (gid * 2u);"));
+
+        // Three spellings of the name: the one definition and the two calls,
+        // one per word, which is what says nothing unpacks twice over.
+        check(countOccurrences(source, "eacpUnpackBFloat16x2(") == 3);
+    }
+
+    // One eight-byte load on Metal, and the two words taken out of it in
+    // registers rather than fetched twice.
+    check(contains(metal,
+                   "float2 t2 = float2(*((device const packed_float2*) "
+                   "(buffer0 + t1)));"));
+    check(contains(metal,
+                   "float4 t3 = float4(eacpUnpackBFloat16x2(as_type<uint>((t2).x)), "
+                   "eacpUnpackBFloat16x2(as_type<uint>((t2).y)));"));
+    check(!contains(metal, "buffer0[t1]"));
+
+    // Two scalar loads elsewhere, since neither dialect can reinterpret a run
+    // of floats as anything wider - the low half of the first word first, which
+    // is the order readBFloat16 walks the elements in.
+    check(contains(hlsl, "float2 t2 = float2(buffer0[t1], buffer0[t1 + 1u]);"));
+    check(contains(hlsl,
+                   "float4 t3 = float4(eacpUnpackBFloat16x2(asuint((t2).x)), "
+                   "eacpUnpackBFloat16x2(asuint((t2).y)));"));
+
+    check(contains(glsl, "vec2 t2 = vec2(buffer0[t1], buffer0[t1 + 1u]);"));
+    check(contains(glsl,
+                   "vec4 t3 = vec4(eacpUnpackBFloat16x2(floatBitsToUint((t2).x)), "
+                   "eacpUnpackBFloat16x2(floatBitsToUint((t2).y)));"));
+
+    expectGlslCompiles(graph);
 };
 
 // Each helper is emitted only into shaders that call it, so a kernel narrowing

--- a/Tests/GPU/PackedHalfTests.cpp
+++ b/Tests/GPU/PackedHalfTests.cpp
@@ -197,6 +197,24 @@ struct LiteralHalfKernel final : ComputeProgram
     EACP_SHADER(weights, output)
 };
 
+// Four halves at a time, which is two words: the width a weight walk wants, and
+// the one the record read underneath turns into a single eight-byte load.
+struct ReadHalf4Kernel final : ComputeProgram
+{
+    ReadHalf4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.readHalf4(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
 struct ReadHalf2Kernel final : ComputeProgram
 {
     ReadHalf2Kernel() { compile(); }
@@ -600,6 +618,44 @@ auto tReadHalf2 = test("PackedHalf/readHalf2ReadsBothHalvesOfAWord") = []
     }
 };
 
+// Four halves across two words, in the order readHalf walks them: the low half
+// of the first word, its high half, then the second word's two.
+auto tReadHalf4 = test("PackedHalf/readHalf4ReadsFourAcrossTwoWords") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto words = everyPackedPair();
+    auto records = words.size() / 2;
+
+    auto input = device.makeBuffer(words.data(),
+                                   words.size() * (int) sizeof(std::uint32_t),
+                                   BufferUsage::Storage);
+
+    auto output = device.makeBuffer(records * 4 * (int) sizeof(float));
+
+    auto kernel = ReadHalf4Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, records);
+    auto result = floatsOf(output);
+
+    // Element by element it is the same walk readHalf makes, which is what says
+    // the two spellings address one layout.
+    for (auto element = 0; element < records * 4; ++element)
+    {
+        auto word = words[element / 2];
+        auto half = (element % 2) == 0 ? (std::uint16_t) (word & 0xffffu)
+                                       : (std::uint16_t) (word >> 16);
+
+        check(matches(result[element], widened(half)));
+    }
+};
+
 // asFloat is asUInt run backwards, so the pair is the identity on bits - and
 // on these bits in particular, most of which are denormal floats.
 auto tBitcastRoundTrip = test("PackedHalf/asFloatUndoesAsUInt") = []
@@ -788,6 +844,52 @@ auto tHalfSourceIsRight = test("PackedHalf/bothBackendsSpellTheHalfHelpers") = [
     // The HLSL carries no MSL spelling anywhere - not in a helper body, not in
     // the kernel - which is the failure a shared emitter invites.
     check(!has(hlsl, "as_type"));
+};
+
+// The four-wide read, per backend: two words fetched as one record - a single
+// packed load on Metal and two subscripts where there is no such spelling -
+// then one unpack helper over each of them.
+auto tHalf4SourceIsRight = test("PackedHalf/theFourWideReadIsOneRecordRead") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    builder.write(output, i, weights.readHalf4(i));
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    auto has = [](const std::string& source, const std::string& text)
+    { return source.find(text) != std::string::npos; };
+
+    // The index counts records of four halves, which is two words.
+    for (const auto& source: {metal, hlsl, glsl})
+        check(has(source, "uint t1 = (gid * 2u);"));
+
+    check(has(metal,
+              "float2 t2 = float2(*((device const packed_float2*) "
+              "(buffer0 + t1)));"));
+    check(has(metal,
+              "float4 t3 = float4(eacpUnpackHalf2(as_type<uint>((t2).x)), "
+              "eacpUnpackHalf2(as_type<uint>((t2).y)));"));
+    check(!has(metal, "buffer0[t1]"));
+
+    check(has(hlsl, "float2 t2 = float2(buffer0[t1], buffer0[t1 + 1u]);"));
+    check(has(hlsl,
+              "float4 t3 = float4(eacpUnpackHalf2(asuint((t2).x)), "
+              "eacpUnpackHalf2(asuint((t2).y)));"));
+
+    check(has(glsl, "vec2 t2 = vec2(buffer0[t1], buffer0[t1 + 1u]);"));
+    check(has(glsl,
+              "vec4 t3 = vec4(eacpUnpackHalf2(floatBitsToUint((t2).x)), "
+              "eacpUnpackHalf2(floatBitsToUint((t2).y)));"));
+
+    expectGlslCompiles(graph);
 };
 
 // Each helper is emitted only into shaders that call it, so a kernel narrowing

--- a/Tests/GPU/ShaderCodegenTests.cpp
+++ b/Tests/GPU/ShaderCodegenTests.cpp
@@ -2200,8 +2200,9 @@ auto tCodegenCompute1DUnchanged = test("GPU/codegenCompute1DKeepsScalarId") = []
 // Vector reads and writes over a buffer of records: read4(i) is elements
 // 4i..4i+3 and write(out, i, Float4) puts four back at the same place, so a
 // kernel over a struct of four floats never spells the stride. The buffer is
-// still a run of floats underneath - N scalar accesses, one index expression -
-// which is what keeps its bytes bindable as a per-instance stream.
+// still a run of floats underneath, which is what keeps its bytes bindable as a
+// per-instance stream - but the read of one is a single sixteen-byte load where
+// the dialect has a spelling for one.
 auto tCodegenComputeVectorElements = test("GPU/codegenComputeVectorElements") = []
 {
     auto builder = ShaderBuilder {};
@@ -2216,7 +2217,6 @@ auto tCodegenComputeVectorElements = test("GPU/codegenComputeVectorElements") = 
     for (const auto& dialect: everyDialect(builder.graph()))
     {
         const auto& text = dialect.source;
-        auto vec4 = std::string(dialect.spell(ValueType::Float4));
 
         // The base index is computed once for the whole kernel. The read and
         // the write build it through separate calls, but the product is the
@@ -2224,22 +2224,36 @@ auto tCodegenComputeVectorElements = test("GPU/codegenComputeVectorElements") = 
         check(contains(text, "uint t0 = (gid * 4u);"));
         check(countOccurrences(text, "(gid * 4u)") == 1);
 
-        // The three offsets off that base are shared the same way - each is
-        // addressed by the read and by the write, so each is named once.
-        check(contains(text, "uint t1 = (t0 + 1u);"));
-        check(contains(text, "uint t2 = (t0 + 2u);"));
-        check(contains(text, "uint t3 = (t0 + 3u);"));
-
-        check(contains(text,
-                       vec4 + " t4 = (" + vec4
-                           + "(buffer0[t0], buffer0[t1], buffer0[t2], buffer0[t3]) "
-                             "* 2.0);"));
-
         // One store per component, at the record's own offsets.
-        check(contains(text, "buffer1[t0] = (t4).x;"));
-        check(contains(text, "buffer1[t1] = (t4).y;"));
-        check(contains(text, "buffer1[t2] = (t4).z;"));
-        check(contains(text, "buffer1[t3] = (t4).w;"));
+        check(contains(text, "buffer1[t0] = (t1).x;"));
+        check(contains(text, "buffer1[(t0 + 1u)] = (t1).y;"));
+        check(contains(text, "buffer1[(t0 + 2u)] = (t1).z;"));
+        check(contains(text, "buffer1[(t0 + 3u)] = (t1).w;"));
+    }
+
+    // Metal reads the four floats as one packed vector through the pointer it
+    // was handed - a packed one, because a BufferRange may start at any
+    // four-byte offset and a float4 load may not.
+    auto metal = emitMetal(builder.graph());
+
+    check(contains(
+        metal,
+        "float4 t1 = (float4(*((device const packed_float4*) (buffer0 + t0))) "
+        "* 2.0);"));
+    check(!contains(metal, "buffer0[t0]"));
+
+    // The other two have nothing to reinterpret: a StructuredBuffer<float> and
+    // an std430 block of floats are runs of scalars and are read as such.
+    for (const auto& dialect: {Dialect {emitHlsl(builder.graph()), false},
+                               Dialect {emitGlsl(builder.graph()), true}})
+    {
+        auto vec4 = std::string(dialect.spell(ValueType::Float4));
+
+        check(contains(dialect.source,
+                       vec4 + " t1 = (" + vec4
+                           + "(buffer0[t0], buffer0[t0 + 1u], buffer0[t0 + 2u], "
+                             "buffer0[t0 + 3u]) * 2.0);"));
+        check(!contains(dialect.source, "packed_float4"));
     }
 
     expectGlslCompiles(builder.graph());
@@ -2260,8 +2274,10 @@ auto tCodegenComputeVectorStrides = test("GPU/codegenComputeVectorStrides") = []
 
     auto metal = emitMetal(builder.graph());
     check(contains(metal, "uint t0 = (gid * 2u);"));
-    check(contains(metal, "float2 t2 = float2(buffer0[t0], buffer0[t1]);"));
-    check(contains(metal, "buffer1[t1] = (t2).y;"));
+    check(contains(
+        metal,
+        "float2 t1 = float2(*((device const packed_float2*) (buffer0 + t0)));"));
+    check(contains(metal, "buffer1[(t0 + 1u)] = (t1).y;"));
     check(!contains(metal, "t0 + 2u"));
 
     auto triples = ShaderBuilder {};
@@ -2271,10 +2287,16 @@ auto tCodegenComputeVectorStrides = test("GPU/codegenComputeVectorStrides") = []
 
     auto hlsl = emitHlsl(triples.graph());
     check(contains(hlsl, "uint t0 = (gid * 3u);"));
-    check(contains(hlsl,
-                   "float3 t3 = float3(buffer0[t0], buffer0[t1], buffer0[t2]);"));
-    check(contains(hlsl, "buffer1[t2] = (t3).z;"));
+    check(contains(
+        hlsl,
+        "float3 t1 = float3(buffer0[t0], buffer0[t0 + 1u], buffer0[t0 + 2u]);"));
+    check(contains(hlsl, "buffer1[(t0 + 2u)] = (t1).z;"));
     check(!contains(hlsl, "t0 + 3u"));
+
+    // And the three-wide Metal form is the twelve-byte packed one, not a
+    // float4 load that would read a float past the record.
+    check(contains(emitMetal(triples.graph()), "packed_float3"));
+    check(!contains(emitMetal(triples.graph()), "packed_float4"));
 
     expectGlslCompiles(builder.graph());
     expectGlslCompiles(triples.graph());
@@ -2328,15 +2350,18 @@ auto tCodegenFragmentBufferRead = test("GPU/codegenFragmentBufferRead") = []
                        + ") readonly buffer Buffer0\n{\n    float buffer0[];\n};"));
     check(!contains(glsl, "} buffer0;"));
 
-    for (const auto& dialect: everyDialect(builder.graph()))
+    for (const auto& dialect: {Dialect {hlsl, false}, Dialect {glsl, true}})
     {
         auto vec3 = std::string(dialect.spell(ValueType::Float3));
 
         check(contains(dialect.source, "uint t0 = (uniforms.u0 * 3u);"));
-        check(contains(
-            dialect.source,
-            vec3 + "(buffer0[t0], buffer0[(t0 + 1u)], buffer0[(t0 + 2u)])"));
+        check(contains(dialect.source,
+                       vec3 + "(buffer0[t0], buffer0[t0 + 1u], buffer0[t0 + 2u])"));
     }
+
+    check(contains(metal, "uint t0 = (uniforms.u0 * 3u);"));
+    check(
+        contains(metal, "float3(*((device const packed_float3*) (buffer0 + t0)))"));
 
     expectGlslCompiles(builder.graph());
 };

--- a/Tests/GPU/SharedMemoryTests.cpp
+++ b/Tests/GPU/SharedMemoryTests.cpp
@@ -94,3 +94,137 @@ auto tExchangeCrossesLanes = test("SharedMemory/everyThreadReadsAnotherLane") = 
     // kernel with unshared scratch would have produced.
     check(values[0] != 0.f);
 };
+
+namespace
+{
+// A kilobyte of tile, which every device eacp runs on has room for, beside a
+// reduction whose scratch the emitter adds behind it.
+constexpr auto tileElements = 256;
+
+struct BudgetedKernel final : ComputeProgram
+{
+    BudgetedKernel() { compile(); }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto lane = localId();
+        auto tile = shared<Float>(tileElements);
+
+        write(tile, lane, input[id]);
+        barrier();
+
+        auto total = groupSum(tile[lane]);
+        ifThen(id < gridCount(), [&] { write(output, id, total); });
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+
+// A tile of three-vectors, which is the one element type whose bytes and whose
+// stride differ: MSL packs a float3 to twelve and an std430 block and a DXBC
+// groupshared array give it sixteen.
+struct WideElementKernel final : ComputeProgram
+{
+    WideElementKernel() { compile(); }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto lane = localId();
+        auto tile = shared<Float3>(tileElements);
+
+        write(tile, lane, float3(input[id], input[id], input[id]));
+        barrier();
+
+        ifThen(id < gridCount(), [&] { write(output, id, tile[lane].x()); });
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+
+// Past every budget any of the three backends reports: Vulkan's floor is 16 KB,
+// the two with a fixed number give 32 KB, and no Metal device reaches a
+// megabyte.
+struct OverBudgetKernel final : ComputeProgram
+{
+    OverBudgetKernel() { compile(); }
+
+    void define() override
+    {
+        auto id = threadId();
+        auto lane = localId();
+        auto tile = shared<Float>(1024 * 1024);
+
+        write(tile, lane, input[id]);
+        barrier();
+
+        ifThen(id < gridCount(), [&] { write(output, id, tile[lane]); });
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+} // namespace
+
+// What the device allows, which is the number a kernel author has had to carry
+// in a comment until now.
+auto tThreadgroupBudgetIsReported =
+    test("SharedMemory/theDeviceReportsItsThreadgroupBudget") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    // Vulkan's spec floor, and so what a kernel may assume on any of the three.
+    check(device.maxThreadgroupMemory() >= 16 * 1024);
+};
+
+// What a kernel spends: its own arrays plus the scratch the emitter adds for a
+// reduction, counted in the same bytes the budget is in.
+auto tKernelReportsWhatItDeclares =
+    test("SharedMemory/aKernelReportsWhatItDeclares") = []
+{
+    auto& device = Device::shared();
+
+    auto budgeted = BudgetedKernel {};
+
+    auto tile = tileElements * (int) sizeof(float);
+    auto scratch = ComputePass::threadGroupWidth * (int) sizeof(float);
+
+    check(budgeted.threadgroupMemoryBytes() == tile + scratch);
+
+    // A vector element is counted at the stride the backends that pad give it,
+    // not at the twelve bytes MSL packs a three-vector to: the budget is what a
+    // kernel is written against, and a kernel is written once.
+    auto wide = WideElementKernel {};
+
+    check(wide.threadgroupMemoryBytes() == tileElements * 16);
+
+    if (!device.isValid())
+        return;
+
+    check(budgeted.fitsThreadgroupMemory(device));
+
+    // And the overspend is answered before the backend is asked to make a
+    // pipeline it cannot: prepare() names the two numbers in the log, and what
+    // it goes on to build is the invalid pipeline the backend was always going
+    // to hand back - the log line being the difference between a kernel that
+    // asked for too much and a kernel that would not compile.
+    auto over = OverBudgetKernel {};
+
+    check(over.threadgroupMemoryBytes() > device.maxThreadgroupMemory());
+    check(!over.fitsThreadgroupMemory(device));
+
+    over.prepare(device);
+    check(!over.pipeline().isValid());
+};

--- a/Tests/GPU/SharedMemoryTests.cpp
+++ b/Tests/GPU/SharedMemoryTests.cpp
@@ -216,15 +216,15 @@ auto tKernelReportsWhatItDeclares =
     check(budgeted.fitsThreadgroupMemory(device));
 
     // And the overspend is answered before the backend is asked to make a
-    // pipeline it cannot: prepare() names the two numbers in the log, and what
-    // it goes on to build is the invalid pipeline the backend was always going
-    // to hand back - the log line being the difference between a kernel that
-    // asked for too much and a kernel that would not compile.
+    // pipeline: prepare() names the two numbers in the log and then builds
+    // anyway. What comes back is the backend's business and differs by
+    // backend - Metal refuses the pipeline, lavapipe hands back one that would
+    // misbehave at dispatch - so the log line, not the pipeline's validity, is
+    // what this asserts by exercising it.
     auto over = OverBudgetKernel {};
 
     check(over.threadgroupMemoryBytes() > device.maxThreadgroupMemory());
     check(!over.fitsThreadgroupMemory(device));
 
     over.prepare(device);
-    check(!over.pipeline().isValid());
 };

--- a/Tests/GPU/UIntBufferVectorTests.cpp
+++ b/Tests/GPU/UIntBufferVectorTests.cpp
@@ -171,12 +171,18 @@ auto tUIntPairsEmitTheirOwnStride =
     for (const auto& text: {metal, hlsl})
     {
         check(contains(text, "uint t0 = (gid * 2u);"));
-        check(contains(text, "uint t1 = (t0 + 1u);"));
-        check(contains(text, "uint2 t2 = (uint2(buffer0[t0], buffer0[t1]) + 1u);"));
-        check(contains(text, "buffer1[t0] = (t2).x;"));
-        check(contains(text, "buffer1[t1] = (t2).y;"));
+        check(contains(text, "buffer1[t0] = (t1).x;"));
+        check(contains(text, "buffer1[(t0 + 1u)] = (t1).y;"));
         check(!contains(text, "t0 + 2u"));
     }
+
+    // The read is one eight-byte load on Metal and the pair of subscripts it
+    // stands in for on HLSL, which has no spelling for reinterpreting a
+    // StructuredBuffer<uint>.
+    check(contains(
+        metal,
+        "uint2 t1 = (uint2(*((device const packed_uint2*) (buffer0 + t0))) + 1u);"));
+    check(contains(hlsl, "uint2 t1 = (uint2(buffer0[t0], buffer0[t0 + 1u]) + 1u);"));
 
     check(contains(metal, "device const uint* buffer0"));
     check(contains(metal, "device uint* buffer1"));

--- a/Tests/GPU/UIntVectorTests.cpp
+++ b/Tests/GPU/UIntVectorTests.cpp
@@ -425,9 +425,16 @@ auto tUIntVectorConversions = test("UIntVector/theCrossingsAreNamedCasts") = []
     builder.write(output, 1u, toUInt(signedCell).y());
     builder.write(output, 2u, toUInt(widened).x());
 
+    // The pair itself is one load on Metal and two subscripts on HLSL; what
+    // this is about is the conversion around it, which is a named cast either
+    // way and is spelled over the vector rather than per component.
+    check(contains(emitMetal(builder.graph()),
+                   "uint2 t1 = uint2(float2(*((device const packed_float2*) "));
+    check(contains(emitHlsl(builder.graph()),
+                   "uint2 t1 = uint2(float2(buffer0[t0], "));
+
     for (const auto& source: {emitMetal(builder.graph()), emitHlsl(builder.graph())})
     {
-        check(contains(source, "uint2 t1 = uint2(float2(buffer0[t0], "));
         check(contains(source, "buffer1[1u] = (uint2(int2(t1))).y;"));
         check(contains(source, "buffer1[2u] = (uint2(float2(t1))).x;"));
     }
@@ -452,7 +459,9 @@ auto tUIntVectorBitcasts = test("UIntVector/theBitcastsUseTheVectorSpelling") = 
     auto metal = emitMetal(builder.graph());
     auto hlsl = emitHlsl(builder.graph());
 
-    check(contains(metal, "uint2 t1 = as_type<uint2>(float2(buffer0[t0], "));
+    check(contains(metal,
+                   "uint2 t1 = as_type<uint2>(float2(*((device const "
+                   "packed_float2*) (buffer0 + t0))));"));
     check(contains(metal, "buffer1[1u] = uint((as_type<float2>(t1)).y);"));
 
     check(contains(hlsl, "uint2 t1 = asuint(float2(buffer0[t0], "));


### PR DESCRIPTION
## Summary

Six additions to the shader EDSL and the device layer, each found while writing gemma-2b (HuggingFaceEACP) against eacp's compute layer:

- **`saturatingTanh`** beside `eacpErf`: exactly ±1 past |x| > 10 on every backend. Metal's fast math returns NaN for `tanh(990)`, and tanh-GELU's argument is cubic in its input.
- **`simdSum` / `simdMax` / `simdMin`** (Float and UInt): a fold over exactly one SIMD group. The intrinsic on Metal, a 32-lane scratch tree on HLSL and GLSL. Whole-group folds are byte-identical to before. On Metal, `prepare` logs when the pipeline's `threadExecutionWidth` is not `simdWidth`.
- **`Device::maxThreadgroupMemory`**, **`ComputeProgram::threadgroupMemoryBytes`** and **`fitsThreadgroupMemory`**: a kernel can size `shared<>` against the backend's budget; `prepare` logs both numbers when a program is over it.
- **`ComputePipeline::threadExecutionWidth`**.
- **`InputBuffer::read2/3/4` are one `packed_floatN` load on Metal** rather than N scalar subscripts (`packed_`, since a `BufferRange` is only 4-byte aligned). HLSL and GLSL stay componentwise because their buffer declarations cannot be reinterpreted without changing the binding; `OutputBuffer` reads stay scalar so a read after a store through the same slot stays ordered.
- **`readHalf4` / `readBFloat16x4`**: four-wide packed reads, one 8-byte load on Metal.

## Testing

- Device tests against a CPU reference for every addition, codegen tests per backend, emitted GLSL compiled by glslang (`EACP_BUILD_SPIRV=ON`).
- On macOS (M4 Max): `GPUCodegenTests` 88/88, `GPUTests` 429/429, `ctest` 1835/1835.
- Not run here: FXC (HLSL is checked at the string level only), and the Windows and Linux device and pipeline files were not compiled locally. That is what this PR's CI is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oUH8j2iqymwMULe55U9cz
