### PR TITLE
GPUView: resize hooks bracket the subclass, Frame knows its own size

### DIFF
--- a/Apps/GPU/Clipping/Main.cpp
+++ b/Apps/GPU/Clipping/Main.cpp
@@ -56,22 +56,23 @@ struct ClippingView final : GPU::GPUView
 
     void resized() override
     {
-        GPUView::resized();
-
-        const auto bounds = getLocalBounds();
-
-        // A resize only moves the logical space; the pipelines the renderer
-        // compiled are unaffected, so it is set rather than rebuilt.
-        if (bounds.w > 0 && bounds.h > 0)
-        {
-            if (sprites)
-                sprites->setLogicalSize({bounds.w, bounds.h});
-            else
-                sprites.emplace(Graphics::Point {bounds.w, bounds.h}, sampleCount());
-        }
-
         layOutPanes();
         repaint();
+    }
+
+    // A resize only moves the logical space; the pipelines the renderer compiled
+    // are unaffected, so it is set rather than rebuilt - and set from the frame,
+    // whose size is the one being drawn into whatever the layout pass has
+    // reached.
+    void ensureRenderer(Graphics::Point size)
+    {
+        if (size.x <= 0.f || size.y <= 0.f)
+            return;
+
+        if (sprites)
+            sprites->setLogicalSize(size);
+        else
+            sprites.emplace(size, sampleCount());
     }
 
     void layOutPanes()
@@ -166,6 +167,8 @@ struct ClippingView final : GPU::GPUView
 
     void render(GPU::Frame& frame) override
     {
+        ensureRenderer(frame.logicalSize());
+
         auto pass = frame.beginPass({background});
 
         if (!sprites)

--- a/Apps/GPU/GlyphAtlas/Main.cpp
+++ b/Apps/GPU/GlyphAtlas/Main.cpp
@@ -125,34 +125,26 @@ struct AtlasTextView final : GPU::GPUView
         builtAtScale = scale;
     }
 
