### PR TITLE
GPU: Add byte and nibble reads to the shader EDSL for quantized weights

### DIFF
--- a/Lib/eacp/GPU/Codegen/ComputeProgram.h
+++ b/Lib/eacp/GPU/Codegen/ComputeProgram.h
@@ -493,6 +493,21 @@ protected:
         builder.writeBFloat16x2(buffer, index, value);
     }
 
+    // Four integers packed into the one float slot that holds them, which
+    // InputBuffer::readInt8x4 and readUInt8x4 read back at the same index.
+    void
+        writeInt8x4(const OutputBuffer& buffer, const UInt& index, const Int4& value)
+    {
+        builder.writeInt8x4(buffer, index, value);
+    }
+
+    void writeUInt8x4(const OutputBuffer& buffer,
+                      const UInt& index,
+                      const UInt4& value)
+    {
+        builder.writeUInt8x4(buffer, index, value);
+    }
+
     // One element of a threadgroup-shared array, published to the rest of the
     // group by the next barrier().
     template <typename T>

--- a/Lib/eacp/GPU/Codegen/PackedVertex.cpp
+++ b/Lib/eacp/GPU/Codegen/PackedVertex.cpp
@@ -123,6 +123,73 @@ float bfloat16ToFloat(std::uint16_t bits)
     return std::bit_cast<float>((std::uint32_t) bits << 16);
 }
 