-    void resized() override
+    void resized() override { repaint(); }
+
+    void ensureRenderers(Graphics::Point size)
     {
-        GPUView::resized();
+        if (size.x <= 0.f || size.y <= 0.f)
+            return;
 
-        const auto bounds = getLocalBounds();
+        if (sprites)
+            sprites->setLogicalSize(size);
+        else
+            sprites.emplace(size, sampleCount());
 
-        if (bounds.w > 0 && bounds.h > 0)
-        {
-            // Both renderers take the new size the same cheap way: it is a
-            // uniform on each, not anything either of them compiled.
-            if (sprites)
-                sprites->setLogicalSize({bounds.w, bounds.h});
-            else
-                sprites.emplace(Graphics::Point {bounds.w, bounds.h}, sampleCount());
+        if (!glyphs)
+            glyphs.emplace();
 
-            if (!glyphs)
-                glyphs.emplace();
-
-            glyphs->setViewportSize({bounds.w, bounds.h});
-        }
-
-        repaint();
+        glyphs->setViewportSize(size);
     }
 
     void backingScaleChanged() override
     {
-        GPUView::backingScaleChanged();
-
         // Glyphs cached for the old display are the wrong size now.
         ensureAtlas();
         repaint();
@@ -228,6 +220,9 @@ struct AtlasTextView final : GPU::GPUView
     {
         ensureAtlas();
 
+        const auto size = frame.logicalSize();
+        ensureRenderers(size);
+
         auto pass = frame.beginPass({background});
 
         if (!sprites || !glyphs || !atlas)
@@ -251,9 +246,9 @@ struct AtlasTextView final : GPU::GPUView
 
         for (const auto& line: lines)
         {
-            sprites->fillRect(
-                {0.f, baseline - metrics.ascent, getLocalBounds().w, lineHeight},
-                &line == &lines.back() ? gutter : Graphics::Color {0, 0, 0, 0});
+            sprites->fillRect({0.f, baseline - metrics.ascent, size.x, lineHeight},
+                              &line == &lines.back() ? gutter
+                                                     : Graphics::Color {0, 0, 0, 0});
 
             layOutLine(line, left, baseline, false);
             baseline += lineHeight;

--- a/Apps/GPU/TextureAtlas/Main.cpp
+++ b/Apps/GPU/TextureAtlas/Main.cpp
@@ -83,23 +83,21 @@ struct AtlasView final : GPU::GPUView
         setSampleCount(1);
     }
 
-    void resized() override
+    void resized() override { repaint(); }
+
+    // A resize only moves the logical space; the pipelines the renderer compiled
+    // are unaffected, so it is set rather than rebuilt - and set from the frame,
+    // whose size is the one being drawn into whatever the layout pass has
+    // reached.
+    void ensureRenderer(Graphics::Point size)
     {
-        GPUView::resized();
+        if (size.x <= 0.f || size.y <= 0.f)
+            return;
 
-        const auto bounds = getLocalBounds();
-
-        // A resize only moves the logical space; the pipelines the renderer
-        // compiled are unaffected, so it is set rather than rebuilt.
-        if (bounds.w > 0 && bounds.h > 0)
-        {
-            if (sprites)
-                sprites->setLogicalSize({bounds.w, bounds.h});
-            else
-                sprites.emplace(Graphics::Point {bounds.w, bounds.h}, sampleCount());
-        }
-
-        repaint();
+        if (sprites)
+            sprites->setLogicalSize(size);
+        else
+            sprites.emplace(size, sampleCount());
     }
 
     void addNextTile()
@@ -145,6 +143,9 @@ struct AtlasView final : GPU::GPUView
 
     void render(GPU::Frame& frame) override
     {
+        const auto size = frame.logicalSize();
+        ensureRenderer(size);
+
         auto pass = frame.beginPass({background});
 
         if (!sprites)
@@ -152,7 +153,7 @@ struct AtlasView final : GPU::GPUView
 
         sprites->begin(pass);
 
-        const auto bounds = getLocalBounds();
+        const auto bounds = Graphics::Rect {0.f, 0.f, size.x, size.y};
         const auto margin = 24.f;
         const auto barHeight = 10.f;
 

--- a/Apps/GPU/VariableFont/Main.cpp
+++ b/Apps/GPU/VariableFont/Main.cpp
@@ -185,32 +185,29 @@ struct VariableFontView final : GPU::GPUView
         staticColumn = specimenColumn + widest + columnGap;
     }
 
-    void resized() override
+    void resized() override { repaint(); }
+
+    // The size both renderers project from, taken off the frame each time: it
+    // is a uniform on each rather than anything they compiled, and read there it
+    // is always the size of the target being drawn into.
+    void ensureRenderers(Graphics::Point size)
     {
-        GPUView::resized();
+        if (size.x <= 0.f || size.y <= 0.f)
+            return;
 
-        const auto bounds = getLocalBounds();
+        if (sprites)
+            sprites->setLogicalSize(size);
+        else
+            sprites.emplace(size, sampleCount());
 
-        if (bounds.w > 0 && bounds.h > 0)
-        {
-            if (sprites)
-                sprites->setLogicalSize({bounds.w, bounds.h});
-            else
-                sprites.emplace(Graphics::Point {bounds.w, bounds.h}, sampleCount());
+        if (!glyphs)
+            glyphs.emplace();
 
-            if (!glyphs)
-                glyphs.emplace();
-
-            glyphs->setViewportSize({bounds.w, bounds.h});
-        }
-
-        repaint();
+        glyphs->setViewportSize(size);
     }
 
     void backingScaleChanged() override
     {
-        GPUView::backingScaleChanged();
-
         ensureAtlas();
         repaint();
     }
@@ -283,7 +280,7 @@ struct VariableFontView final : GPU::GPUView
             top + (rowHeight - metrics.lineHeight()) * 0.5f + metrics.ascent;
 
         if (pass == Pass::draw)
-            sprites->fillRect({0.f, top, getLocalBounds().w, rowHeight},
+            sprites->fillRect({0.f, top, sprites->getLogicalSize().x, rowHeight},
                               live ? liveRowFill : rowFill);
 
         const auto label = std::to_string(weight);
@@ -379,6 +376,7 @@ struct VariableFontView final : GPU::GPUView
     void render(GPU::Frame& frame) override
     {
         ensureAtlas();
+        ensureRenderers(frame.logicalSize());
 
         auto pass = frame.beginPass({background});
 

--- a/Lib/eacp/GPU/CMakeLists.txt
+++ b/Lib/eacp/GPU/CMakeLists.txt
@@ -42,6 +42,7 @@ target_link_libraries(eacp-gpu PUBLIC eacp-graphics eacp-gpu-codegen)
 target_sources(eacp-gpu PRIVATE
         Buffer/StreamingBuffers.cpp
         Device/Device.cpp
+        Frame/Frame.cpp
         Frame/RenderPass.cpp
         Timing/CommandTimer.cpp
         Timing/FrameTimer.cpp

--- a/Lib/eacp/GPU/Frame/Frame-Apple.mm
+++ b/Lib/eacp/GPU/Frame/Frame-Apple.mm
@@ -181,16 +181,32 @@ struct Frame::Native
     Device* device = nullptr;
 };
 
-Frame::Frame(Device& device, void* drawable, void* msaaTexture, void* depthTexture)
+Frame::Frame(Device& device,
+             void* drawable,
+             void* msaaTexture,
+             void* depthTexture,
+             float backingScaleToUse)
     : impl(device, drawable, msaaTexture, depthTexture)
+    , scale(backingScaleToUse)
 {
     device.beginFrame();
 }
 
-Frame::Frame(Device& device, const OffscreenTarget& target)
+Frame::Frame(Device& device, const OffscreenTarget& target, float backingScaleToUse)
     : impl(device, target)
+    , scale(backingScaleToUse)
 {
     device.beginFrame();
+}
+
+Graphics::Point Frame::pixelSize() const
+{
+    auto target = impl->storeTexture();
+
+    if (target == nil)
+        return {};
+
+    return {(float) target.width, (float) target.height};
 }
 
 Frame::~Frame()

--- a/Lib/eacp/GPU/Frame/Frame-Linux.cpp
+++ b/Lib/eacp/GPU/Frame/Frame-Linux.cpp
@@ -239,18 +239,36 @@ struct Frame::Native
     bool offscreen = false;
 };
 
-Frame::Frame(Device& device, void* drawable, void* msaaTexture, void* depthTexture)
+Frame::Frame(Device& device,
+             void* drawable,
+             void* msaaTexture,
+             void* depthTexture,
+             float backingScaleToUse)
     : impl(device, drawable, msaaTexture, depthTexture)
+    , scale(backingScaleToUse)
 {
     device.beginFrame();
     impl->beginTiming();
 }
 
-Frame::Frame(Device& device, const OffscreenTarget& target)
+Frame::Frame(Device& device, const OffscreenTarget& target, float backingScaleToUse)
     : impl(device, target)
+    , scale(backingScaleToUse)
 {
     device.beginFrame();
     impl->beginTiming();
+}
+
+// The swapchain image for a drawable frame and the app's texture off screen are
+// the same VulkanTextureData either way - the one beginPassOn takes its render
+// area and viewport from.
+Graphics::Point Frame::pixelSize() const
+{
+    if (impl->target == nullptr)
+        return {};
+
+    return {static_cast<float>(impl->target->width),
+            static_cast<float>(impl->target->height)};
 }
 
 Frame::~Frame()

--- a/Lib/eacp/GPU/Frame/Frame-Windows.cpp
+++ b/Lib/eacp/GPU/Frame/Frame-Windows.cpp
@@ -144,18 +144,35 @@ struct Frame::Native
     bool offscreen = false;
 };
 
-Frame::Frame(Device& device, void* drawable, void* msaaTexture, void* depthTexture)
+Frame::Frame(Device& device,
+             void* drawable,
+             void* msaaTexture,
+             void* depthTexture,
+             float backingScaleToUse)
     : impl(device, drawable, msaaTexture, depthTexture)
+    , scale(backingScaleToUse)
 {
     device.beginFrame();
     impl->beginTiming();
 }
 
-Frame::Frame(Device& device, const OffscreenTarget& target)
+Frame::Frame(Device& device, const OffscreenTarget& target, float backingScaleToUse)
     : impl(device, target)
+    , scale(backingScaleToUse)
 {
     device.beginFrame();
     impl->beginTiming();
+}
+
+// The back buffer's size, which the off-screen path carries in a D3D12Drawable
+// of its own - the same pair of numbers beginPass sets the viewport from.
+Graphics::Point Frame::pixelSize() const
+{
+    if (impl->drawable == nullptr)
+        return {};
+
+    return {static_cast<float>(impl->drawable->width),
+            static_cast<float>(impl->drawable->height)};
 }
 
 Frame::~Frame()

--- a/Lib/eacp/GPU/Frame/Frame.cpp
+++ b/Lib/eacp/GPU/Frame/Frame.cpp
@@ -1,0 +1,17 @@
+#include "Frame.h"
+
+namespace eacp::GPU
+{
+float Frame::backingScale() const
+{
+    return scale;
+}
+
+Graphics::Point Frame::logicalSize() const
+{
+    const auto pixels = pixelSize();
+    const auto divisor = scale > 0.f ? scale : 1.f;
+
+    return {pixels.x / divisor, pixels.y / divisor};
+}
+} // namespace eacp::GPU

--- a/Lib/eacp/GPU/Frame/Frame.h
+++ b/Lib/eacp/GPU/Frame/Frame.h
@@ -104,12 +104,39 @@ struct OffscreenTarget
 class Frame
 {
 public:
-    Frame(Device& device, void* drawable, void* msaaTexture, void* depthTexture);
-    Frame(Device& device, const OffscreenTarget& target);
+    Frame(Device& device,
+          void* drawable,
+          void* msaaTexture,
+          void* depthTexture,
+          float backingScaleToUse = 1.f);
+
+    Frame(Device& device,
+          const OffscreenTarget& target,
+          float backingScaleToUse = 1.f);
+
     ~Frame();
 
     Frame(const Frame&) = delete;
     Frame& operator=(const Frame&) = delete;
+
+    // The size of the target this frame draws into: the drawable's texture on
+    // screen, the app's texture off it.
+    //
+    // **This is what a projection set inside render() should be derived from.**
+    // A size cached in resized() is a different thing that is usually equal to
+    // it - what the view will be once the layout pass is over - and the one
+    // frame where the two disagree is a live resize, whose drawable is already
+    // the new size while the cached divisor is still the old one. Read off the
+    // frame, a projection cannot disagree with the viewport it draws through.
+    Graphics::Point pixelSize() const;
+
+    // Device pixels per logical point for this frame's target: the view's
+    // backing scale on screen, and the scale a snapshot was asked for off it.
+    float backingScale() const;
+
+    // pixelSize() in logical points - the units views, mouse events and the
+    // sprite and glyph renderers all work in.
+    Graphics::Point logicalSize() const;
 
     RenderPass beginPass(const RenderPassDescriptor& descriptor = {});
 
@@ -202,5 +229,7 @@ public:
 private:
     struct Native;
     Pimpl<Native> impl;
+
+    float scale = 1.f;
 };
 } // namespace eacp::GPU

--- a/Lib/eacp/GPU/View/GPUView-Apple.mm
+++ b/Lib/eacp/GPU/View/GPUView-Apple.mm
@@ -279,24 +279,19 @@ int GPUView::framesInFlight() const
     return impl->framesInFlight;
 }
 
-void GPUView::resized()
+// Serves both events: the drawable follows the new bounds or the new scale, and
+// updateSize() fires onBackingScaleChanged for itself when the scale is what
+// moved.
+void GPUView::resizeStarted()
 {
-    Graphics::View::resized();
     impl->updateSize();
-
-    // Draw at the new size now, synchronously within the layout/resize pass,
-    // instead of waiting for the async display link a frame or more later.
-    renderNow();
 }
 
-void GPUView::backingScaleChanged()
+void GPUView::resizeFinished()
 {
-    Graphics::View::backingScaleChanged();
-
-    // Resize the drawable to the new scale (same logical bounds, different pixel
-    // count) and fire onBackingScaleChanged, then redraw: the presented frame
-    // was rasterized for the old scale.
-    impl->updateSize();
+    // Synchronously inside the layout pass, and after the subclass has answered
+    // the new size: presentsWithTransaction makes this the frame the compositor
+    // shows, so it has to be drawn with the new projection.
     renderNow();
 }
 
@@ -340,7 +335,8 @@ void GPUView::renderNow()
         auto frame = Frame(Device::shared(),
                            (__bridge void*) drawable,
                            (__bridge void*) impl->msaaTexture.get(),
-                           (__bridge void*) impl->depthTexture.get());
+                           (__bridge void*) impl->depthTexture.get(),
+                           backingScale());
         render(frame);
     }
 }