+std::uint32_t int8x4FromBytes(const std::array<std::int8_t, 4>& values)
+{
+    auto word = std::uint32_t {};
+
+    for (auto i = std::size_t {}; i < values.size(); ++i)
+        word |= (std::uint32_t) (std::uint8_t) values[i] << (i * 8);
+
+    return word;
+}
+
+std::uint32_t uint8x4FromBytes(const std::array<std::uint8_t, 4>& values)
+{
+    auto word = std::uint32_t {};
+
+    for (auto i = std::size_t {}; i < values.size(); ++i)
+        word |= (std::uint32_t) values[i] << (i * 8);
+
+    return word;
+}
+
+std::int8_t int8x4ToByte(std::uint32_t word, int index)
+{
+    const auto byte = (word >> (index * 8)) & 0xFFu;
+
+    // The shader's sign extension, not a cast: a byte read as unsigned stands
+    // for (b ^ 0x80) - 128, and writing it the same way on both sides is what
+    // makes a disagreement a real fault rather than two spellings drifting.
+    return (std::int8_t) ((int) (byte ^ 0x80u) - 128);
+}
+
+std::uint8_t uint8x4ToByte(std::uint32_t word, int index)
+{
+    return (std::uint8_t) ((word >> (index * 8)) & 0xFFu);
+}
+
+std::uint32_t int4x8FromNibbles(const std::array<std::int8_t, 8>& values)
+{
+    auto word = std::uint32_t {};
+
+    for (auto i = std::size_t {}; i < values.size(); ++i)
+        word |= ((std::uint32_t) (std::uint8_t) values[i] & 0xFu) << (i * 4);
+
+    return word;
+}
+
+std::uint32_t uint4x8FromNibbles(const std::array<std::uint8_t, 8>& values)
+{
+    auto word = std::uint32_t {};
+
+    for (auto i = std::size_t {}; i < values.size(); ++i)
+        word |= ((std::uint32_t) values[i] & 0xFu) << (i * 4);
+
+    return word;
+}
+
+std::int8_t int4x8ToNibble(std::uint32_t word, int index)
+{
+    const auto nibble = (word >> (index * 4)) & 0xFu;
+
+    return (std::int8_t) ((int) (nibble ^ 0x8u) - 8);
+}
+
+std::uint8_t uint4x8ToNibble(std::uint32_t word, int index)
+{
+    return (std::uint8_t) ((word >> (index * 4)) & 0xFu);
+}
+
 UNorm8x4 UNorm8x4::fromFloats(float x, float y, float z, float w)
 {
     return {{toUnsignedNormalized(x),

--- a/Lib/eacp/GPU/Codegen/PackedVertex.h
+++ b/Lib/eacp/GPU/Codegen/PackedVertex.h
@@ -3,6 +3,7 @@
 #include "../Pipeline/VertexLayout.h"
 #include "ShaderValue.h"
 
+#include <array>
 #include <cstdint>
 
 // CPU storage types for packed vertex attributes.
@@ -56,6 +57,32 @@ float halfToFloat(std::uint16_t bits);
 // NaN rather than carrying into the exponent and becoming an infinity.
 std::uint16_t bfloat16FromFloat(float value);
 float bfloat16ToFloat(std::uint16_t bits);
+
+// The word layouts the quantized reads expect, and the way back out of one:
+// the host side of InputBuffer::readInt8, readInt8x4 and readInt4x8, and what a
+// loader turning a block-quantized checkpoint into a storage buffer writes.
+// Here beside the float pair above for the same reason it is there - no vertex
+// format carries either, and they are the same kind of thing.
+//
+// One word holds four bytes or eight nibbles, element zero in the low bits, so
+// a row packed by walking it through these reads back on the GPU in the order
+// it was written. The signed forms are two's complement - a byte over
+// [-128, 127], a nibble over [-8, 7] - and an element is extracted as
+// (b ^ 0x80) - 128 rather than cast, which is the arithmetic the shader helper
+// does, so the two agree by construction rather than by both happening to be
+// right.
+//
+// Only the low bits of each value are kept: something outside a nibble's range
+// wraps rather than saturating, exactly as packInt8x4 does in a shader.
+std::uint32_t int8x4FromBytes(const std::array<std::int8_t, 4>& values);
+std::uint32_t uint8x4FromBytes(const std::array<std::uint8_t, 4>& values);
+std::int8_t int8x4ToByte(std::uint32_t word, int index);
+std::uint8_t uint8x4ToByte(std::uint32_t word, int index);
+
+std::uint32_t int4x8FromNibbles(const std::array<std::int8_t, 8>& values);
+std::uint32_t uint4x8FromNibbles(const std::array<std::uint8_t, 8>& values);
+std::int8_t int4x8ToNibble(std::uint32_t word, int index);
+std::uint8_t uint4x8ToNibble(std::uint32_t word, int index);
 
 // Four bytes, read as 0..1 in the shader. What a vertex colour should be: this
 // is the storage ImDrawVert and every mesh format already use, and expanding it

--- a/Lib/eacp/GPU/Codegen/ShaderBuilder.h
+++ b/Lib/eacp/GPU/Codegen/ShaderBuilder.h
@@ -628,6 +628,23 @@ public:
         write(buffer, index, asFloat(packBFloat16x2(value)));
     }
 
+    // Four integers packed into the one float slot that holds them, which
+    // InputBuffer::readInt8x4 and readUInt8x4 read back at the same index. The
+    // value is an integer vector rather than a Float4 for the reason
+    // packInt8x4 gives: the rounding is the caller's decision to make.
+    void
+        writeInt8x4(const OutputBuffer& buffer, const UInt& index, const Int4& value)
+    {
+        write(buffer, index, asFloat(packInt8x4(value)));
+    }
+
+    void writeUInt8x4(const OutputBuffer& buffer,
+                      const UInt& index,
+                      const UInt4& value)
+    {
+        write(buffer, index, asFloat(packUInt8x4(value)));
+    }
+
     // One element of an integer output, index or value spelled as a literal
     // where it is one.
     void write(const UIntOutputBuffer& buffer, const UInt& index, const UInt& value)

--- a/Lib/eacp/GPU/Codegen/ShaderEmitter.cpp
+++ b/Lib/eacp/GPU/Codegen/ShaderEmitter.cpp
@@ -487,7 +487,133 @@ constexpr auto packBFloat16HelperGlsl =
     "    return (low >> 16u) | (high & 0xffff0000u);\n"
     "}\n\n";
 
-const auto shaderHelpers = Array<ShaderHelper, 10> {
+// The quantized widenings, and the sign extension inside them, which is why
+// these are helpers rather than arithmetic at the call site.
+//
+// A byte lifted out of a word is an unsigned 0..255, and the signed value it
+// stands for is (b ^ 0x80) - 128; a nibble's is (n ^ 0x8) - 8. That spelling is
+// arithmetic on values no wider than the word, moving no bit into or out of a
+// sign position, so MSL, HLSL and GLSL define it identically - which is why one
+// string serves Metal and DirectX here, as it does for erf. The alternatives do
+// not: as_type<char4> is Metal's answer alone, and shifting a byte up into the
+// sign bit and arithmetically back asks each language what its own sign bit
+// does under a shift, which is three rules spelled three ways for a widening
+// that has to agree to the bit.
+constexpr auto unpackInt8x4Helper =
+    "float4 eacpUnpackInt8x4(uint bits)\n"
+    "{\n"
+    "    return float4(float((bits & 0xffu) ^ 0x80u) - 128.0,\n"
+    "                  float(((bits >> 8u) & 0xffu) ^ 0x80u) - 128.0,\n"
+    "                  float(((bits >> 16u) & 0xffu) ^ 0x80u) - 128.0,\n"
+    "                  float(((bits >> 24u) & 0xffu) ^ 0x80u) - 128.0);\n"
+    "}\n\n";
+
+constexpr auto unpackInt8x4HelperGlsl =
+    "vec4 eacpUnpackInt8x4(uint bits)\n"
+    "{\n"
+    "    return vec4(float((bits & 0xffu) ^ 0x80u) - 128.0,\n"
+    "                float(((bits >> 8u) & 0xffu) ^ 0x80u) - 128.0,\n"
+    "                float(((bits >> 16u) & 0xffu) ^ 0x80u) - 128.0,\n"
+    "                float(((bits >> 24u) & 0xffu) ^ 0x80u) - 128.0);\n"
+    "}\n\n";
+
+constexpr auto unpackUInt8x4Helper =
+    "float4 eacpUnpackUInt8x4(uint bits)\n"
+    "{\n"
+    "    return float4(float(bits & 0xffu),\n"
+    "                  float((bits >> 8u) & 0xffu),\n"
+    "                  float((bits >> 16u) & 0xffu),\n"
+    "                  float((bits >> 24u) & 0xffu));\n"
+    "}\n\n";
+
+constexpr auto unpackUInt8x4HelperGlsl =
+    "vec4 eacpUnpackUInt8x4(uint bits)\n"
+    "{\n"
+    "    return vec4(float(bits & 0xffu),\n"
+    "                float((bits >> 8u) & 0xffu),\n"
+    "                float((bits >> 16u) & 0xffu),\n"
+    "                float((bits >> 24u) & 0xffu));\n"
+    "}\n\n";
+
+// Four nibbles out of the low sixteen bits of a word. The high four are the
+// same function of the word shifted down sixteen, which unpackInt4x8 records as
+// a shift node rather than a second helper - so one definition covers both
+// halves and the shift is visible in the emitted source.
+constexpr auto unpackInt4x4Helper =
+    "float4 eacpUnpackInt4x4(uint bits)\n"
+    "{\n"
+    "    return float4(float((bits & 0xfu) ^ 0x8u) - 8.0,\n"
+    "                  float(((bits >> 4u) & 0xfu) ^ 0x8u) - 8.0,\n"
+    "                  float(((bits >> 8u) & 0xfu) ^ 0x8u) - 8.0,\n"
+    "                  float(((bits >> 12u) & 0xfu) ^ 0x8u) - 8.0);\n"
+    "}\n\n";
+
+constexpr auto unpackInt4x4HelperGlsl =
+    "vec4 eacpUnpackInt4x4(uint bits)\n"
+    "{\n"
+    "    return vec4(float((bits & 0xfu) ^ 0x8u) - 8.0,\n"
+    "                float(((bits >> 4u) & 0xfu) ^ 0x8u) - 8.0,\n"
+    "                float(((bits >> 8u) & 0xfu) ^ 0x8u) - 8.0,\n"
+    "                float(((bits >> 12u) & 0xfu) ^ 0x8u) - 8.0);\n"
+    "}\n\n";
+
+constexpr auto unpackUInt4x4Helper =
+    "float4 eacpUnpackUInt4x4(uint bits)\n"
+    "{\n"
+    "    return float4(float(bits & 0xfu),\n"
+    "                  float((bits >> 4u) & 0xfu),\n"
+    "                  float((bits >> 8u) & 0xfu),\n"
+    "                  float((bits >> 12u) & 0xfu));\n"
+    "}\n\n";
+
+constexpr auto unpackUInt4x4HelperGlsl =
+    "vec4 eacpUnpackUInt4x4(uint bits)\n"
+    "{\n"
+    "    return vec4(float(bits & 0xfu),\n"
+    "                float((bits >> 4u) & 0xfu),\n"
+    "                float((bits >> 8u) & 0xfu),\n"
+    "                float((bits >> 12u) & 0xfu));\n"
+    "}\n\n";
+
+// The inverse. Each component is masked to its low eight bits in the *signed*
+// domain first, which every one of the three defines as the two's-complement
+// pattern and which leaves a value in 0..255 - so the conversion to uint that
+// follows is of a non-negative number and has nothing left to disagree about.
+// Casting a negative int straight to uint would be the shorter spelling and the
+// one whose result each language words differently.
+constexpr auto packInt8x4Helper =
+    "uint eacpPackInt8x4(int4 values)\n"
+    "{\n"
+    "    return uint(values.x & 0xff) | (uint(values.y & 0xff) << 8u)\n"
+    "           | (uint(values.z & 0xff) << 16u)\n"
+    "           | (uint(values.w & 0xff) << 24u);\n"
+    "}\n\n";
+
+constexpr auto packInt8x4HelperGlsl =
+    "uint eacpPackInt8x4(ivec4 values)\n"
+    "{\n"
+    "    return uint(values.x & 0xff) | (uint(values.y & 0xff) << 8u)\n"
+    "           | (uint(values.z & 0xff) << 16u)\n"
+    "           | (uint(values.w & 0xff) << 24u);\n"
+    "}\n\n";
+
+constexpr auto packUInt8x4Helper =
+    "uint eacpPackUInt8x4(uint4 values)\n"
+    "{\n"
+    "    return (values.x & 0xffu) | ((values.y & 0xffu) << 8u)\n"
+    "           | ((values.z & 0xffu) << 16u)\n"
+    "           | ((values.w & 0xffu) << 24u);\n"
+    "}\n\n";
+
+constexpr auto packUInt8x4HelperGlsl =
+    "uint eacpPackUInt8x4(uvec4 values)\n"
+    "{\n"
+    "    return (values.x & 0xffu) | ((values.y & 0xffu) << 8u)\n"
+    "           | ((values.z & 0xffu) << 16u)\n"
+    "           | ((values.w & 0xffu) << 24u);\n"
+    "}\n\n";
+
+const auto shaderHelpers = Array<ShaderHelper, 18> {
     ShaderHelper {"eacpUnpackHalf2",
                   "inline float2 eacpUnpackHalf2(uint bits)\n"
                   "{\n"
@@ -589,6 +715,69 @@ const auto shaderHelpers = Array<ShaderHelper, 10> {
                   packBFloat16HelperMetal,
                   packBFloat16HelperHlsl,
                   packBFloat16HelperGlsl},
+
+    // One byte chosen by its position in the word, as eacpReadHalf and
+    // eacpReadBFloat16 choose a half: shifting the wanted byte down is one
+    // instruction everywhere, where selecting between four unpacked values
+    // computes four and keeps one.
+    ShaderHelper {"eacpReadInt8",
+                  "float eacpReadInt8(uint bits, uint byteIndex)\n"
+                  "{\n"
+                  "    uint value = (bits >> (8u * byteIndex)) & 0xffu;\n"
+                  "    return float(value ^ 0x80u) - 128.0;\n"
+                  "}\n\n",
+                  "float eacpReadInt8(uint bits, uint byteIndex)\n"
+                  "{\n"
+                  "    uint value = (bits >> (8u * byteIndex)) & 0xffu;\n"
+                  "    return float(value ^ 0x80u) - 128.0;\n"
+                  "}\n\n",
+                  "float eacpReadInt8(uint bits, uint byteIndex)\n"
+                  "{\n"
+                  "    uint value = (bits >> (8u * byteIndex)) & 0xffu;\n"
+                  "    return float(value ^ 0x80u) - 128.0;\n"
+                  "}\n\n"},
+
+    ShaderHelper {"eacpReadUInt8",
+                  "float eacpReadUInt8(uint bits, uint byteIndex)\n"
+                  "{\n"
+                  "    return float((bits >> (8u * byteIndex)) & 0xffu);\n"
+                  "}\n\n",
+                  "float eacpReadUInt8(uint bits, uint byteIndex)\n"
+                  "{\n"
+                  "    return float((bits >> (8u * byteIndex)) & 0xffu);\n"
+                  "}\n\n",
+                  "float eacpReadUInt8(uint bits, uint byteIndex)\n"
+                  "{\n"
+                  "    return float((bits >> (8u * byteIndex)) & 0xffu);\n"
+                  "}\n\n"},
+
+    ShaderHelper {"eacpUnpackInt8x4",
+                  unpackInt8x4Helper,
+                  unpackInt8x4Helper,
+                  unpackInt8x4HelperGlsl},
+
+    ShaderHelper {"eacpUnpackUInt8x4",
+                  unpackUInt8x4Helper,
+                  unpackUInt8x4Helper,
+                  unpackUInt8x4HelperGlsl},
+
+    ShaderHelper {"eacpUnpackInt4x4",
+                  unpackInt4x4Helper,
+                  unpackInt4x4Helper,
+                  unpackInt4x4HelperGlsl},
+
+    ShaderHelper {"eacpUnpackUInt4x4",
+                  unpackUInt4x4Helper,
+                  unpackUInt4x4Helper,
+                  unpackUInt4x4HelperGlsl},
+
+    ShaderHelper {
+        "eacpPackInt8x4", packInt8x4Helper, packInt8x4Helper, packInt8x4HelperGlsl},
+
+    ShaderHelper {"eacpPackUInt8x4",
+                  packUInt8x4Helper,
+                  packUInt8x4Helper,
+                  packUInt8x4HelperGlsl},
 
     ShaderHelper {"log10", nullptr, nullptr, log10HelperGlsl}};
 

--- a/Lib/eacp/GPU/Codegen/ShaderValue.h
+++ b/Lib/eacp/GPU/Codegen/ShaderValue.h
@@ -650,6 +650,53 @@ T readBufferVectorLoad(
 }
 } // namespace detail
 
+// Eight values out of one word, which is wider than any vector the three
+// languages share - none of them has a float8, and inventing one in the EDSL
+// would leave nothing to emit it into. So the eight nibbles of a word come back
+// as the two Float4s they unpack into: .low is nibbles 0..3 and .high nibbles
+// 4..7, in the order the word holds them.
+//
+// A pair rather than a readInt4x8Low beside a readInt4x8High, because the graph
+// shares constants and pure binaries and nothing else, so the two calls would
+// be two loads of the same word. One read unpacked twice in registers is what a
+// kernel consuming eight consecutive weights wants, and the call site reads as
+// one fetch because it is one:
+//
+//     auto weights = quantized.readInt4x8(block);
+//     sum += dot(weights.low, activations.read4(block * 2u))
+//          + dot(weights.high, activations.read4(block * 2u + 1u));
+struct Float4Pair
+{
+    Float4 low;
+    Float4 high;
+};
+
+// Sixteen values out of one record, for the same reason and one width further:
+// the widest single load the three backends have is sixteen bytes, and what
+// that many quantized weights unpack into is four Float4s.
+//
+// Lettered a..d rather than extended from .low/.high, because those two words
+// name a two-way split honestly and there is no equally honest pair of words
+// for the middle of a four-way one - .lowMid and .highMid would invent a
+// vocabulary, and read as an ordering of magnitudes where this is an ordering
+// of addresses. Inside a Float4 the components already run x, y, z, w in the
+// order the bytes sit; across the quad they run a, b, c, d the same way, so
+// q.a.x is the record's first element and q.d.w its sixteenth, and the whole
+// thing reads left to right:
+//
+//     auto weights = quantized.readInt8x16(block);
+//     sum += dot(weights.a, activations.read4(block * 4u))
+//          + dot(weights.b, activations.read4(block * 4u + 1u))
+//          + dot(weights.c, activations.read4(block * 4u + 2u))
+//          + dot(weights.d, activations.read4(block * 4u + 3u));
+struct Float4Quad
+{
+    Float4 a;
+    Float4 b;
+    Float4 c;
+    Float4 d;
+};
+
 // Storage buffers of float elements, declared by a compute kernel. Like
 // Texture2D they are slot-identified rather than expression nodes: an input's
 // one operation is the indexed read, an output's is the store recorded via
@@ -753,6 +800,60 @@ struct InputBuffer
     Float2 readBFloat16x2(unsigned index) const;
     Float4 readBFloat16x4(const UInt& index) const;
     Float4 readBFloat16x4(unsigned index) const;
+
+    // The byte reads, for the int8 half of a block-quantized checkpoint, on the
+    // same two index conventions: readInt8 and readUInt8 count bytes, so a
+    // buffer of N quantized weights is walked 0..N-1, and readInt8x4 and
+    // readUInt8x4 count the words that hold four. Each hands back the stored
+    // integer widened to a float exactly - the block's scale is a multiply the
+    // kernel does itself, since which scale belongs to which run of weights is
+    // the format's business and not a buffer read's.
+    Float readInt8(const UInt& index) const;
+    Float readInt8(unsigned index) const;
+    Float readUInt8(const UInt& index) const;
+    Float readUInt8(unsigned index) const;
+    Float4 readInt8x4(const UInt& index) const;
+    Float4 readInt8x4(unsigned index) const;
+    Float4 readUInt8x4(const UInt& index) const;
+    Float4 readUInt8x4(unsigned index) const;
+
+    // The wide byte reads, on the same convention one width up: readInt8x8
+    // counts records of eight bytes - the two words starting at word 2 * i -
+    // and readInt8x16 records of sixteen, the four words starting at word
+    // 4 * i. Both take their words through a single record read, so the eight
+    // or sixteen bytes arrive in one load wherever the backend has one and the
+    // widening is register arithmetic over what it brought back.
+    //
+    // That is the whole point of them. readInt8x4 fetches four bytes in a
+    // four-byte load, so a kernel walking a row with it issues as many loads as
+    // the same walk in bf16 does for twice the data, and becomes bound by how
+    // fast it can issue them rather than by memory. These two put the same
+    // bytes behind a load as wide as the bf16 one.
+    Float4Pair readInt8x8(const UInt& index) const;
+    Float4Pair readInt8x8(unsigned index) const;
+    Float4Pair readUInt8x8(const UInt& index) const;
+    Float4Pair readUInt8x8(unsigned index) const;
+    Float4Quad readInt8x16(const UInt& index) const;
+    Float4Quad readInt8x16(unsigned index) const;
+    Float4Quad readUInt8x16(const UInt& index) const;
+    Float4Quad readUInt8x16(unsigned index) const;
+
+    // The nibble reads, for the int4 half of one. The index counts words - one
+    // word is eight nibbles, nibble 0 in the low four bits - and the eight
+    // values arrive as a Float4Pair for the reason that type gives. A signed
+    // nibble is two's complement over [-8, 7] and an unsigned one is [0, 15].
+    Float4Pair readInt4x8(const UInt& index) const;
+    Float4Pair readInt4x8(unsigned index) const;
+    Float4Pair readUInt4x8(const UInt& index) const;
+    Float4Pair readUInt4x8(unsigned index) const;
+
+    // Sixteen nibbles, which is the same eight bytes readInt8x8 fetches and so
+    // the same single load: two words read as one record, each unpacked into
+    // the pair of Float4s it holds. The index counts records of sixteen.
+    Float4Quad readInt4x16(const UInt& index) const;
+    Float4Quad readInt4x16(unsigned index) const;
+    Float4Quad readUInt4x16(const UInt& index) const;
+    Float4Quad readUInt4x16(unsigned index) const;
 
     ShaderGraph* graph = nullptr;
     int slot = -1;
@@ -3016,6 +3117,252 @@ inline Float2 InputBuffer::readBFloat16x2(const UInt& index) const
 inline Float2 InputBuffer::readBFloat16x2(unsigned index) const
 {
     return readBFloat16x2(detail::bufferIndex(graph, index));
+}
+
+// The four bytes of one word, widened: .x the low eight bits through .w the
+// high, which is little-endian order and so the order a memcpy of a row of
+// int8 weights already leaves them in.
+//
+// The sign extension is an exclusive-or and a subtraction rather than a cast or
+// a pair of shifts, because that is the one spelling the three languages define
+// identically: a byte read as unsigned is the signed value (b ^ 0x80) - 128,
+// which is arithmetic entirely inside the range a uint holds and moves no bit
+// into or out of a sign position. as_type<char4> would be Metal's answer and
+// nothing else's, and shifting a byte up into the sign bit and
+// arithmetically back leans on each language's own rule for what the sign bit
+// does under a shift - three rules, spelled three ways, for a widening that has
+// to be bit-identical.
+inline Float4 unpackInt8x4(const UInt& bits)
+{
+    return detail::call<Float4>(bits, ValueType::Float4, "eacpUnpackInt8x4");
+}
+
+inline Float4 unpackUInt8x4(const UInt& bits)
+{
+    return detail::call<Float4>(bits, ValueType::Float4, "eacpUnpackUInt8x4");
+}
+
+// The inverse: four integers packed into one word, .x in the low eight bits.
+//
+// It takes an Int4 rather than a Float4 on purpose. Narrowing a float to an
+// integer is a rounding decision, and the three dialects each make their own -
+// which is exactly the disagreement packHalf2 documents. An already-integral
+// vector leaves nothing to disagree about, and a kernel that has floats rounds
+// them itself, with round() or floor(), where the choice is visible.
+//
+// Only the low eight bits of each component are stored, so a value outside
+// [-128, 127] wraps rather than saturating. Quantization clamps before it gets
+// here; nothing is spent re-clamping in the shader.
+inline UInt packInt8x4(const Int4& values)
+{
+    return detail::call<UInt>(values, ValueType::UInt, "eacpPackInt8x4");
+}
+
+inline UInt packUInt8x4(const UInt4& values)
+{
+    return detail::call<UInt>(values, ValueType::UInt, "eacpPackUInt8x4");
+}
+
+// The eight nibbles of one word, widened, as the two halves Float4Pair
+// describes. Two float4s rather than one returned aggregate because no dialect
+// spells a returned struct the way the others do, and a float4 is what all
+// three have.
+//
+// The high half is the low half of the word shifted down sixteen, so it is the
+// same helper over a shift node rather than a second helper - one definition
+// covers both halves, and the shift is a pure binary the graph shares with any
+// other use of it.
+inline Float4Pair unpackInt4x8(const UInt& bits)
+{
+    return {
+        detail::call<Float4>(bits, ValueType::Float4, "eacpUnpackInt4x4"),
+        detail::call<Float4>(bits >> 16u, ValueType::Float4, "eacpUnpackInt4x4")};
+}
+
+inline Float4Pair unpackUInt4x8(const UInt& bits)
+{
+    return {
+        detail::call<Float4>(bits, ValueType::Float4, "eacpUnpackUInt4x4"),
+        detail::call<Float4>(bits >> 16u, ValueType::Float4, "eacpUnpackUInt4x4")};
+}
+
+// One byte of a buffer whose elements are int8 rather than float, widened. The
+// index counts bytes, so the call site never spells the packing: the word is
+// index / 4 and which byte of it is index % 4.
+//
+// The byte position goes into the helper rather than selecting between four
+// unpacked values, for the reason readHalf gives - shifting the wanted byte
+// down is one instruction in every language, where a select computes four and
+// throws three away.
+inline Float InputBuffer::readInt8(const UInt& index) const
+{
+    return detail::call2<Float>(
+        asUInt((*this)[index / 4u]), index % 4u, ValueType::Float, "eacpReadInt8");
+}
+
+// The literal form, folded here rather than emitted as `6u / 4u`.
+inline Float InputBuffer::readInt8(unsigned index) const
+{
+    return detail::call2<Float>(asUInt((*this)[index / 4u]),
+                                detail::bufferIndex(graph, index % 4u),
+                                ValueType::Float,
+                                "eacpReadInt8");
+}
+
+inline Float InputBuffer::readUInt8(const UInt& index) const
+{
+    return detail::call2<Float>(
+        asUInt((*this)[index / 4u]), index % 4u, ValueType::Float, "eacpReadUInt8");
+}
+
+inline Float InputBuffer::readUInt8(unsigned index) const
+{
+    return detail::call2<Float>(asUInt((*this)[index / 4u]),
+                                detail::bufferIndex(graph, index % 4u),
+                                ValueType::Float,
+                                "eacpReadUInt8");
+}
+
+// All four bytes of one word, which is what a kernel walking a quantized row
+// wants. The index counts words here rather than bytes - it is the same index
+// the matching writeInt8x4 stores at.
+inline Float4 InputBuffer::readInt8x4(const UInt& index) const
+{
+    return unpackInt8x4(asUInt((*this)[index]));
+}
+
+inline Float4 InputBuffer::readInt8x4(unsigned index) const
+{
+    return readInt8x4(detail::bufferIndex(graph, index));
+}
+
+inline Float4 InputBuffer::readUInt8x4(const UInt& index) const
+{
+    return unpackUInt8x4(asUInt((*this)[index]));
+}
+
+inline Float4 InputBuffer::readUInt8x4(unsigned index) const
+{
+    return readUInt8x4(detail::bufferIndex(graph, index));
+}
+
+// Eight nibbles out of one word, on the terms readInt8x4 sets: the index counts
+// words, and the whole word is fetched once.
+inline Float4Pair InputBuffer::readInt4x8(const UInt& index) const
+{
+    return unpackInt4x8(asUInt((*this)[index]));
+}
+
+inline Float4Pair InputBuffer::readInt4x8(unsigned index) const
+{
+    return readInt4x8(detail::bufferIndex(graph, index));
+}
+
+inline Float4Pair InputBuffer::readUInt4x8(const UInt& index) const
+{
+    return unpackUInt4x8(asUInt((*this)[index]));
+}
+
+inline Float4Pair InputBuffer::readUInt4x8(unsigned index) const
+{
+    return readUInt4x8(detail::bufferIndex(graph, index));
+}
+
+// The wide byte reads. Each takes its words through one record read - read2 for
+// eight bytes, read4 for sixteen - rather than through that many subscripts, so
+// the whole record is one vector load wherever the backend has one and the four
+// unpackings are register arithmetic over the value it brought back. It is the
+// same shape readBFloat16x4 has, and deliberately: half the bytes for the same
+// number of loads is the point of storing weights as bytes at all.
+//
+// The load is emitted once because the record read is one node with four uses,
+// and the emitter names any node it evaluates more than once. Nothing here
+// depends on a compiler noticing two subscripts are the same address, which the
+// graph does not look for.
+inline Float4Pair InputBuffer::readInt8x8(const UInt& index) const
+{
+    auto words = read2(index);
+
+    return {unpackInt8x4(asUInt(words.x())), unpackInt8x4(asUInt(words.y()))};
+}
+
+inline Float4Pair InputBuffer::readInt8x8(unsigned index) const
+{
+    return readInt8x8(detail::bufferIndex(graph, index));
+}
+
+inline Float4Pair InputBuffer::readUInt8x8(const UInt& index) const
+{
+    auto words = read2(index);
+
+    return {unpackUInt8x4(asUInt(words.x())), unpackUInt8x4(asUInt(words.y()))};
+}
+
+inline Float4Pair InputBuffer::readUInt8x8(unsigned index) const
+{
+    return readUInt8x8(detail::bufferIndex(graph, index));
+}
+
+inline Float4Quad InputBuffer::readInt8x16(const UInt& index) const
+{
+    auto words = read4(index);
+
+    return {unpackInt8x4(asUInt(words.x())),
+            unpackInt8x4(asUInt(words.y())),
+            unpackInt8x4(asUInt(words.z())),
+            unpackInt8x4(asUInt(words.w()))};
+}
+
+inline Float4Quad InputBuffer::readInt8x16(unsigned index) const
+{
+    return readInt8x16(detail::bufferIndex(graph, index));
+}
+
+inline Float4Quad InputBuffer::readUInt8x16(const UInt& index) const
+{
+    auto words = read4(index);
+
+    return {unpackUInt8x4(asUInt(words.x())),
+            unpackUInt8x4(asUInt(words.y())),
+            unpackUInt8x4(asUInt(words.z())),
+            unpackUInt8x4(asUInt(words.w()))};
+}
+
+inline Float4Quad InputBuffer::readUInt8x16(unsigned index) const
+{
+    return readUInt8x16(detail::bufferIndex(graph, index));
+}
+
+// Sixteen nibbles are the eight bytes readInt8x8 already fetches in one load,
+// unpacked four ways instead of two - so the wide nibble read is the wide byte
+// read's machinery with unpackInt4x8 in place of unpackInt8x4, and costs a
+// helper of its own nothing.
+inline Float4Quad InputBuffer::readInt4x16(const UInt& index) const
+{
+    auto words = read2(index);
+    auto first = unpackInt4x8(asUInt(words.x()));
+    auto second = unpackInt4x8(asUInt(words.y()));
+
+    return {first.low, first.high, second.low, second.high};
+}
+
+inline Float4Quad InputBuffer::readInt4x16(unsigned index) const
+{
+    return readInt4x16(detail::bufferIndex(graph, index));
+}
+
+inline Float4Quad InputBuffer::readUInt4x16(const UInt& index) const
+{
+    auto words = read2(index);
+    auto first = unpackUInt4x8(asUInt(words.x()));
+    auto second = unpackUInt4x8(asUInt(words.y()));
+
+    return {first.low, first.high, second.low, second.high};
+}
+
+inline Float4Quad InputBuffer::readUInt4x16(unsigned index) const
+{
+    return readUInt4x16(detail::bufferIndex(graph, index));
 }
 
 template <ShaderScalarLike T>

--- a/Lib/eacp/GPU/README.md
+++ b/Lib/eacp/GPU/README.md
@@ -1448,6 +1448,138 @@ quieted rather than rounded, so it cannot carry into the exponent and come back
 as an infinity. `bfloat16FromFloat` / `bfloat16ToFloat` in `PackedVertex.h` are
 the host side of the same encoding, for filling a buffer or checking one.
 
+### int8 and int4 weights, kept packed
+
+The same storage trick again, for weights that are not floats at all. A
+block-quantized checkpoint stores a run of small integers and one scale per
+block, so what a read owes is the **integer, exactly** — the scale is a multiply
+the kernel does, since which scale belongs to which run is the format's business
+and not a buffer read's:
+
+```cpp
+void define() override
+{
+    auto i = threadId();
+    auto block = i / 32u;
+
+    write(output, i, weights.readInt8(i) * scales[block]);  // int8 in, fp32 out
+}
+```
+
+| call | what it gives |
+| --- | --- |
+| `input.readInt8(i)` / `readUInt8(i)` | element `i` of a buffer of bytes, widened to a `Float`. `i` counts bytes, so an N-weight buffer is walked `0..N-1` |
+| `input.readInt8x4(i)` / `readUInt8x4(i)` | all four bytes of word `i` as a `Float4`, `.x` the low eight bits. `i` counts words, and element `k` is `readInt8x4(k / 4)` component `k % 4` |
+| `input.readInt8x8(i)` / `readUInt8x8(i)` | eight bytes as a `Float4Pair`, one eight-byte load. `i` counts records of eight |
+| `input.readInt8x16(i)` / `readUInt8x16(i)` | sixteen bytes as a `Float4Quad` — `.a .b .c .d` in address order, one sixteen-byte load. `i` counts records of sixteen |
+| `input.readInt4x8(i)` / `readUInt4x8(i)` | the eight nibbles of word `i` as a `Float4Pair` — `.low` is nibbles 0..3 and `.high` nibbles 4..7. `i` counts words |
+| `input.readInt4x16(i)` / `readUInt4x16(i)` | sixteen nibbles — the same eight bytes, one load — as a `Float4Quad`. `i` counts records of sixteen |
+| `unpackInt8x4(bits)` / `unpackUInt8x4(bits)` | the same, from a `UInt` already in hand |
+| `unpackInt4x8(bits)` / `unpackUInt4x8(bits)` | likewise for the eight nibbles |
+| `packInt8x4(values)` | four `Int4` components packed into a `UInt`, `.x` in the low eight bits |
+| `packUInt8x4(values)` | the same from a `UInt4` |
+| `writeInt8x4(out, i, values)` / `writeUInt8x4(out, i, values)` | that word stored at `i` — `readInt8x4` reads it back |
+
+Signed values are two's complement: a byte over `[-128, 127]`, a nibble over
+`[-8, 7]`. Size the buffer in whole words — `readInt8` fetches the word at
+`i / 4`, so a count of bytes that is not a multiple of four reads past the last
+one on the final element.
+
+Every read in the family is on one index convention: `i` counts records of
+whatever the name's last number says, and every record is the elements
+`width * i` through `width * i + width - 1` of the buffer. So element `k` is
+`readInt8(k)`, and component `k % 16` of `readInt8x16(k / 16)`, and the tests
+assert exactly that.
+
+### Pick the widest read, not the widest type
+
+`readInt8x4` is correct and slow, and the reason is worth stating because it is
+not obvious from the call: **four bytes is a four-byte load**. `readBFloat16x4`
+fetches eight bytes in one load for its four weights, so an int8 kernel written
+with `readInt8x4` issues the same number of loads as the bf16 kernel it replaced
+for half the data — and stops being bound by bandwidth and starts being bound by
+how fast it can issue loads. Halving the bytes then buys a fraction of what it
+should. Measured downstream on gemma-2b: bf16 at 427–478 GB/s, int8 through
+`readInt8x4` at 298–335 GB/s, a 1.32x decode speedup where halving the bytes
+predicts 1.88x.
+
+`readInt8x8` and `readInt8x16` are the fix. They take their words through one
+record read — `read2` and `read4` — so the eight or sixteen bytes arrive in a
+single vector load wherever the backend has one (a `packed_float2` or
+`packed_float4` pointer on Metal, the componentwise construct on HLSL and GLSL),
+and the widening is register arithmetic over the value it brought back.
+`readInt8x16` is the sixteen-byte load `read4` already lowers to, holding
+sixteen weights instead of four.
+
+This is not something to leave to the shader compiler: the graph shares
+constants and pure binaries and **not reads**, so four subscripts of the same
+address stay four loads. One record read is one node, and the emitter names any
+node it evaluates more than once, which is what puts the load in a local with
+the four words as swizzles of it. `GPU/codegenWideInt8Reads` asserts the emitted
+MSL has exactly one buffer subscript for a `readInt8x16`, and
+`PackedQuantized/aWideReadCostsOneRecordRead` asserts on the real
+`ComputeProgram` path that sixteen bytes cost what a `read4` of plain floats
+costs.
+
+`Float4Pair` is what an eight-wide read hands back, and `Float4Quad` a
+sixteen-wide one, because no dialect has a float8 and inventing one in the EDSL
+would leave nothing to emit it into. They are single structs rather than a
+`readInt4x8Low` beside a `readInt4x8High` for the sharing reason above — two
+calls would be two loads of the same words. One read, unpacked in registers:
+
+```cpp
+auto w = quantized.readInt4x8(block);
+auto sum = dot(w.low, activations.read4(block * 2u))
+         + dot(w.high, activations.read4(block * 2u + 1u));
+```
+
+`Float4Pair` names its halves `.low` and `.high`; `Float4Quad` letters its four
+`.a .b .c .d` rather than inventing a `.lowMid`, which would read as an ordering
+of magnitudes where this is an ordering of addresses. Inside a `Float4` the
+components already run `x, y, z, w` in the order the bytes sit, so across the
+quad `q.a.x` is the record's first element and `q.d.w` its sixteenth:
+
+```cpp
+auto w = quantized.readInt8x16(block);
+auto sum = dot(w.a, activations.read4(block * 4u))
+         + dot(w.b, activations.read4(block * 4u + 1u))
+         + dot(w.c, activations.read4(block * 4u + 2u))
+         + dot(w.d, activations.read4(block * 4u + 3u));
+```
+
+The widening is **bit-identical on every backend**, and that is why the sign
+extension is written the way it is. A byte read as unsigned stands for
+`(b ^ 0x80) - 128` and a nibble for `(n ^ 0x8) - 8` — arithmetic on values no
+wider than the word, moving no bit into or out of a sign position, which MSL,
+HLSL and GLSL all define identically. `as_type<char4>` would be Metal's answer
+and nothing else's, and shifting a byte up into the sign bit and arithmetically
+back asks each language what its own sign bit does under a shift. The same
+arithmetic serves Metal and DirectX from one helper string, as `eacpErf` does.
+
+There are four widening helpers for the whole family and no more:
+`eacpUnpackInt8x4` and `eacpUnpackInt4x4` and their unsigned twins. The wide
+reads are those helpers applied once per word of the record, so a
+`readInt8x16` emits one load and four calls, and a `readInt4x16` one load and
+four calls of the nibble helper — the high nibbles of a word being the same
+helper over the word shifted down sixteen, which is a shift node in the graph
+rather than a fifth helper.
+
+`packInt8x4` takes an `Int4` rather than a `Float4` on purpose: narrowing a
+float to an integer is a rounding decision and the three dialects each make
+their own, so a kernel that has floats rounds them itself — with `round()` or
+`floor()` — where the choice is visible. Only the low eight bits of each
+component are stored, so a value outside the range wraps rather than saturating;
+quantization clamps before this point and nothing is spent re-clamping in the
+shader.
+
+`int8x4FromBytes` / `uint8x4FromBytes` / `int4x8FromNibbles` /
+`uint4x8FromNibbles` in `PackedVertex.h`, with `int8x4ToByte` and
+`int4x8ToNibble` going the other way, are the host side of the same layout —
+what a loader turning a quantized checkpoint into a storage buffer writes. They
+are per word, and that is all the wide reads need: a record is a run of
+consecutive words, so a buffer packed one word at a time reads back through
+`readInt8x16` in the order it was written.
+
 ## Mipmaps
 
 ```cpp

--- a/Tests/GPU/CMakeLists.txt
+++ b/Tests/GPU/CMakeLists.txt
@@ -61,6 +61,7 @@ set(gpu_test_sources
         MultisampledTargetTests.cpp
         PackedBFloat16Tests.cpp
         PackedHalfTests.cpp
+        PackedQuantizedTests.cpp
         PipelineStateTests.cpp
         ProgramGraphTests.cpp
         RenderBufferRangeTests.cpp

--- a/Tests/GPU/PackedQuantizedTests.cpp
+++ b/Tests/GPU/PackedQuantizedTests.cpp
@@ -1,0 +1,1270 @@
+#include "Common.h"
+
+#include <array>
+#include <cstdint>
+
+// The byte and nibble reads: the int8 and int4 storage a block-quantized
+// checkpoint ships in, read out of an ordinary float buffer and widened to the
+// integer each element stands for.
+//
+// The bf16 family beside this one is a float narrowed; this one is not a float
+// at all. A quantized weight is a small integer and a scale that belongs to the
+// block it sits in, so what a read owes is the integer, exactly, and the scale
+// is a multiply the kernel does. Three things have to hold:
+//
+//   1. Every byte value and every nibble value widens to exactly the integer
+//      it encodes, at every position in the word. An int8 row is a run of
+//      numbers, and one of them read as 44 instead of -84 is not noise, it is
+//      a different weight.
+//   2. The sign extension is the same on every backend. It is written as an
+//      exclusive-or and a subtraction rather than a cast for that reason, and
+//      the host helpers do the same arithmetic so a buffer packed on the CPU
+//      reads back as what was put in it.
+//   3. The two index conventions address one layout: element k of a buffer is
+//      readInt8(k), and it is component k % 4 of readInt8x4(k / 4).
+
+using namespace nano;
+using namespace eacp;
+using namespace eacp::GPU;
+
+namespace
+{
+// The layouts, written out rather than called through int8x4FromBytes, because
+// the host helpers are under test beside the shader and a reference that is the
+// thing it checks proves nothing.
+std::uint32_t packedBytes(int a, int b, int c, int d)
+{
+    return (std::uint32_t) (a & 0xFF) | ((std::uint32_t) (b & 0xFF) << 8)
+           | ((std::uint32_t) (c & 0xFF) << 16) | ((std::uint32_t) (d & 0xFF) << 24);
+}
+
+std::uint32_t packedNibbles(const int* values)
+{
+    auto word = std::uint32_t {};
+
+    for (auto i = 0; i < 8; ++i)
+        word |= (std::uint32_t) (values[i] & 0xF) << (i * 4);
+
+    return word;
+}
+
+// What a byte pattern means read as signed, and what a nibble does: two's
+// complement over [-128, 127] and over [-8, 7].
+int asSignedByte(int pattern)
+{
+    return pattern < 128 ? pattern : pattern - 256;
+}
+
+int asSignedNibble(int pattern)
+{
+    return pattern < 8 ? pattern : pattern - 16;
+}
+
+// And what one means read as unsigned, which is itself - named so a check over
+// the unsigned reads is spelled the same way as the signed one beside it.
+int asUnsignedValue(int pattern)
+{
+    return pattern;
+}
+
+// Every byte value at every position of a record `width` bytes wide, which is
+// what catches a shift that is right for the first byte of a record and wrong
+// for the last: position p of record r holds (r + (256 / width) * p) % 256, so
+// each of the 256 * width (value, position) pairs appears exactly once across
+// 256 records.
+//
+// Taking the width rather than fixing it at four is what lets the eight- and
+// sixteen-byte reads be checked at every position they have, which is the whole
+// question a wider read raises - a swizzle picking the wrong word of a vector
+// load is right for the first four bytes and wrong after them.
+Vector<int> everyBytePatternIn(int width)
+{
+    auto patterns = Vector<int> {};
+
+    for (auto record = 0; record < 256; ++record)
+        for (auto position = 0; position < width; ++position)
+            patterns.add((record + (256 / width) * position) % 256);
+
+    return patterns;
+}
+
+Vector<int> everyBytePattern()
+{
+    return everyBytePatternIn(4);
+}
+
+// The same for nibbles: sixteen records is enough for every value to land at
+// every position, whatever the record's width.
+Vector<int> everyNibblePatternIn(int width)
+{
+    auto patterns = Vector<int> {};
+
+    for (auto record = 0; record < 16; ++record)
+        for (auto position = 0; position < width; ++position)
+            patterns.add((record + position) % 16);
+
+    return patterns;
+}
+
+Vector<int> everyNibblePattern()
+{
+    return everyNibblePatternIn(8);
+}
+
+Vector<std::uint32_t> wordsOfBytes(const Vector<int>& patterns)
+{
+    auto words = Vector<std::uint32_t> {};
+
+    for (auto i = 0; i < patterns.size(); i += 4)
+        words.add(packedBytes(
+            patterns[i], patterns[i + 1], patterns[i + 2], patterns[i + 3]));
+
+    return words;
+}
+
+Vector<std::uint32_t> wordsOfNibbles(const Vector<int>& patterns)
+{
+    auto words = Vector<std::uint32_t> {};
+
+    for (auto i = 0; i < patterns.size(); i += 8)
+        words.add(packedNibbles(patterns.data() + i));
+
+    return words;
+}
+
+// One element at a time out of a buffer whose elements are bytes, which is what
+// a kernel walking a quantized row writes rather than doing the word and the
+// byte arithmetic itself.
+struct ReadInt8Kernel final : ComputeProgram
+{
+    ReadInt8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.readInt8(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadUInt8Kernel final : ComputeProgram
+{
+    ReadUInt8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.readUInt8(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// The literal-index overload, which a kernel reaching for a fixed element - a
+// zero point, a block header - is what spells.
+struct LiteralInt8Kernel final : ComputeProgram
+{
+    LiteralInt8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+
+        for (auto element = 0u; element < 8u; ++element)
+            write(output, i * 8u + element, weights.readInt8(element));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// Four bytes at a time, which is one word: the width a quantized weight walk
+// wants, and one load rather than four.
+struct ReadInt8x4Kernel final : ComputeProgram
+{
+    ReadInt8x4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.readInt8x4(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadUInt8x4Kernel final : ComputeProgram
+{
+    ReadUInt8x4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.readUInt8x4(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// Eight nibbles out of one word, written back as the two records they arrive
+// in, so the output is the eight elements in the order the word holds them.
+struct ReadInt4x8Kernel final : ComputeProgram
+{
+    ReadInt4x8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto nibbles = weights.readInt4x8(i);
+
+        write(output, i * 2u, nibbles.low);
+        write(output, i * 2u + 1u, nibbles.high);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadUInt4x8Kernel final : ComputeProgram
+{
+    ReadUInt4x8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto nibbles = weights.readUInt4x8(i);
+
+        write(output, i * 2u, nibbles.low);
+        write(output, i * 2u + 1u, nibbles.high);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// Eight and sixteen bytes at a time, which is the width a quantized weight walk
+// actually wants: the same eight or sixteen bytes a bf16 walk fetches in one
+// load, holding twice as many weights. Four bytes at a time is correct and slow
+// - it issues a load per four weights where a bf16 row issues one per four, so
+// the kernel runs out of load slots long before it runs out of bandwidth.
+struct ReadInt8x8Kernel final : ComputeProgram
+{
+    ReadInt8x8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto bytes = weights.readInt8x8(i);
+
+        write(output, i * 2u, bytes.low);
+        write(output, i * 2u + 1u, bytes.high);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadUInt8x8Kernel final : ComputeProgram
+{
+    ReadUInt8x8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto bytes = weights.readUInt8x8(i);
+
+        write(output, i * 2u, bytes.low);
+        write(output, i * 2u + 1u, bytes.high);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadInt8x16Kernel final : ComputeProgram
+{
+    ReadInt8x16Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto bytes = weights.readInt8x16(i);
+
+        write(output, i * 4u, bytes.a);
+        write(output, i * 4u + 1u, bytes.b);
+        write(output, i * 4u + 2u, bytes.c);
+        write(output, i * 4u + 3u, bytes.d);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadUInt8x16Kernel final : ComputeProgram
+{
+    ReadUInt8x16Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto bytes = weights.readUInt8x16(i);
+
+        write(output, i * 4u, bytes.a);
+        write(output, i * 4u + 1u, bytes.b);
+        write(output, i * 4u + 2u, bytes.c);
+        write(output, i * 4u + 3u, bytes.d);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// Sixteen nibbles, which is the eight bytes readInt8x8 fetches read four ways
+// instead of two.
+struct ReadInt4x16Kernel final : ComputeProgram
+{
+    ReadInt4x16Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto nibbles = weights.readInt4x16(i);
+
+        write(output, i * 4u, nibbles.a);
+        write(output, i * 4u + 1u, nibbles.b);
+        write(output, i * 4u + 2u, nibbles.c);
+        write(output, i * 4u + 3u, nibbles.d);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct ReadUInt4x16Kernel final : ComputeProgram
+{
+    ReadUInt4x16Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        auto nibbles = weights.readUInt4x16(i);
+
+        write(output, i * 4u, nibbles.a);
+        write(output, i * 4u + 1u, nibbles.b);
+        write(output, i * 4u + 2u, nibbles.c);
+        write(output, i * 4u + 3u, nibbles.d);
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// Widen a word and pack it straight back into the float slot it came out of -
+// the whole int8-storage round trip in one line.
+struct RoundTripInt8Kernel final : ComputeProgram
+{
+    RoundTripInt8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, asFloat(packInt8x4(toInt(weights.readInt8x4(i)))));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// The same thing said the short way, which is the only claim writeInt8x4
+// makes.
+struct WriteInt8x4Kernel final : ComputeProgram
+{
+    WriteInt8x4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        writeInt8x4(output, i, toInt(weights.readInt8x4(i)));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct RoundTripUInt8Kernel final : ComputeProgram
+{
+    RoundTripUInt8Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, asFloat(packUInt8x4(toUInt(weights.readUInt8x4(i)))));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct WriteUInt8x4Kernel final : ComputeProgram
+{
+    WriteUInt8x4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        writeUInt8x4(output, i, toUInt(weights.readUInt8x4(i)));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// The same eight and sixteen bytes as plain floats, which is what the wide
+// reads have to cost: one record read of that width, whatever the backend
+// spells that as.
+struct PlainRead2Kernel final : ComputeProgram
+{
+    PlainRead2Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.read2(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+struct PlainRead4Kernel final : ComputeProgram
+{
+    PlainRead4Kernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, weights.read4(i));
+    }
+
+    Uniform<InputBuffer> weights;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(weights, output)
+};
+
+// Ordinary arithmetic, so nothing pulls a helper in.
+struct PlainQuantizedKernel final : ComputeProgram
+{
+    PlainQuantizedKernel() { compile(); }
+
+    void define() override
+    {
+        auto i = threadId();
+        write(output, i, input[i] * 2.0f);
+    }
+
+    Uniform<InputBuffer> input;
+    Uniform<OutputBuffer> output;
+
+    EACP_SHADER(input, output)
+};
+
+void runKernel(Device& device, ComputeProgram& kernel, int threads)
+{
+    auto commands = device.makeCommandBuffer();
+
+    {
+        auto pass = commands.beginCompute();
+        pass.dispatch(kernel, threads);
+    }
+
+    commands.commit();
+}
+
+Vector<float> floatsOf(const Buffer& buffer)
+{
+    auto values = Vector<float>(buffer.size() / (int) sizeof(float));
+    buffer.read(values.data(), buffer.size());
+    return values;
+}
+
+Vector<std::uint32_t> wordsOf(const Buffer& buffer)
+{
+    auto words = Vector<std::uint32_t>(buffer.size() / (int) sizeof(std::uint32_t));
+    buffer.read(words.data(), buffer.size());
+    return words;
+}
+
+Buffer storageOf(Device& device, const Vector<std::uint32_t>& words)
+{
+    return device.makeBuffer(words.data(),
+                             words.size() * (int) sizeof(std::uint32_t),
+                             BufferUsage::Storage);
+}
+
+// One wide read over a buffer holding every value at every position of its
+// record: run it and check each widened float against what the pattern at that
+// element says it stands for.
+//
+// Exactly, not within a tolerance - every value a byte or a nibble encodes is
+// an integer a float holds outright, so any difference at all is a fault.
+template <typename Kernel>
+void checkWidensEveryPattern(Device& device,
+                             const Vector<std::uint32_t>& words,
+                             const Vector<int>& patterns,
+                             int width,
+                             int (*meaning)(int))
+{
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(patterns.size() * (int) sizeof(float));
+
+    auto kernel = Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, patterns.size() / width);
+
+    auto result = floatsOf(output);
+
+    for (auto i = 0; i < patterns.size(); ++i)
+        check(result[i] == (float) meaning(patterns[i]));
+}
+
+bool contains(const std::string& text, const char* needle)
+{
+    return text.find(needle) != std::string::npos;
+}
+
+int countOccurrences(const std::string& text, const char* needle)
+{
+    const auto length = std::string_view(needle).size();
+    auto count = 0;
+
+    for (auto found = text.find(needle); found != std::string::npos;
+         found = text.find(needle, found + length))
+        ++count;
+
+    return count;
+}
+} // namespace
+
+// What the encoding is, pinned against values rather than against the shift
+// that implements it.
+auto tQuantizedEncoding = test("PackedQuantized/elementZeroIsInTheLowBits") = []
+{
+    check(packedBytes(1, 2, 3, 4) == 0x04030201u);
+    check(packedBytes(0, 0, 0, 255) == 0xFF000000u);
+    check(packedBytes(255, 0, 0, 0) == 0x000000FFu);
+
+    const auto ascending = std::array<int, 8> {0, 1, 2, 3, 4, 5, 6, 7};
+    check(packedNibbles(ascending.data()) == 0x76543210u);
+
+    check(asSignedByte(0) == 0);
+    check(asSignedByte(127) == 127);
+    check(asSignedByte(128) == -128);
+    check(asSignedByte(255) == -1);
+
+    check(asSignedNibble(0) == 0);
+    check(asSignedNibble(7) == 7);
+    check(asSignedNibble(8) == -8);
+    check(asSignedNibble(15) == -1);
+};
+
+// The host pair is the same layout the shader reads, which is what lets a
+// loader pack a buffer the GPU reads back unchanged, and the same two's
+// complement in both directions.
+auto tQuantizedHostHelpers = test("PackedQuantized/hostHelpersAreTheSameLayout") = []
+{
+    for (auto pattern = 0; pattern < 256; ++pattern)
+    {
+        for (auto position = 0; position < 4; ++position)
+        {
+            auto bytes = std::array<std::int8_t, 4> {};
+            auto unsignedBytes = std::array<std::uint8_t, 4> {};
+
+            bytes[(std::size_t) position] = (std::int8_t) asSignedByte(pattern);
+            unsignedBytes[(std::size_t) position] = (std::uint8_t) pattern;
+
+            auto expected = std::array<int, 4> {};
+            expected[(std::size_t) position] = pattern;
+
+            const auto word =
+                packedBytes(expected[0], expected[1], expected[2], expected[3]);
+
+            check(int8x4FromBytes(bytes) == word);
+            check(uint8x4FromBytes(unsignedBytes) == word);
+            check(int8x4ToByte(word, position) == asSignedByte(pattern));
+            check(uint8x4ToByte(word, position) == pattern);
+        }
+    }
+
+    for (auto pattern = 0; pattern < 16; ++pattern)
+    {
+        for (auto position = 0; position < 8; ++position)
+        {
+            auto nibbles = std::array<std::int8_t, 8> {};
+            auto unsignedNibbles = std::array<std::uint8_t, 8> {};
+
+            nibbles[(std::size_t) position] = (std::int8_t) asSignedNibble(pattern);
+            unsignedNibbles[(std::size_t) position] = (std::uint8_t) pattern;
+
+            auto expected = std::array<int, 8> {};
+            expected[(std::size_t) position] = pattern;
+
+            const auto word = packedNibbles(expected.data());
+
+            check(int4x8FromNibbles(nibbles) == word);
+            check(uint4x8FromNibbles(unsignedNibbles) == word);
+            check(int4x8ToNibble(word, position) == asSignedNibble(pattern));
+            check(uint4x8ToNibble(word, position) == pattern);
+        }
+    }
+};
+
+auto tReadInt8 = test("PackedQuantized/readsEverySignedByteByIndex") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+    auto count = patterns.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * (int) sizeof(float));
+
+    auto kernel = ReadInt8Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, count);
+    auto result = floatsOf(output);
+
+    // Exactly, not within a tolerance: every value a byte encodes is an
+    // integer a float holds outright, so any difference at all is a fault.
+    for (auto i = 0; i < count; ++i)
+        check(result[i] == (float) asSignedByte(patterns[i]));
+};
+
+auto tReadUInt8 = test("PackedQuantized/readsEveryUnsignedByteByIndex") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+    auto count = patterns.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * (int) sizeof(float));
+
+    auto kernel = ReadUInt8Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, count);
+    auto result = floatsOf(output);
+
+    for (auto i = 0; i < count; ++i)
+        check(result[i] == (float) patterns[i]);
+};
+
+auto tQuantizedReadLiteral = test("PackedQuantized/readsBytesAtLiteralIndices") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(8 * (int) sizeof(float));
+
+    auto kernel = LiteralInt8Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, 1);
+    auto result = floatsOf(output);
+
+    for (auto i = 0; i < 8; ++i)
+        check(result[i] == (float) asSignedByte(patterns[i]));
+};
+
+auto tReadInt8x4 = test("PackedQuantized/readInt8x4ReadsAllFourOfAWord") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+    auto count = words.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * 4 * (int) sizeof(float));
+
+    auto kernel = ReadInt8x4Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, count);
+    auto result = floatsOf(output);
+
+    // Component by component this is the same walk readInt8 makes, which is
+    // what says the two index conventions address one layout.
+    for (auto element = 0; element < patterns.size(); ++element)
+        check(result[element] == (float) asSignedByte(patterns[element]));
+};
+
+auto tReadUInt8x4 = test("PackedQuantized/readUInt8x4ReadsAllFourOfAWord") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+    auto count = words.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * 4 * (int) sizeof(float));
+
+    auto kernel = ReadUInt8x4Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, count);
+    auto result = floatsOf(output);
+
+    for (auto element = 0; element < patterns.size(); ++element)
+        check(result[element] == (float) patterns[element]);
+};
+
+auto tReadInt4x8 = test("PackedQuantized/readInt4x8ReadsEightNibbles") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyNibblePattern();
+    auto words = wordsOfNibbles(patterns);
+    auto count = words.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * 8 * (int) sizeof(float));
+
+    auto kernel = ReadInt4x8Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, count);
+    auto result = floatsOf(output);
+
+    // The low four then the high four, which is nibble 0 through nibble 7 of
+    // the word in order.
+    for (auto element = 0; element < patterns.size(); ++element)
+        check(result[element] == (float) asSignedNibble(patterns[element]));
+};
+
+auto tReadUInt4x8 = test("PackedQuantized/readUInt4x8ReadsEightNibbles") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyNibblePattern();
+    auto words = wordsOfNibbles(patterns);
+    auto count = words.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * 8 * (int) sizeof(float));
+
+    auto kernel = ReadUInt4x8Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, count);
+    auto result = floatsOf(output);
+
+    for (auto element = 0; element < patterns.size(); ++element)
+        check(result[element] == (float) patterns[element]);
+};
+
+// The wide reads, over buffers holding every byte value at every one of the
+// eight or sixteen positions of a record. A four-wide read has four places a
+// shift can be wrong in; a sixteen-wide read has sixteen, and the four extra
+// ones a swizzle of the vector load can be wrong in on top of that, which is
+// exactly what a narrower fixture would miss.
+auto tReadInt8x8 = test("PackedQuantized/readInt8x8ReadsEightAcrossTwoWords") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePatternIn(8);
+
+    checkWidensEveryPattern<ReadInt8x8Kernel>(
+        device, wordsOfBytes(patterns), patterns, 8, asSignedByte);
+};
+
+auto tReadUInt8x8 = test("PackedQuantized/readUInt8x8ReadsEightAcrossTwoWords") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePatternIn(8);
+
+    checkWidensEveryPattern<ReadUInt8x8Kernel>(
+        device, wordsOfBytes(patterns), patterns, 8, asUnsignedValue);
+};
+
+auto tReadInt8x16 =
+    test("PackedQuantized/readInt8x16ReadsSixteenAcrossFourWords") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePatternIn(16);
+
+    checkWidensEveryPattern<ReadInt8x16Kernel>(
+        device, wordsOfBytes(patterns), patterns, 16, asSignedByte);
+};
+
+auto tReadUInt8x16 =
+    test("PackedQuantized/readUInt8x16ReadsSixteenAcrossFourWords") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePatternIn(16);
+
+    checkWidensEveryPattern<ReadUInt8x16Kernel>(
+        device, wordsOfBytes(patterns), patterns, 16, asUnsignedValue);
+};
+
+auto tReadInt4x16 = test("PackedQuantized/readInt4x16ReadsSixteenNibbles") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyNibblePatternIn(16);
+
+    checkWidensEveryPattern<ReadInt4x16Kernel>(
+        device, wordsOfNibbles(patterns), patterns, 16, asSignedNibble);
+};
+
+auto tReadUInt4x16 = test("PackedQuantized/readUInt4x16ReadsSixteenNibbles") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyNibblePatternIn(16);
+
+    checkWidensEveryPattern<ReadUInt4x16Kernel>(
+        device, wordsOfNibbles(patterns), patterns, 16, asUnsignedValue);
+};
+
+// One layout, three widths of read over it: element 16k + j of a byte buffer is
+// component j of readInt8x16(k) and component j % 8 of readInt8x8(2k + j / 8).
+//
+// Said by reading the same buffer three ways and comparing the results, rather
+// than by checking each against the same table: a table that is wrong about
+// what the bytes mean would let all three pass, where this only passes if they
+// agree with each other, and the tests above already pin what they agree on.
+auto tWideReadsAgreeWithTheByteIndex =
+    test("PackedQuantized/theWideReadsAgreeWithTheByteIndex") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePatternIn(16);
+    auto words = wordsOfBytes(patterns);
+    auto count = patterns.size();
+
+    auto input = storageOf(device, words);
+
+    auto readEachWay = [&](auto&& kernel, int records)
+    {
+        auto output = device.makeBuffer(count * (int) sizeof(float));
+
+        kernel.weights = input;
+        kernel.output = output;
+        kernel.prepare(device);
+
+        runKernel(device, kernel, records);
+
+        return floatsOf(output);
+    };
+
+    auto scalar = readEachWay(ReadInt8Kernel {}, count);
+    auto pairs = readEachWay(ReadInt8x8Kernel {}, count / 8);
+    auto quads = readEachWay(ReadInt8x16Kernel {}, count / 16);
+
+    for (auto i = 0; i < count; ++i)
+    {
+        check(pairs[i] == scalar[i]);
+        check(quads[i] == scalar[i]);
+    }
+};
+
+// And the same for nibbles: sixteen of them are two of readInt4x8's words, in
+// that order.
+auto tWideNibbleReadsAgree =
+    test("PackedQuantized/theWideNibbleReadAgreesWithTheNarrowOne") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyNibblePatternIn(16);
+    auto words = wordsOfNibbles(patterns);
+    auto count = patterns.size();
+
+    auto input = storageOf(device, words);
+
+    auto narrowOutput = device.makeBuffer(count * (int) sizeof(float));
+    auto wideOutput = device.makeBuffer(count * (int) sizeof(float));
+
+    auto narrow = ReadInt4x8Kernel {};
+    narrow.weights = input;
+    narrow.output = narrowOutput;
+    narrow.prepare(device);
+    runKernel(device, narrow, words.size());
+
+    auto wide = ReadInt4x16Kernel {};
+    wide.weights = input;
+    wide.output = wideOutput;
+    wide.prepare(device);
+    runKernel(device, wide, count / 16);
+
+    auto narrowValues = floatsOf(narrowOutput);
+    auto wideValues = floatsOf(wideOutput);
+
+    for (auto i = 0; i < count; ++i)
+        check(wideValues[i] == narrowValues[i]);
+};
+
+// What the wide reads are for, on the real ComputeProgram path: sixteen bytes
+// reach the kernel through the one record read sixteen bytes of floats take,
+// and no more.
+//
+// Correctness would survive four separate reads of the same address - the
+// reason to store weights as bytes would not. A kernel issuing a load per four
+// weights issues as many as a bf16 kernel does for twice the data and becomes
+// bound by how fast it can ask, which is the whole point of the widths.
+//
+// Counted against a read4 of plain floats rather than against a Metal pointer
+// cast, so the assertion is the same one on whichever dialect the machine
+// running the suite emits.
+auto tWideReadCostsOneRecordRead =
+    test("PackedQuantized/aWideReadCostsOneRecordRead") = []
+{
+    auto twoFloats = PlainRead2Kernel {};
+    auto fourFloats = PlainRead4Kernel {};
+    auto pair = ReadInt8x8Kernel {};
+    auto quad = ReadInt8x16Kernel {};
+    auto nibbles = ReadInt4x16Kernel {};
+
+    auto accesses = [](const ComputeProgram& kernel)
+    { return countOccurrences(kernel.source().source, "buffer0"); };
+
+    check(accesses(quad) == accesses(fourFloats));
+    check(accesses(pair) == accesses(twoFloats));
+
+    // Sixteen nibbles are eight bytes, so they cost the narrower read and
+    // twice as many widenings of what it brought back.
+    check(accesses(nibbles) == accesses(twoFloats));
+
+    // One definition and four calls each: every word of the record widened
+    // once, off the one value the load landed in.
+    check(countOccurrences(quad.source().source, "eacpUnpackInt8x4(") == 5);
+    check(countOccurrences(nibbles.source().source, "eacpUnpackInt4x4(") == 5);
+};
+
+// Widening and packing back is exact for every byte there is: the integer in
+// between holds all eight bits and nothing is rounded on either leg.
+auto tQuantizedRoundTrip = test("PackedQuantized/packRoundTripsEveryByte") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+    auto count = words.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * (int) sizeof(std::uint32_t));
+
+    auto signedKernel = RoundTripInt8Kernel {};
+    signedKernel.weights = input;
+    signedKernel.output = output;
+    signedKernel.prepare(device);
+
+    runKernel(device, signedKernel, count);
+
+    for (auto i = 0; i < count; ++i)
+        check(wordsOf(output)[i] == words[i]);
+
+    auto unsignedKernel = RoundTripUInt8Kernel {};
+    unsignedKernel.weights = input;
+    unsignedKernel.output = output;
+    unsignedKernel.prepare(device);
+
+    runKernel(device, unsignedKernel, count);
+
+    for (auto i = 0; i < count; ++i)
+        check(wordsOf(output)[i] == words[i]);
+};
+
+// writeInt8x4 is the store the round trip spells out by hand, so the two
+// kernels have to emit the same body and produce the same bytes.
+auto tWriteIsTheStore = test("PackedQuantized/writeInt8x4IsThePackedStore") = []
+{
+    auto spelledOut = RoundTripInt8Kernel {};
+    auto shorthand = WriteInt8x4Kernel {};
+
+    check(spelledOut.source().source == shorthand.source().source);
+
+    auto spelledOutUnsigned = RoundTripUInt8Kernel {};
+    auto shorthandUnsigned = WriteUInt8x4Kernel {};
+
+    check(spelledOutUnsigned.source().source == shorthandUnsigned.source().source);
+
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = wordsOfBytes(patterns);
+    auto count = words.size();
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(count * (int) sizeof(std::uint32_t));
+
+    shorthand.weights = input;
+    shorthand.output = output;
+    shorthand.prepare(device);
+
+    runKernel(device, shorthand, count);
+    auto result = wordsOf(output);
+
+    for (auto i = 0; i < count; ++i)
+        check(result[i] == words[i]);
+};
+
+// A buffer packed by the host helpers, read back by the shader: the two sides
+// of the layout, checked against each other rather than each against itself.
+auto tHostPackedBufferReadsBack =
+    test("PackedQuantized/aHostPackedBufferReadsBackExactly") = []
+{
+    auto& device = Device::shared();
+
+    if (!device.isValid())
+        return;
+
+    auto patterns = everyBytePattern();
+    auto words = Vector<std::uint32_t> {};
+
+    for (auto i = 0; i < patterns.size(); i += 4)
+        words.add(int8x4FromBytes({(std::int8_t) asSignedByte(patterns[i]),
+                                   (std::int8_t) asSignedByte(patterns[i + 1]),
+                                   (std::int8_t) asSignedByte(patterns[i + 2]),
+                                   (std::int8_t) asSignedByte(patterns[i + 3])}));
+
+    auto input = storageOf(device, words);
+    auto output = device.makeBuffer(patterns.size() * (int) sizeof(float));
+
+    auto kernel = ReadInt8Kernel {};
+    kernel.weights = input;
+    kernel.output = output;
+    kernel.prepare(device);
+
+    runKernel(device, kernel, patterns.size());
+    auto result = floatsOf(output);
+
+    for (auto i = 0; i < patterns.size(); ++i)
+        check(result[i] == (float) asSignedByte(patterns[i]));
+
+    auto nibblePatterns = everyNibblePattern();
+    auto nibbleWords = Vector<std::uint32_t> {};
+
+    for (auto i = 0; i < nibblePatterns.size(); i += 8)
+    {
+        auto nibbles = std::array<std::int8_t, 8> {};
+
+        for (auto n = std::size_t {}; n < nibbles.size(); ++n)
+            nibbles[n] = (std::int8_t) asSignedNibble(nibblePatterns[i + (int) n]);
+
+        nibbleWords.add(int4x8FromNibbles(nibbles));
+    }
+
+    auto nibbleInput = storageOf(device, nibbleWords);
+    auto nibbleOutput =
+        device.makeBuffer(nibblePatterns.size() * (int) sizeof(float));
+
+    auto nibbleKernel = ReadInt4x8Kernel {};
+    nibbleKernel.weights = nibbleInput;
+    nibbleKernel.output = nibbleOutput;
+    nibbleKernel.prepare(device);
+
+    runKernel(device, nibbleKernel, nibbleWords.size());
+    auto nibbleResult = floatsOf(nibbleOutput);
+
+    for (auto i = 0; i < nibblePatterns.size(); ++i)
+        check(nibbleResult[i] == (float) asSignedNibble(nibblePatterns[i]));
+};
+
+// Both backends' source, generated on whichever host runs the suite - the
+// Windows half being the one that cannot be executed here.
+auto tQuantizedSourceIsRight =
+    test("PackedQuantized/bothBackendsSpellTheHelpers") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    auto nibbles = weights.readInt4x8(i);
+
+    builder.write(output, i, weights.readInt8(i));
+    builder.write(output, i + 1u, weights.readUInt8(i));
+    builder.write(output, i * 4u + 4u, weights.readInt8x4(i));
+    builder.write(output, i * 4u + 5u, nibbles.low + nibbles.high);
+    builder.writeInt8x4(output, i + 6u, toInt(weights.readInt8x4(i)));
+
+    auto metal = emitMetal(builder.graph());
+    auto hlsl = emitHlsl(builder.graph());
+
+    for (const auto& source: {metal, hlsl})
+    {
+        check(contains(source, "float eacpReadInt8(uint bits, uint byteIndex)"));
+        check(contains(source, "float eacpReadUInt8(uint bits, uint byteIndex)"));
+        check(contains(source, "float4 eacpUnpackInt8x4(uint bits)"));
+        check(contains(source, "float4 eacpUnpackInt4x4(uint bits)"));
+        check(contains(source, "uint eacpPackInt8x4(int4 values)"));
+
+        // The sign extension, which is the same arithmetic in both because
+        // nothing delegates it to the language.
+        check(contains(source, "return float(value ^ 0x80u) - 128.0;"));
+        check(contains(source, "float((bits & 0xffu) ^ 0x80u) - 128.0"));
+        check(contains(source, "float((bits & 0xfu) ^ 0x8u) - 8.0"));
+
+        // And no dialect's own cast anywhere near it.
+        check(!contains(source, "char4"));
+        check(!contains(source, "int8_t"));
+    }
+
+    check(contains(metal, "as_type<uint>("));
+    check(contains(hlsl, "asuint("));
+    check(!contains(hlsl, "as_type"));
+};
+
+// Each helper is emitted only into shaders that call it, so a kernel reading
+// bytes carries no nibble helper and one that quantizes nothing carries none.
+auto tQuantizedHelpersAreNotAlwaysEmitted =
+    test("PackedQuantized/emitsEachHelperOnlyWhenUsed") = []
+{
+    auto plain = PlainQuantizedKernel {};
+    auto readingBytes = ReadInt8Kernel {};
+    auto readingNibbles = ReadInt4x8Kernel {};
+    auto packing = RoundTripInt8Kernel {};
+
+    check(!contains(plain.source().source, "eacpReadInt8"));
+    check(!contains(plain.source().source, "eacpUnpackInt8x4"));
+    check(!contains(plain.source().source, "eacpUnpackInt4x4"));
+    check(!contains(plain.source().source, "eacpPackInt8x4"));
+
+    check(contains(readingBytes.source().source, "eacpReadInt8"));
+    check(!contains(readingBytes.source().source, "eacpUnpackInt4x4"));
+    check(!contains(readingBytes.source().source, "eacpPackInt8x4"));
+
+    check(contains(readingNibbles.source().source, "eacpUnpackInt4x4"));
+    check(!contains(readingNibbles.source().source, "eacpUnpackUInt4x4"));
+    check(!contains(readingNibbles.source().source, "eacpReadInt8"));
+
+    check(contains(packing.source().source, "eacpPackInt8x4"));
+    check(contains(packing.source().source, "eacpUnpackInt8x4"));
+    check(!contains(packing.source().source, "eacpPackUInt8x4"));
+
+    // And the definition arrives before the body that calls it.
+    const auto& source = readingNibbles.source().source;
+    check(source.find("eacpUnpackInt4x4") < source.rfind("eacpUnpackInt4x4"));
+};

--- a/Tests/GPU/ShaderCodegenTests.cpp
+++ b/Tests/GPU/ShaderCodegenTests.cpp
@@ -3003,6 +3003,310 @@ auto tCodegenGlslBFloat16Helpers = test("GPU/codegenGlslBFloat16Helpers") = []
     expectGlslCompiles(graph);
 };
 
+// The int8 reads, per backend. Nothing here is a builtin anywhere, and the
+// arithmetic is integer arithmetic all three define the same way - which is why
+// one helper string serves Metal and DirectX, and why the GLSL differs only in
+// its type names.
+auto tCodegenInt8Helpers = test("GPU/codegenInt8ReadHelpers") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    builder.write(output, i, weights.readInt8(i));
+    builder.write(output, i + 1u, weights.readUInt8(i));
+    builder.write(output, i + 2u, weights.readInt8x4(i));
+    builder.write(output, i + 3u, weights.readUInt8x4(i));
+    builder.writeInt8x4(output, i + 4u, toInt(weights.readInt8x4(i)));
+    builder.writeUInt8x4(output, i + 5u, toUInt(weights.readUInt8x4(i)));
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    // The scalar reads count bytes, so the word and the byte within it are
+    // computed at the call site and the helper is handed both.
+    for (const auto& source: {metal, hlsl, glsl})
+    {
+        check(contains(source, "uint t0 = (gid / 4u);"));
+        check(contains(source, "uint t1 = (gid % 4u);"));
+
+        check(contains(source, "float eacpReadInt8(uint bits, uint byteIndex)"));
+        check(contains(source, "uint value = (bits >> (8u * byteIndex)) & 0xffu;"));
+        check(contains(source, "return float(value ^ 0x80u) - 128.0;"));
+        check(contains(source, "float eacpReadUInt8(uint bits, uint byteIndex)"));
+
+        // The sign extension, which is the one thing that has to be the same
+        // arithmetic everywhere rather than each dialect's own cast.
+        check(contains(source, "float((bits & 0xffu) ^ 0x80u) - 128.0"));
+        check(!contains(source, "char4"));
+    }
+
+    check(contains(metal, "float4 eacpUnpackInt8x4(uint bits)"));
+    check(contains(metal, "float4 eacpUnpackUInt8x4(uint bits)"));
+    check(contains(metal, "uint eacpPackInt8x4(int4 values)"));
+    check(contains(metal, "uint eacpPackUInt8x4(uint4 values)"));
+    check(contains(metal, "as_type<float>(eacpPackInt8x4(int4("));
+
+    check(contains(hlsl, "float4 eacpUnpackInt8x4(uint bits)"));
+    check(contains(hlsl, "float4 eacpUnpackUInt8x4(uint bits)"));
+    check(contains(hlsl, "uint eacpPackInt8x4(int4 values)"));
+    check(contains(hlsl, "uint eacpPackUInt8x4(uint4 values)"));
+    check(contains(hlsl, "asfloat(eacpPackInt8x4(int4("));
+    check(!contains(hlsl, "as_type"));
+
+    check(contains(glsl, "vec4 eacpUnpackInt8x4(uint bits)"));
+    check(contains(glsl, "vec4 eacpUnpackUInt8x4(uint bits)"));
+    check(contains(glsl, "uint eacpPackInt8x4(ivec4 values)"));
+    check(contains(glsl, "uint eacpPackUInt8x4(uvec4 values)"));
+    check(contains(glsl, "uintBitsToFloat(eacpPackInt8x4(ivec4("));
+    check(!contains(glsl, "as_type"));
+    check(!contains(glsl, "asfloat"));
+    check(!contains(glsl, "float4"));
+
+    // The packer masks in the signed domain before it converts, so the
+    // conversion it does make is of a value in 0..255.
+    for (const auto& source: {metal, hlsl, glsl})
+        check(contains(source, "uint(values.x & 0xff) | (uint(values.y & 0xff)"));
+
+    expectGlslCompiles(graph);
+};
+
+// The nibble reads. Eight values come out of one word as two float4s over one
+// load, the high half being the low half of the word shifted down sixteen -
+// which is a shift node in the graph rather than a second helper.
+auto tCodegenInt4Helpers = test("GPU/codegenInt4ReadHelpers") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    auto signedNibbles = weights.readInt4x8(i);
+    auto unsignedNibbles = weights.readUInt4x8(i);
+
+    builder.write(output, i * 4u, signedNibbles.low);
+    builder.write(output, i * 4u + 1u, signedNibbles.high);
+    builder.write(output, i * 4u + 2u, unsignedNibbles.low);
+    builder.write(output, i * 4u + 3u, unsignedNibbles.high);
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    for (const auto& source: {metal, hlsl, glsl})
+    {
+        // One definition and two calls for each of the two, which is what says
+        // the high half reuses the low half's helper.
+        check(countOccurrences(source, "eacpUnpackInt4x4(") == 3);
+        check(countOccurrences(source, "eacpUnpackUInt4x4(") == 3);
+
+        // Two's complement over [-8, 7], written as the same exclusive-or and
+        // subtraction the byte reads use.
+        check(contains(source, "float((bits & 0xfu) ^ 0x8u) - 8.0"));
+
+        // The high half is that same helper over the word shifted down
+        // sixteen, and the word is fetched once for the four values either
+        // side of the shift - which is the whole reason the pair comes back
+        // from one call rather than from a Low and a High.
+        check(contains(source, "eacpUnpackInt4x4((t2 >> 16u))"));
+        check(contains(source, "eacpUnpackUInt4x4((t7 >> 16u))"));
+        check(countOccurrences(source, "buffer0[gid]") == 2);
+    }
+
+    check(contains(metal, "float4 eacpUnpackInt4x4(uint bits)"));
+    check(contains(metal, "float4 eacpUnpackUInt4x4(uint bits)"));
+    check(contains(metal, "uint t2 = as_type<uint>(buffer0[gid]);"));
+
+    check(contains(hlsl, "float4 eacpUnpackInt4x4(uint bits)"));
+    check(contains(hlsl, "uint t2 = asuint(buffer0[gid]);"));
+
+    check(contains(glsl, "vec4 eacpUnpackInt4x4(uint bits)"));
+    check(contains(glsl, "vec4 eacpUnpackUInt4x4(uint bits)"));
+    check(contains(glsl, "uint t2 = floatBitsToUint(buffer0[gid]);"));
+    check(!contains(glsl, "float4"));
+
+    expectGlslCompiles(graph);
+};
+
+// Sixteen bytes in one load. This is the whole claim readInt8x16 makes, so it
+// is the emitted text the test pins rather than the values, which the device
+// suite covers: one packed vector load into a local, and the four words as four
+// swizzles of it.
+//
+// It matters because nothing downstream would catch it going wrong. Four
+// subscripts of the same address is still correct arithmetic - it just issues
+// four loads where the point of storing weights as bytes was to issue one, and
+// the kernel goes back to being bound by how fast it can ask for memory. The
+// graph shares constants and pure binaries and not reads, so it is the single
+// record node that makes this one load, not a compiler noticing anything.
+auto tCodegenWideInt8Reads = test("GPU/codegenWideInt8Reads") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    auto quad = weights.readInt8x16(i);
+
+    builder.write(output, i * 4u, quad.a);
+    builder.write(output, i * 4u + 1u, quad.b);
+    builder.write(output, i * 4u + 2u, quad.c);
+    builder.write(output, i * 4u + 3u, quad.d);
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    // Sixteen bytes through a packed_uint4-shaped pointer, once, and no
+    // element subscript of the weights anywhere.
+    check(contains(
+        metal,
+        "float4 t2 = float4(*((device const packed_float4*) (buffer0 + t0)));"));
+    check(countOccurrences(metal, "buffer0 + t0") == 1);
+    check(!contains(metal, "buffer0["));
+
+    // And the four words are swizzles of that one local rather than four
+    // reads - which is what makes the load count one rather than four.
+    check(contains(metal, "eacpUnpackInt8x4(as_type<uint>((t2).x))"));
+    check(contains(metal, "eacpUnpackInt8x4(as_type<uint>((t2).y))"));
+    check(contains(metal, "eacpUnpackInt8x4(as_type<uint>((t2).z))"));
+    check(contains(metal, "eacpUnpackInt8x4(as_type<uint>((t2).w))"));
+
+    // One definition and four calls.
+    check(countOccurrences(metal, "eacpUnpackInt8x4(") == 5);
+
+    // The other two spell the record as the componentwise construct read4
+    // already emits there, for the reason ExprKind::BufferVectorRead gives: a
+    // StructuredBuffer<float> and an std430 block of floats have no way to
+    // reinterpret themselves. Four subscripts, not sixteen, and still one
+    // widening per word.
+    check(contains(hlsl,
+                   "float4 t2 = float4(buffer0[t0], buffer0[t0 + 1u], "
+                   "buffer0[t0 + 2u], buffer0[t0 + 3u]);"));
+    check(countOccurrences(hlsl, "buffer0[t0") == 4);
+    check(contains(hlsl, "eacpUnpackInt8x4(asuint((t2).x))"));
+    check(contains(hlsl, "eacpUnpackInt8x4(asuint((t2).w))"));
+    check(countOccurrences(hlsl, "eacpUnpackInt8x4(") == 5);
+
+    check(contains(glsl,
+                   "vec4 t2 = vec4(buffer0[t0], buffer0[t0 + 1u], "
+                   "buffer0[t0 + 2u], buffer0[t0 + 3u]);"));
+    check(countOccurrences(glsl, "buffer0[t0") == 4);
+    check(contains(glsl, "eacpUnpackInt8x4(floatBitsToUint((t2).x))"));
+    check(contains(glsl, "eacpUnpackInt8x4(floatBitsToUint((t2).w))"));
+    check(!contains(glsl, "float4"));
+
+    expectGlslCompiles(graph);
+};
+
+// Eight bytes in one load, which is the same eight bytes readBFloat16x4 fetches
+// - so an int8 walk issues the loads a bf16 walk does for twice the weights.
+auto tCodegenWideInt8PairReads = test("GPU/codegenWideInt8PairReads") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    auto pair = weights.readUInt8x8(i);
+
+    builder.write(output, i * 2u, pair.low);
+    builder.write(output, i * 2u + 1u, pair.high);
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    check(contains(
+        metal,
+        "float2 t2 = float2(*((device const packed_float2*) (buffer0 + t0)));"));
+    check(countOccurrences(metal, "buffer0 + t0") == 1);
+    check(!contains(metal, "buffer0["));
+
+    check(contains(metal, "eacpUnpackUInt8x4(as_type<uint>((t2).x))"));
+    check(contains(metal, "eacpUnpackUInt8x4(as_type<uint>((t2).y))"));
+    check(countOccurrences(metal, "eacpUnpackUInt8x4(") == 3);
+
+    check(contains(hlsl, "float2 t2 = float2(buffer0[t0], buffer0[t0 + 1u]);"));
+    check(countOccurrences(hlsl, "buffer0[t0") == 2);
+    check(contains(hlsl, "eacpUnpackUInt8x4(asuint((t2).y))"));
+
+    check(contains(glsl, "vec2 t2 = vec2(buffer0[t0], buffer0[t0 + 1u]);"));
+    check(countOccurrences(glsl, "buffer0[t0") == 2);
+    check(contains(glsl, "eacpUnpackUInt8x4(floatBitsToUint((t2).y))"));
+    check(!contains(glsl, "float4"));
+
+    expectGlslCompiles(graph);
+};
+
+// Sixteen nibbles are those same eight bytes, so the wide nibble read is the
+// wide byte read's load with the nibble helper over it - twice per word, the
+// high four being the word shifted down sixteen.
+auto tCodegenWideInt4Reads = test("GPU/codegenWideInt4Reads") = []
+{
+    auto builder = ShaderBuilder {};
+
+    auto weights = builder.inputBuffer();
+    auto output = builder.outputBuffer();
+    auto i = builder.threadId();
+
+    auto quad = weights.readInt4x16(i);
+
+    builder.write(output, i * 4u, quad.a);
+    builder.write(output, i * 4u + 1u, quad.b);
+    builder.write(output, i * 4u + 2u, quad.c);
+    builder.write(output, i * 4u + 3u, quad.d);
+
+    const auto& graph = builder.graph();
+    auto metal = emitMetal(graph);
+    auto hlsl = emitHlsl(graph);
+    auto glsl = emitGlsl(graph);
+
+    check(contains(
+        metal,
+        "float2 t3 = float2(*((device const packed_float2*) (buffer0 + t2)));"));
+    check(countOccurrences(metal, "buffer0 + t2") == 1);
+    check(!contains(metal, "buffer0["));
+
+    check(contains(metal, "uint t4 = as_type<uint>((t3).x);"));
+    check(contains(metal, "uint t9 = as_type<uint>((t3).y);"));
+
+    check(contains(hlsl, "float2 t3 = float2(buffer0[t2], buffer0[t2 + 1u]);"));
+    check(contains(hlsl, "uint t4 = asuint((t3).x);"));
+    check(countOccurrences(hlsl, "buffer0[t2") == 2);
+
+    check(contains(glsl, "vec2 t3 = vec2(buffer0[t2], buffer0[t2 + 1u]);"));
+    check(contains(glsl, "uint t4 = floatBitsToUint((t3).x);"));
+    check(countOccurrences(glsl, "buffer0[t2") == 2);
+    check(!contains(glsl, "float4"));
+
+    // Both halves of each word from the one helper, the high half over the
+    // shift - so sixteen values cost one load, two reinterpretations and four
+    // calls, and the word a pair of calls shares is named once rather than
+    // recomputed.
+    for (const auto& source: {metal, hlsl, glsl})
+    {
+        check(countOccurrences(source, "eacpUnpackInt4x4(") == 5);
+        check(contains(source, "eacpUnpackInt4x4(t4)"));
+        check(contains(source, "eacpUnpackInt4x4((t4 >> 16u))"));
+        check(contains(source, "eacpUnpackInt4x4(t9)"));
+        check(contains(source, "eacpUnpackInt4x4((t9 >> 16u))"));
+        check(contains(source, "float((bits & 0xfu) ^ 0x8u) - 8.0"));
+    }
+
+    expectGlslCompiles(graph);
+};
+
 // A GLSL sampler2D over a depth image hands back four channels, so the call
 // takes .r; on MSL and HLSL the declared type does that instead.
 auto tCodegenGlslDepthSample = test("GPU/codegenGlslDepthSample") = []


### PR DESCRIPTION
## Summary

Int8 and int4 block-quantized weights need to be read the way `readHalf` and `readBFloat16` read packed sixteen-bit ones, and the EDSL stopped at the half. Found while writing gemma-2b's int8 path against it (HuggingFaceEACP, plan.md gap 6). Every addition mirrors the bf16 family in naming, index convention and emitter shape.

- `InputBuffer::readInt8` / `readUInt8` counting bytes; `readInt8x4` / `readUInt8x4` counting words; `readInt8x8` (`Float4Pair`) counting records of eight; `readInt8x16` (`Float4Quad`) counting records of sixteen. The wide ones are one packed vector load on Metal, the same load `read4` emits, with four register bitcasts and no second buffer access.
- `readInt4x8` / `readUInt4x8` (`Float4Pair`) and `readInt4x16` / `readUInt4x16` (`Float4Quad`) over nibbles.
- `unpackInt8x4` / `unpackUInt8x4` / `unpackInt4x8` / `unpackUInt4x8` and `packInt8x4` / `packUInt8x4` free functions; `writeInt8x4` / `writeUInt8x4` on `ShaderBuilder` and `ComputeProgram`.
- Host helpers `int8x4FromBytes`, `int4x8FromNibbles` and their inverses in `PackedVertex.h`.

Sign extension is `(b ^ 0x80) - 128` (nibbles `(n ^ 0x8) - 8`), spelled identically in every dialect and on the host, so it is bit-identical everywhere without `as_type<char4>` or a reliance on each language's arithmetic-shift rule.

**Why the widths matter**, measured downstream and recorded in `Lib/eacp/GPU/README.md`: a four-byte read issues as many loads as an eight-byte bf16 read, so an int8 decode step bound by loads rather than bytes reached 299 GB/s where bf16 reached 433; sixteen weights per load took it to 375 GB/s.

Known limits, unchanged by this PR and noted in the README: HLSL and GLSL still expand a record read componentwise (as `read4` already does), so the single-load win is Metal-only; the graph does not share buffer reads across calls; `asUInt` stays scalar-only.

## Test plan

- [x] `GPUCodegenTests`: 93 passed. New tests assert MSL, HLSL and GLSL for every read, compile the GLSL through glslang, and assert a `readInt8x16` is exactly one subscript.
- [x] `GPUTests`: 452 passed. `PackedQuantizedTests.cpp` reads host-packed buffers covering every byte and nibble value at every position of every record width, exact equality; the three index conventions are asserted to address one layout.
- [x] Full `ctest`: 1779 of 1779 passed on macOS (Metal).
- [x] All 717 targets build with unity off; clang-format clean.
- [ ] CI on Windows and Linux lanes (this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PyWivvJrpKx6sYbDt3eUa4