@@ -392,7 +388,7 @@ Graphics::Image GPUView::renderNativeContent(float scale)
             auto target = OffscreenTarget {(__bridge void*) colorTexture,
                                            (__bridge void*) msaaTexture,
                                            (__bridge void*) depthTexture};
-            auto frame = Frame(Device::shared(), target);
+            auto frame = Frame(Device::shared(), target, scale);
 
             // Rendered as a view of this scale: a snapshot at 1x on a 2x
             // display would otherwise rasterize its masks and glyphs, and
@@ -478,6 +474,10 @@ bool GPUView::renderNativeContentToTarget(void* nativeTarget, float)
     auto device = (__bridge id<MTLDevice>) Device::shared().nativeDevice();
     auto samples = (NSUInteger) impl->sampleCount;
 
+    const auto logicalWidth = getLocalBounds().w;
+    const auto targetScale =
+        logicalWidth > 0.f ? (float) pixelWidth / logicalWidth : backingScale();
+
     @autoreleasepool
     {
         // The colour target aliases the CVPixelBuffer's IOSurface, so render()
@@ -525,7 +525,12 @@ bool GPUView::renderNativeContentToTarget(void* nativeTarget, float)
         auto target = OffscreenTarget {(__bridge void*) colorTexture,
                                        (__bridge void*) msaaTexture,
                                        (__bridge void*) depthTexture};
-        auto frame = Frame(Device::shared(), target);
+
+        // Measured against the view rather than taken from the caller: the
+        // recorder sizes its buffers from a probe and rounds them to even, so
+        // the encoder's `scale` is not the one this buffer actually came out at,
+        // and it is this one that makes frame.logicalSize() the view's bounds.
+        auto frame = Frame(Device::shared(), target, targetScale);
         render(frame);
     }
 

--- a/Lib/eacp/GPU/View/GPUView-Linux.cpp
+++ b/Lib/eacp/GPU/View/GPUView-Linux.cpp
@@ -119,6 +119,22 @@ struct GPUView::Native
         return Graphics::linuxDefaultBackingScale;
     }
 
+    // A scale change tells itself apart from a resize by the surface's own
+    // scale. Nothing is recorded before a surface carries a real one, so the
+    // first that arrives is the initial scale rather than a change.
+    void notifyScaleChange()
+    {
+        if (record.surface == nullptr)
+            return;
+
+        const auto scale = surfaceScale();
+        const auto changed = backingScale > 0.f && scale != backingScale;
+        backingScale = scale;
+
+        if (changed)
+            view.onBackingScaleChanged(scale);
+    }
+
     void startContinuous()
     {
         stampedTick = Threads::DisplayLink::timedTick(
@@ -697,7 +713,7 @@ struct GPUView::Native
         record.requestFrameCallback();
 
         {
-            auto frame = Frame(gpu, &drawable, nullptr, nullptr);
+            auto frame = Frame(gpu, &drawable, nullptr, nullptr, surfaceScale());
             view.render(frame);
         }
 
@@ -771,6 +787,10 @@ struct GPUView::Native
     bool companionsStale = false;
     bool deviceLost = false;
     bool rendering = false;
+
+    // Zero until the surface reports one, which is how the initial scale is told
+    // apart from a change.
+    float backingScale = 0.f;
 
     Callback stampedTick = [] {};
 
@@ -873,17 +893,17 @@ int GPUView::framesInFlight() const
     return impl->framesInFlight;
 }
 
-void GPUView::resized()
+// No drawable to resize here: the swapchain is rebuilt from the surface's own
+// configure, so all this owes either event is the scale notification.
+void GPUView::resizeStarted()
 {
-    Graphics::View::resized();
+    impl->notifyScaleChange();
 }
 
-void GPUView::backingScaleChanged()
-{
-    Graphics::View::backingScaleChanged();
-
-    onBackingScaleChanged(backingScale());
-}
+// Nothing to order after the subclass: the swapchain is rebuilt from that
+// configure and the frame drawn from a frame callback, both after every
+// override has run.
+void GPUView::resizeFinished() {}
 
 float GPUView::backingScale() const
 {
@@ -940,7 +960,7 @@ Graphics::Image GPUView::renderNativeContent(float scale)
         auto target = OffscreenTarget {};
         target.colorTexture = texture.nativeTexture();
 
-        auto frame = Frame(device, target);
+        auto frame = Frame(device, target, scale);
 
         renderScale = scale;
         render(frame);

--- a/Lib/eacp/GPU/View/GPUView-Windows.cpp
+++ b/Lib/eacp/GPU/View/GPUView-Windows.cpp
@@ -174,6 +174,20 @@ struct GPUView::Native : DeviceResourceHolder
 
         updateMultisampleTexture();
         updateDepthTexture();
+
+        notifyScaleChange(scale);
+    }
+
+    // Told after the swapchain is consistent at the new scale, so a handler
+    // rebuilding pixel-sized resources sees what it will draw into. The first
+    // pass only records: there is no previous scale for it to differ from.
+    void notifyScaleChange(float newScale)
+    {
+        const auto changed = backingScale > 0.f && newScale != backingScale;
+        backingScale = newScale;
+
+        if (changed)
+            view.onBackingScaleChanged(newScale);
     }
 
     void createSwapChain()
@@ -476,7 +490,8 @@ struct GPUView::Native : DeviceResourceHolder
             auto frame = Frame(Device::shared(),
                                &drawable,
                                useMsaa ? &msaa : nullptr,
-                               useDepth ? &depth : nullptr);
+                               useDepth ? &depth : nullptr,
+                               dpiScale());
             view.render(frame);
         }
 
@@ -508,8 +523,8 @@ struct GPUView::Native : DeviceResourceHolder
             reported = true;
 
             char code[16] = {};
-            std::snprintf(code, sizeof(code), "0x%08lX",
-                          static_cast<unsigned long>(reason));
+            std::snprintf(
+                code, sizeof(code), "0x%08lX", static_cast<unsigned long>(reason));
 
             LOG("GPUView: the D3D12 device was removed, reason ", code);
         }
@@ -559,6 +574,10 @@ struct GPUView::Native : DeviceResourceHolder
     bool stencilEnabled = false;
     UINT width = 0;
     UINT height = 0;
+
+    // Device pixels per logical point, refreshed by updateSize(). Zero until the
+    // first update, which is how the initial scale is told apart from a change.
+    float backingScale = 0.f;
 
     IDCompositionDesktopDevice* compositionDevice = nullptr;
     Microsoft::WRL::ComPtr<IDCompositionVisual2> spriteVisual;
@@ -672,23 +691,18 @@ int GPUView::framesInFlight() const
     return impl->framesInFlight;
 }
 
-void GPUView::resized()
+// Serves both events: the swapchain follows the new bounds or the new scale
+// (same logical bounds, different pixel count), and updateSize() fires
+// onBackingScaleChanged for itself when the scale is what moved.
+void GPUView::resizeStarted()
 {
-    Graphics::View::resized();
     impl->updateSize();
     repaint();
 }
 
-void GPUView::backingScaleChanged()
-{
-    Graphics::View::backingScaleChanged();
-
-    // Resize the swapchain to the new scale (same logical bounds, different
-    // pixel count), then redraw: the presented frame was built for the old one.
-    impl->updateSize();
-    onBackingScaleChanged(backingScale());
-    repaint();
-}
+// Nothing to order after the subclass: the repaint above draws the frame, by
+// which time every override has run.
+void GPUView::resizeFinished() {}
 
 float GPUView::backingScale() const
 {
@@ -893,7 +907,7 @@ Graphics::Image GPUView::renderNativeContent(float scale)
         target.msaaTexture = useMsaa ? &msaaTarget : nullptr;
         target.depthTexture = depthTexture ? &depthTarget : nullptr;
 
-        auto frame = Frame(Device::shared(), target);
+        auto frame = Frame(Device::shared(), target, scale);
 
         // Rendered as a view of this scale: see the Apple side.
         renderScale = scale;

--- a/Lib/eacp/GPU/View/GPUView.h
+++ b/Lib/eacp/GPU/View/GPUView.h
@@ -31,8 +31,11 @@ public:
     // frame's delta time, so motion stays smooth and rate-independent.
     virtual void update(Threads::FrameTime) {}
 
-    void resized() override;
-    void backingScaleChanged() override;
+    // The drawable is resized before the subclass answers the new size, and the
+    // resize's own frame drawn after it on the backends that draw one -- so a
+    // subclass overriding resized() or backingScaleChanged() calls neither base.
+    void resizeStarted() override;
+    void resizeFinished() override;
 
     // Multisample (MSAA) count used for rendering; defaults to 4 for smooth
     // edges. Feed this into your RenderPipelineDescriptor::sampleCount so the

--- a/Lib/eacp/Graphics/View/View-Linux.cpp
+++ b/Lib/eacp/Graphics/View/View-Linux.cpp
@@ -307,7 +307,9 @@ struct View::Native
     void setBounds(const Rect& newBounds)
     {
         bounds = newBounds;
+        ownerView->resizeStarted();
         ownerView->resized();
+        ownerView->resizeFinished();
     }
 
     void focus() { focused = true; }
@@ -457,7 +459,9 @@ bool View::hasFocus() const
 
 void notifyBackingScaleChanged(View& view)
 {
+    view.resizeStarted();
     view.backingScaleChanged();
+    view.resizeFinished();
 
     for (auto* child: view.getSubviews())
         notifyBackingScaleChanged(*child);

--- a/Lib/eacp/Graphics/View/View-Windows.cpp
+++ b/Lib/eacp/Graphics/View/View-Windows.cpp
@@ -394,7 +394,9 @@ struct View::Native
     {
         bounds = newBounds;
         updateVisualPosition();
+        ownerView->resizeStarted();
         ownerView->resized();
+        ownerView->resizeFinished();
 
         // Repaint at the new size, so a view that draws shows up on its initial
         // layout and on resize without waiting for an external repaint(). Views

--- a/Lib/eacp/Graphics/View/View-iOS.mm
+++ b/Lib/eacp/Graphics/View/View-iOS.mm
@@ -41,7 +41,9 @@
 - (void)layoutSubviews
 {
     [super layoutSubviews];
+    cppView->resizeStarted();
     cppView->resized();
+    cppView->resizeFinished();
 }
 
 - (void)setFrame:(CGRect)newFrame

--- a/Lib/eacp/Graphics/View/View-macOS.mm
+++ b/Lib/eacp/Graphics/View/View-macOS.mm
@@ -206,7 +206,11 @@ void layout(id self, SEL)
     ObjC::sendSuper<void>(self, [NSView class], @selector(layout));
 
     if (auto* view = getView(self))
+    {
+        view->resizeStarted();
         view->resized();
+        view->resizeFinished();
+    }
 }
 
 BOOL isFlipped(id, SEL)
@@ -245,7 +249,11 @@ void viewDidChangeBackingProperties(id self, SEL)
     // sized in device pixels (a CAMetalLayer's drawableSize, a glyph atlas) does
     // not, so tell the view.
     if (auto* eacpView = getView(self))
+    {
+        eacpView->resizeStarted();
         eacpView->backingScaleChanged();
+        eacpView->resizeFinished();
+    }
 }
 
 void setFrame(id self, SEL, NSRect newFrame)

--- a/Lib/eacp/Graphics/View/View.h
+++ b/Lib/eacp/Graphics/View/View.h
@@ -228,6 +228,11 @@ public:
     virtual void keyUp(const KeyEvent&) {}
     virtual void resized();
 
+    //Internal helpers to deal with scaling
+    //you likely never have to call or override those
+    virtual void resizeStarted() {}
+    virtual void resizeFinished() {}
+
     // The view moved to a display with a different backing scale (a window
     // dragged between a Retina and a non-Retina screen), or that display's scale
     // changed. Anything sized in device pixels rather than logical points is now

--- a/Lib/eacp/Graphics/Window/Window-Linux.cpp
+++ b/Lib/eacp/Graphics/Window/Window-Linux.cpp
@@ -485,9 +485,11 @@ struct Window::Native : WaylandWindowSurface
         if (contentView == nullptr)
             return;
 
-        // A scale change carries no size with it, so nothing else reports it.
-        notifyBackingScaleChanged(*contentView);
+        // The surfaces take the new scale first, so the notification after them
+        // reads it rather than the one it replaces. A scale change carries no
+        // size with it, so nothing else reports either.
         waylandWindowSurfaceStateChanged(*contentView);
+        notifyBackingScaleChanged(*contentView);
     }
 
     void setMouseLocked(bool locked)

--- a/Lib/eacp/UI/Host/ComponentHost.cpp
+++ b/Lib/eacp/UI/Host/ComponentHost.cpp
@@ -153,34 +153,16 @@ void ComponentHost::setFontFamily(const std::string& family)
     setFont(updated);
 }
 
-// The tree is laid out BEFORE the base class hears of the resize, because
-// GPUView::resized draws a frame there and then - inside the resize's own
-// transaction, which on macOS is the frame that lands with the new size. Laid
-// out after it, that frame is the old layout in the new drawable, and the
-// correct one that follows presents into a transaction that has already
-// committed, so the window keeps the stale frame until something else
-// invalidates it: at the end of a drag, that is what the user is left with.
 void ComponentHost::resized()
 {
     auto bounds = getLocalBounds();
 
     if (bounds.w <= 0.f || bounds.h <= 0.f)
-    {
-        GPUView::resized();
         return;
-    }
 
-    // A resize only moves the logical space the shaders map from, so the
-    // renderer is told rather than rebuilt -- its pipelines are unaffected.
-    if (shapes.has_value())
-    {
-        shapes->setLogicalSize({bounds.w, bounds.h});
-        shapes->setPixelScale(backingScale());
-        meshes->setLogicalSize({bounds.w, bounds.h});
-        images->setLogicalSize({bounds.w, bounds.h});
-        layers->setLogicalSize({bounds.w, bounds.h});
-    }
-    else
+    // Only built here. What each of them projects from is set per frame, from
+    // the frame's own size -- see setSurfaceSize in render().
+    if (!shapes.has_value())
     {
         paths.emplace();
         shapes.emplace(*paths,
@@ -196,8 +178,20 @@ void ComponentHost::resized()
 
     if (root != nullptr)
         root->setBounds(bounds);
+}
 
-    GPUView::resized();
+// A resize only moves the logical space the shaders map from, so every batch is
+// told rather than rebuilt -- their pipelines are unaffected by it.
+void ComponentHost::setSurfaceSize(Point size)
+{
+    if (!shapes.has_value())
+        return;
+
+    shapes->setLogicalSize(size);
+    shapes->setPixelScale(backingScale());
+    meshes->setLogicalSize(size);
+    images->setLogicalSize(size);
+    layers->setLogicalSize(size);
 }
 
 void ComponentHost::markTreeDirty(Component& component)
@@ -436,10 +430,7 @@ void ComponentHost::renderLayer(Layer& layer, GPU::Frame& frame)
 
     auto pass = frame.beginPass(layer.getTexture(), descriptor);
 
-    shapes->setLogicalSize({bounds.w, bounds.h});
-    meshes->setLogicalSize({bounds.w, bounds.h});
-    images->setLogicalSize({bounds.w, bounds.h});
-    layers->setLogicalSize({bounds.w, bounds.h});
+    setSurfaceSize({bounds.w, bounds.h});
 
     shapes->begin(pass);
     meshes->begin(pass);
@@ -483,12 +474,9 @@ void ComponentHost::renderLayer(Layer& layer, GPU::Frame& frame)
     meshes->end();
     images->end();
 
-    auto surface = getLocalBounds();
-
-    shapes->setLogicalSize({surface.w, surface.h});
-    meshes->setLogicalSize({surface.w, surface.h});
-    images->setLogicalSize({surface.w, surface.h});
-    layers->setLogicalSize({surface.w, surface.h});
+    // Back to the frame's own space for whatever draws into the drawable after
+    // this layer's pass.
+    setSurfaceSize(frame.logicalSize());
 
     layer.markRendered();
     ++lastRenderedLayers;
@@ -599,7 +587,11 @@ void ComponentHost::reportDroppedPaths(int count)
 
 void ComponentHost::render(GPU::Frame& frame)
 {
-    auto bounds = getLocalBounds();
+    // The frame's own size rather than the view's: on a live resize the drawable
+    // is already the new one while a size cached at layout is still the old one,
+    // and it is the drawable this projection has to agree with.
+    const auto size = frame.logicalSize();
+    auto bounds = Rect {0.f, 0.f, size.x, size.y};
 
     if (root == nullptr || !shapes.has_value() || bounds.w <= 0.f || bounds.h <= 0.f)
     {
@@ -608,6 +600,8 @@ void ComponentHost::render(GPU::Frame& frame)
     }
 
     renderer();
+
+    setSurfaceSize(size);
 
     text->setViewport({bounds.w, bounds.h}, backingScale());
 

--- a/Lib/eacp/UI/Host/ComponentHost.h
+++ b/Lib/eacp/UI/Host/ComponentHost.h
@@ -206,6 +206,11 @@ private:
         int shared = 0;
     };
 
+    // The logical space every batch projects from. Set at the top of each frame
+    // from the frame's own size rather than cached at layout: it is the size of
+    // the target being drawn into, so it cannot be a resize behind the drawable.
+    void setSurfaceSize(Point size);
+
     // Rendering every Layer in the tree whose content changed, each into a pass
     // of its own, before the frame's own pass opens -- which is the only place
     // it can happen, a pass not being able to begin inside another one.

--- a/Tests/GPU/BackingScaleTests.cpp
+++ b/Tests/GPU/BackingScaleTests.cpp
@@ -88,7 +88,8 @@ auto tScaleMatchesRenderedPixels = test("BackingScale/matchesRenderedPixelSize")
 
 // The callback is never null, so the framework can fire it without a null check
 // and an app that ignores scale changes needs no boilerplate.
-auto tNotificationDefaultsToNoOp = test("BackingScale/notificationDefaultsToNoOp") = []
+auto tNotificationDefaultsToNoOp =
+    test("BackingScale/notificationDefaultsToNoOp") = []
 {
     if (!Device::shared().isValid())
         return;
@@ -129,8 +130,9 @@ auto tHookIsVirtualOnView = test("BackingScale/hookIsVirtualOnBaseView") = []
     check(view.changes == 1);
 };
 
-// The same call on a GPUView re-syncs the drawable and stays safe to invoke
-// directly -- the platform hook calls exactly this.
+// The bracket the platform dispatches around it re-syncs the drawable on a
+// GPUView, and the three together stay safe to invoke directly -- the platform
+// hook calls exactly this.
 auto tHookIsSafeOnGPUView = test("BackingScale/hookIsSafeOnGPUView") = []
 {
     if (!Device::shared().isValid())
@@ -140,7 +142,9 @@ auto tHookIsSafeOnGPUView = test("BackingScale/hookIsSafeOnGPUView") = []
     view.setBounds({0.f, 0.f, 48.f, 48.f});
 
     auto& asBase = static_cast<Graphics::View&>(view);
+    asBase.resizeStarted();
     asBase.backingScaleChanged();
+    asBase.resizeFinished();
 
     check(view.backingScale() > 0.f);
 };


### PR DESCRIPTION
## Summary

Fixes the rubber-like stretch of text during live resize in `Apps/GPU/GlyphAtlas` on macOS, and removes the need for `GPUView` subclasses to call the base class from `resized()` or `backingScaleChanged()`.

**Cause.** `GPUView::resized()` resized the drawable and rendered synchronously before the subclass override that pushed the new size into the sprite and glyph renderers had run. With `presentsWithTransaction` that stale frame is the one the compositor shows, so each resize step drew the old projection into the new drawable until the async repaint caught up.

**Changes**
- `Graphics::View` gains `resizeStarted()` / `resizeFinished()`, framework hooks bracketing `resized()` and `backingScaleChanged()` at every platform dispatch point (macOS, iOS, Windows, Linux).
- `GPUView` overrides only the brackets: drawable resized in the first, the resize's frame drawn in the second on Apple. It no longer overrides the user hooks, so subclasses never call up.
- Windows and Linux fire `onBackingScaleChanged` from a stored-scale comparison, once per change, matching Apple. The Linux window now updates surface scale before notifying the view, so the callback reports the new scale rather than the previous one.
- `GPU::Frame` gains `pixelSize()`, `backingScale()` and `logicalSize()`, plus a scale parameter on its constructors, so a projection set in `render()` comes off the target actually being drawn into.
- The four GPU examples and `ComponentHost` read the size from the frame in `render()` and drop their base calls.

## Verification
- macOS: full build warning-free, `ctest` 1809/1809, `GlyphAtlas` and `ComponentTree` smoke-launched.
- Windows and Linux edits are uncompiled locally. This PR exists to run them through CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VjcPfRc3ktuMw9qmRcAQQt
